### PR TITLE
feat: RSS例外クラスを実装 (#54)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,6 @@ addopts = [
     "-ra",
     "--strict-markers",
     "--strict-config",
-    "--cov-branch",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/src/market_analysis/__init__.py
+++ b/src/market_analysis/__init__.py
@@ -82,44 +82,44 @@ from .utils import (
 # __all__ - 公開シンボル定義
 # =============================================================================
 __all__ = [
-    # --- Public API (主要インターフェース) ---
-    "MarketData",
-    "Analysis",
-    # --- Analysis (内部クラス) ---
-    "Analyzer",
-    "CorrelationAnalyzer",
-    "IndicatorCalculator",
-    # --- Export ---
-    "DataExporter",
+    # --- Utilities ---
+    "PRESET_GROUPS",
     # --- Types ---
     "AgentOutput",
     "AgentOutputMetadata",
-    "AnalysisOptions",
-    "AnalysisResult",
-    "AssetType",
-    "CacheConfig",
-    "ChartOptions",
-    "CorrelationResult",
-    "DataSource",
-    "ExportOptions",
-    "FetchOptions",
-    "Interval",
-    "MarketDataResult",
-    "RetryConfig",
+    # --- Public API (主要インターフェース) ---
+    "Analysis",
     # --- Errors ---
     "AnalysisError",
+    "AnalysisOptions",
+    "AnalysisResult",
+    # --- Analysis (内部クラス) ---
+    "Analyzer",
+    "AssetType",
+    "CacheConfig",
     "CacheError",
+    "ChartOptions",
+    "CorrelationAnalyzer",
+    "CorrelationResult",
+    # --- Export ---
+    "DataExporter",
     "DataFetchError",
+    "DataSource",
     "ErrorCode",
     "ExportError",
+    "ExportOptions",
+    "FetchOptions",
+    "IndicatorCalculator",
+    "Interval",
     "MarketAnalysisError",
+    "MarketData",
+    "MarketDataResult",
     "RateLimitError",
-    "TimeoutError",
-    "ValidationError",
-    # --- Utilities ---
-    "PRESET_GROUPS",
+    "RetryConfig",
     "TickerInfo",
     "TickerRegistry",
+    "TimeoutError",
+    "ValidationError",
     "get_logger",
     "get_ticker_registry",
 ]

--- a/src/market_analysis/api/analysis.py
+++ b/src/market_analysis/api/analysis.py
@@ -43,7 +43,7 @@ def _find_column(df: pd.DataFrame, col_name: str, operation: str) -> pd.Series:
     col_lower = col_name.lower()
     for c in df.columns:
         if c.lower() == col_lower:
-            return cast(pd.Series, df[c])
+            return cast("pd.Series", df[c])
     raise AnalysisError(
         f"Column '{col_name}' not found in DataFrame",
         operation=operation,
@@ -416,7 +416,7 @@ class Analysis:
                         code=ErrorCode.INVALID_PARAMETER,
                     )
 
-                price_data[symbols[i]] = cast(pd.Series, df[actual_col])
+                price_data[symbols[i]] = cast("pd.Series", df[actual_col])
 
             # Create combined DataFrame
             combined = pd.DataFrame(price_data)

--- a/src/rss/exceptions.py
+++ b/src/rss/exceptions.py
@@ -1,0 +1,167 @@
+"""Custom exceptions for RSS feed management.
+
+This module defines all exceptions used throughout the RSS package.
+All custom exceptions inherit from RSSError for easy catching.
+"""
+
+
+class RSSError(Exception):
+    """Base exception for all RSS package errors.
+
+    This is the root exception class for the RSS package.
+    All custom exceptions inherit from this class to allow
+    catching all RSS-related errors with a single except clause.
+
+    Examples
+    --------
+    >>> try:
+    ...     raise RSSError("Something went wrong")
+    ... except RSSError as e:
+    ...     print(f"RSS error occurred: {e}")
+    RSS error occurred: Something went wrong
+    """
+
+
+class FeedNotFoundError(RSSError):
+    """Feed not found error.
+
+    Raised when attempting to access or manipulate a feed that does not exist
+    in the feed registry.
+
+    Parameters
+    ----------
+    message : str
+        Error message describing which feed was not found.
+        Should include the feed ID for debugging.
+
+    Examples
+    --------
+    >>> feed_id = "550e8400-e29b-41d4-a716-446655440000"
+    >>> raise FeedNotFoundError(f"Feed not found: {feed_id}")
+    Traceback (most recent call last):
+    ...
+    FeedNotFoundError: Feed not found: 550e8400-e29b-41d4-a716-446655440000
+    """
+
+
+class FeedAlreadyExistsError(RSSError):
+    """Feed already exists error.
+
+    Raised when attempting to register a feed with a URL that is already
+    registered in the feed registry.
+
+    Parameters
+    ----------
+    message : str
+        Error message describing the duplicate feed.
+        Should include the URL for debugging.
+
+    Examples
+    --------
+    >>> url = "https://example.com/feed.xml"
+    >>> raise FeedAlreadyExistsError(f"Feed already exists: {url}")
+    Traceback (most recent call last):
+    ...
+    FeedAlreadyExistsError: Feed already exists: https://example.com/feed.xml
+    """
+
+
+class FeedFetchError(RSSError):
+    """Feed fetch error.
+
+    Raised when fetching a feed fails due to network issues, HTTP errors,
+    or timeouts. This error is raised after all retry attempts have been exhausted.
+
+    Parameters
+    ----------
+    message : str
+        Error message describing the fetch failure.
+        Should include HTTP status code or error details.
+
+    Examples
+    --------
+    >>> raise FeedFetchError("Failed to fetch feed: HTTP 404 Not Found")
+    Traceback (most recent call last):
+    ...
+    FeedFetchError: Failed to fetch feed: HTTP 404 Not Found
+
+    >>> raise FeedFetchError("Failed to fetch feed: Connection timeout after 3 retries")
+    Traceback (most recent call last):
+    ...
+    FeedFetchError: Failed to fetch feed: Connection timeout after 3 retries
+    """
+
+
+class FeedParseError(RSSError):
+    """Feed parse error.
+
+    Raised when parsing a feed fails due to invalid XML/HTML structure,
+    missing required fields, or unexpected format.
+
+    Parameters
+    ----------
+    message : str
+        Error message describing the parse failure.
+        Should include details about what went wrong.
+
+    Examples
+    --------
+    >>> raise FeedParseError("Failed to parse feed: Invalid XML structure")
+    Traceback (most recent call last):
+    ...
+    FeedParseError: Failed to parse feed: Invalid XML structure
+
+    >>> raise FeedParseError("Failed to parse feed: Missing required 'title' field")
+    Traceback (most recent call last):
+    ...
+    FeedParseError: Failed to parse feed: Missing required 'title' field
+    """
+
+
+class InvalidURLError(RSSError):
+    """Invalid URL error.
+
+    Raised when a URL fails validation, such as having an unsupported scheme
+    (not HTTP/HTTPS) or invalid format.
+
+    Parameters
+    ----------
+    message : str
+        Error message describing the invalid URL.
+        Should include the URL and reason for rejection.
+
+    Examples
+    --------
+    >>> url = "ftp://example.com/feed.xml"
+    >>> raise InvalidURLError(f"Invalid URL format: {url}. Only HTTP/HTTPS allowed.")
+    Traceback (most recent call last):
+    ...
+    InvalidURLError: Invalid URL format: ftp://example.com/feed.xml. Only HTTP/HTTPS allowed.
+
+    >>> raise InvalidURLError("Invalid URL format: not-a-url")
+    Traceback (most recent call last):
+    ...
+    InvalidURLError: Invalid URL format: not-a-url
+    """
+
+
+class FileLockError(RSSError):
+    """File lock error.
+
+    Raised when failing to acquire a file lock within the specified timeout period.
+    This typically indicates that another process is currently accessing the file.
+
+    Parameters
+    ----------
+    message : str
+        Error message describing the lock failure.
+        Should include the lock file path and timeout duration.
+
+    Examples
+    --------
+    >>> lock_file = "/tmp/.feeds.lock"
+    >>> raise FileLockError(f"Failed to acquire lock: {lock_file}. Timeout after 10s.")
+    Traceback (most recent call last):
+    ...
+    FileLockError: Failed to acquire lock: /tmp/.feeds.lock. Timeout after 10s.
+    """

--- a/template/tests/unit/test_helpers.py
+++ b/template/tests/unit/test_helpers.py
@@ -76,7 +76,7 @@ class TestLoadJsonFile:
         json_file = temp_dir / "array.json"
         json_file.write_text("[1, 2, 3]", encoding="utf-8")
 
-        with pytest.raises(ValueError, match="Expected JSON object.*got list"):
+        with pytest.raises(ValueError, match=r"Expected JSON object.*got list"):
             load_json_file(json_file)
 
     def test_エッジケース_空の辞書を読み込める(

--- a/tests/market_analysis/unit/visualization/test_price_charts.py
+++ b/tests/market_analysis/unit/visualization/test_price_charts.py
@@ -151,7 +151,7 @@ class TestPriceChartData:
         self, sample_ohlcv_df: pd.DataFrame
     ) -> None:
         """start_dateがend_dateより後の場合にValueErrorが発生することを確認。"""
-        with pytest.raises(ValueError, match="start_date.*must be before end_date"):
+        with pytest.raises(ValueError, match=r"start_date.*must be before end_date"):
             PriceChartData(
                 df=sample_ohlcv_df,
                 symbol="TEST",

--- a/tests/rss/unit/test_exceptions.py
+++ b/tests/rss/unit/test_exceptions.py
@@ -1,0 +1,217 @@
+"""Unit tests for exceptions module."""
+
+import pytest
+
+
+class TestRSSError:
+    """Test RSSError base exception."""
+
+    def test_正常系_基底例外クラスがExceptionを継承する(self) -> None:
+        """RSSErrorがExceptionを継承していることを確認。"""
+        from rss.exceptions import RSSError
+
+        # RSSErrorがExceptionのサブクラスであることを確認
+        assert issubclass(RSSError, Exception)
+
+    def test_正常系_メッセージ付きで例外を生成できる(self) -> None:
+        """メッセージ付きでRSSErrorを生成できることを確認。"""
+        from rss.exceptions import RSSError
+
+        error = RSSError("Test error message")
+        assert str(error) == "Test error message"
+
+    def test_正常系_例外をraiseできる(self) -> None:
+        """RSSErrorを正常にraiseできることを確認。"""
+        from rss.exceptions import RSSError
+
+        with pytest.raises(RSSError, match="Test error"):
+            raise RSSError("Test error")
+
+
+class TestFeedNotFoundError:
+    """Test FeedNotFoundError exception."""
+
+    def test_正常系_RSSErrorを継承する(self) -> None:
+        """FeedNotFoundErrorがRSSErrorを継承していることを確認。"""
+        from rss.exceptions import FeedNotFoundError, RSSError
+
+        assert issubclass(FeedNotFoundError, RSSError)
+
+    def test_正常系_フィードIDを含むエラーメッセージ(self) -> None:
+        """フィードIDを含むエラーメッセージを生成できることを確認。"""
+        from rss.exceptions import FeedNotFoundError
+
+        feed_id = "550e8400-e29b-41d4-a716-446655440000"
+        error = FeedNotFoundError(f"Feed not found: {feed_id}")
+        assert feed_id in str(error)
+
+    def test_正常系_例外をraiseできる(self) -> None:
+        """FeedNotFoundErrorを正常にraiseできることを確認。"""
+        from rss.exceptions import FeedNotFoundError
+
+        with pytest.raises(FeedNotFoundError, match="Feed not found"):
+            raise FeedNotFoundError("Feed not found: abc123")
+
+
+class TestFeedAlreadyExistsError:
+    """Test FeedAlreadyExistsError exception."""
+
+    def test_正常系_RSSErrorを継承する(self) -> None:
+        """FeedAlreadyExistsErrorがRSSErrorを継承していることを確認。"""
+        from rss.exceptions import FeedAlreadyExistsError, RSSError
+
+        assert issubclass(FeedAlreadyExistsError, RSSError)
+
+    def test_正常系_URLを含むエラーメッセージ(self) -> None:
+        """URLを含むエラーメッセージを生成できることを確認。"""
+        from rss.exceptions import FeedAlreadyExistsError
+
+        url = "https://example.com/feed.xml"
+        error = FeedAlreadyExistsError(f"Feed already exists: {url}")
+        assert url in str(error)
+
+    def test_正常系_例外をraiseできる(self) -> None:
+        """FeedAlreadyExistsErrorを正常にraiseできることを確認。"""
+        from rss.exceptions import FeedAlreadyExistsError
+
+        with pytest.raises(FeedAlreadyExistsError, match="already exists"):
+            raise FeedAlreadyExistsError(
+                "Feed already exists: https://example.com/feed.xml"
+            )
+
+
+class TestFeedFetchError:
+    """Test FeedFetchError exception."""
+
+    def test_正常系_RSSErrorを継承する(self) -> None:
+        """FeedFetchErrorがRSSErrorを継承していることを確認。"""
+        from rss.exceptions import FeedFetchError, RSSError
+
+        assert issubclass(FeedFetchError, RSSError)
+
+    def test_正常系_HTTPステータスコードを含むエラーメッセージ(self) -> None:
+        """HTTPステータスコードを含むエラーメッセージを生成できることを確認。"""
+        from rss.exceptions import FeedFetchError
+
+        error = FeedFetchError("Failed to fetch feed: HTTP 404")
+        assert "404" in str(error)
+
+    def test_正常系_例外をraiseできる(self) -> None:
+        """FeedFetchErrorを正常にraiseできることを確認。"""
+        from rss.exceptions import FeedFetchError
+
+        with pytest.raises(FeedFetchError, match="Failed to fetch"):
+            raise FeedFetchError("Failed to fetch feed: Connection timeout")
+
+
+class TestFeedParseError:
+    """Test FeedParseError exception."""
+
+    def test_正常系_RSSErrorを継承する(self) -> None:
+        """FeedParseErrorがRSSErrorを継承していることを確認。"""
+        from rss.exceptions import FeedParseError, RSSError
+
+        assert issubclass(FeedParseError, RSSError)
+
+    def test_正常系_パースエラー詳細を含むエラーメッセージ(self) -> None:
+        """パースエラー詳細を含むエラーメッセージを生成できることを確認。"""
+        from rss.exceptions import FeedParseError
+
+        error = FeedParseError("Failed to parse feed: Invalid XML structure")
+        assert "Invalid XML" in str(error)
+
+    def test_正常系_例外をraiseできる(self) -> None:
+        """FeedParseErrorを正常にraiseできることを確認。"""
+        from rss.exceptions import FeedParseError
+
+        with pytest.raises(FeedParseError, match="Failed to parse"):
+            raise FeedParseError("Failed to parse feed: Unexpected format")
+
+
+class TestInvalidURLError:
+    """Test InvalidURLError exception."""
+
+    def test_正常系_RSSErrorを継承する(self) -> None:
+        """InvalidURLErrorがRSSErrorを継承していることを確認。"""
+        from rss.exceptions import InvalidURLError, RSSError
+
+        assert issubclass(InvalidURLError, RSSError)
+
+    def test_正常系_無効なURLを含むエラーメッセージ(self) -> None:
+        """無効なURLを含むエラーメッセージを生成できることを確認。"""
+        from rss.exceptions import InvalidURLError
+
+        invalid_url = "ftp://invalid.com/feed"
+        error = InvalidURLError(
+            f"Invalid URL format: {invalid_url}. Only HTTP/HTTPS allowed."
+        )
+        assert invalid_url in str(error)
+
+    def test_正常系_例外をraiseできる(self) -> None:
+        """InvalidURLErrorを正常にraiseできることを確認。"""
+        from rss.exceptions import InvalidURLError
+
+        with pytest.raises(InvalidURLError, match="Invalid URL"):
+            raise InvalidURLError("Invalid URL format: not-a-url")
+
+
+class TestFileLockError:
+    """Test FileLockError exception."""
+
+    def test_正常系_RSSErrorを継承する(self) -> None:
+        """FileLockErrorがRSSErrorを継承していることを確認。"""
+        from rss.exceptions import FileLockError, RSSError
+
+        assert issubclass(FileLockError, RSSError)
+
+    def test_正常系_ロックファイルパスを含むエラーメッセージ(self) -> None:
+        """ロックファイルパスを含むエラーメッセージを生成できることを確認。"""
+        from rss.exceptions import FileLockError
+
+        lock_file = "/tmp/.feeds.lock"
+        error = FileLockError(f"Failed to acquire lock: {lock_file}")
+        assert lock_file in str(error)
+
+    def test_正常系_例外をraiseできる(self) -> None:
+        """FileLockErrorを正常にraiseできることを確認。"""
+        from rss.exceptions import FileLockError
+
+        with pytest.raises(FileLockError, match="Failed to acquire lock"):
+            raise FileLockError("Failed to acquire lock: timeout after 10s")
+
+
+class TestExceptionInheritanceChain:
+    """Test exception inheritance chain."""
+
+    def test_正常系_全例外がRSSErrorを継承する(self) -> None:
+        """全ての例外クラスがRSSErrorを継承していることを確認。"""
+        from rss.exceptions import (
+            FeedAlreadyExistsError,
+            FeedFetchError,
+            FeedNotFoundError,
+            FeedParseError,
+            FileLockError,
+            InvalidURLError,
+            RSSError,
+        )
+
+        exceptions = [
+            FeedNotFoundError,
+            FeedAlreadyExistsError,
+            FeedFetchError,
+            FeedParseError,
+            InvalidURLError,
+            FileLockError,
+        ]
+
+        for exc_class in exceptions:
+            assert issubclass(
+                exc_class, RSSError
+            ), f"{exc_class.__name__} should inherit from RSSError"
+
+    def test_正常系_RSSError例外でキャッチできる(self) -> None:
+        """全ての例外がRSSErrorでキャッチできることを確認。"""
+        from rss.exceptions import FeedNotFoundError, RSSError
+
+        with pytest.raises(RSSError):
+            raise FeedNotFoundError("Test")


### PR DESCRIPTION
## 概要
RSS/Atomフィード管理に必要な例外クラスを実装しました。

## 変更内容
- `RSSError` 基底例外クラスを実装（`Exception`を継承）
- 6つの派生例外クラスを実装:
  - `FeedNotFoundError` - フィードが見つからない
  - `FeedAlreadyExistsError` - フィードが既に存在する
  - `FeedFetchError` - フィード取得に失敗
  - `FeedParseError` - フィードのパースに失敗
  - `InvalidURLError` - 無効なURL形式
  - `FileLockError` - ファイルロック取得に失敗

## 実装ファイル
- `src/rss/exceptions.py` - 7つの例外クラス（NumPy形式docstring付き）
- `tests/rss/unit/test_exceptions.py` - 23個のテストケース

## テストプラン
- [x] TDDでRed→Greenサイクル実装済み
- [x] 23個のテストケース全て成功
- [x] 型チェック成功（pyright エラー0件）
- [x] 各例外クラスにNumPy形式のdocstringを実装
- [x] Issue #54 の全受け入れ条件を満たす

## その他の修正
- `pyproject.toml`: pytest設定から`--cov-branch`を削除（pytest-cov未インストール対応）
- Ruffの警告修正:
  - `__all__`のアルファベット順ソート
  - pytest `match`パターンのraw文字列化

## 関連Issue
Closes #54

🤖 Generated with [Claude Code](https://claude.ai/claude-code)