### PR TITLE
feat: RSS/Atomパーサー（FeedParser）を実装 (#59)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "tenacity>=9.1.2",
     "scipy>=1.17.0",
     "kaleido>=1.2.0",
+    "feedparser>=6.0.12",
 ]
 [project.optional-dependencies]
 dev = [

--- a/src/rss/core/__init__.py
+++ b/src/rss/core/__init__.py
@@ -1,5 +1,6 @@
 """Core functionality of the rss package."""
 
 from .diff_detector import DiffDetector
+from .parser import FeedParser
 
-__all__: list[str] = ["DiffDetector"]
+__all__: list[str] = ["DiffDetector", "FeedParser"]

--- a/src/rss/core/parser.py
+++ b/src/rss/core/parser.py
@@ -1,0 +1,253 @@
+"""RSS/Atom feed parser module."""
+
+import uuid
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+import feedparser
+
+from ..exceptions import FeedParseError
+from ..types import FeedItem
+
+
+# Logger lazy initialization to avoid circular imports
+def _get_logger() -> Any:
+    try:
+        from ..utils.logging_config import get_logger
+
+        return get_logger(__name__, module="parser")
+    except ImportError:
+        import logging
+
+        return logging.getLogger(__name__)
+
+
+logger: Any = _get_logger()
+
+
+class FeedParser:
+    """RSS 2.0 and Atom feed parser.
+
+    This class parses RSS 2.0 and Atom formatted feeds and converts them
+    to a unified FeedItem structure.
+
+    Examples
+    --------
+    >>> parser = FeedParser()
+    >>> items = parser.parse(rss_content)
+    >>> len(items)
+    10
+    """
+
+    def parse(self, content: bytes) -> list[FeedItem]:
+        """Parse RSS 2.0 or Atom feed content.
+
+        Parameters
+        ----------
+        content : bytes
+            Raw feed content as bytes
+
+        Returns
+        -------
+        list[FeedItem]
+            List of parsed feed items
+
+        Raises
+        ------
+        FeedParseError
+            If the content cannot be parsed as valid RSS 2.0 or Atom
+        """
+        logger.debug("Parsing feed content started", content_length=len(content))
+
+        try:
+            parsed = feedparser.parse(content)
+        except Exception as e:
+            logger.error(
+                "Feed parsing failed",
+                error=str(e),
+                content_length=len(content),
+                exc_info=True,
+            )
+            raise FeedParseError(f"Failed to parse feed: {e}") from e
+
+        # Check for bozo errors (malformed feed)
+        if parsed.bozo:
+            bozo_exception = parsed.get("bozo_exception")
+            # feedparser can still parse some malformed feeds, so only raise on critical errors
+            if not parsed.entries and bozo_exception:
+                error_msg = str(bozo_exception)
+                logger.error(
+                    "Feed parsing failed due to malformed content",
+                    error=error_msg,
+                    bozo=True,
+                )
+                raise FeedParseError(f"Failed to parse feed: {error_msg}")
+
+        # Check if it's a recognized feed format (RSS or Atom)
+        # feedparser sets version to empty string for unrecognized formats like HTML
+        feed_version = getattr(parsed, "version", "")
+        if not feed_version:
+            logger.error(
+                "Invalid feed format",
+                version=feed_version,
+                has_entries=bool(parsed.entries),
+            )
+            raise FeedParseError(
+                "Invalid feed format: not a recognized RSS or Atom format"
+            )
+
+        # Check if it's a valid feed (has entries or is a recognized format)
+        if not parsed.entries and not parsed.feed:
+            logger.error(
+                "Invalid feed format",
+                has_entries=bool(parsed.entries),
+                has_feed=bool(parsed.feed),
+            )
+            raise FeedParseError(
+                "Invalid feed format: no entries or feed metadata found"
+            )
+
+        fetched_at = datetime.now(timezone.utc).isoformat()
+        items: list[FeedItem] = []
+
+        for entry in parsed.entries:
+            try:
+                item = self._convert_entry(entry, fetched_at)
+                items.append(item)
+            except Exception as e:
+                logger.warning(
+                    "Failed to convert entry, skipping",
+                    error=str(e),
+                    entry_title=entry.get("title", "unknown"),
+                )
+                continue
+
+        logger.info(
+            "Feed parsing completed",
+            total_entries=len(parsed.entries),
+            converted_items=len(items),
+            feed_title=parsed.feed.get("title", "unknown"),
+        )
+
+        return items
+
+    def _convert_entry(self, entry: Any, fetched_at: str) -> FeedItem:
+        """Convert a feedparser entry to FeedItem.
+
+        Parameters
+        ----------
+        entry : Any
+            A feedparser entry object
+        fetched_at : str
+            Fetch timestamp in ISO 8601 format
+
+        Returns
+        -------
+        FeedItem
+            Converted feed item
+        """
+        item_id = str(uuid.uuid4())
+        title = entry.get("title", "")
+        link = entry.get("link", "")
+
+        # Parse published date
+        published = self._parse_published(entry)
+
+        # Get summary (description in RSS, summary in Atom)
+        summary = entry.get("summary") or entry.get("description")
+
+        # Get content (content:encoded in RSS, content in Atom)
+        content = self._extract_content(entry)
+
+        # Get author
+        author = entry.get("author")
+
+        logger.debug(
+            "Entry converted",
+            item_id=item_id,
+            title=title[:50] if title else None,
+            has_published=published is not None,
+            has_summary=summary is not None,
+            has_content=content is not None,
+            has_author=author is not None,
+        )
+
+        return FeedItem(
+            item_id=item_id,
+            title=title,
+            link=link,
+            published=published,
+            summary=summary,
+            content=content,
+            author=author,
+            fetched_at=fetched_at,
+        )
+
+    def _parse_published(self, entry: Any) -> str | None:
+        """Parse published date from entry.
+
+        Parameters
+        ----------
+        entry : Any
+            A feedparser entry object
+
+        Returns
+        -------
+        str | None
+            ISO 8601 formatted date string, or None if not available
+        """
+        # feedparser provides parsed date as a time tuple
+        if hasattr(entry, "published_parsed") and entry.published_parsed:
+            try:
+                dt = datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
+                return dt.isoformat()
+            except (ValueError, TypeError):
+                pass
+
+        # Try updated_parsed as fallback (common in Atom)
+        if hasattr(entry, "updated_parsed") and entry.updated_parsed:
+            try:
+                dt = datetime(*entry.updated_parsed[:6], tzinfo=timezone.utc)
+                return dt.isoformat()
+            except (ValueError, TypeError):
+                pass
+
+        # Try raw published string
+        published_str = entry.get("published") or entry.get("updated")
+        if published_str:
+            try:
+                # Try parsing RFC 2822 format
+                dt = parsedate_to_datetime(published_str)
+                return dt.isoformat()
+            except (ValueError, TypeError):
+                pass
+
+        return None
+
+    def _extract_content(self, entry: Any) -> str | None:
+        """Extract full content from entry.
+
+        Parameters
+        ----------
+        entry : Any
+            A feedparser entry object
+
+        Returns
+        -------
+        str | None
+            Full content, or None if not available
+        """
+        # Atom content (can be a list)
+        if "content" in entry and entry.content:
+            contents = entry.content
+            if isinstance(contents, list) and contents:
+                # Prefer HTML content
+                for c in contents:
+                    if getattr(c, "type", "") == "text/html":
+                        return c.get("value")
+                # Fall back to first content
+                return contents[0].get("value")
+            return None
+
+        return None

--- a/src/rss/types.py
+++ b/src/rss/types.py
@@ -179,14 +179,14 @@ class FeedItem:
         Item title
     link : str
         Item URL
-    published : str
-        Publication timestamp (ISO 8601 format)
-    summary : str
-        Item summary
-    content : str
-        Full content
+    published : str | None
+        Publication timestamp (ISO 8601 format), None if not provided
+    summary : str | None
+        Item summary, None if not provided
+    content : str | None
+        Full content, None if not provided
     author : str | None
-        Author name
+        Author name, None if not provided
     fetched_at : str
         Fetch timestamp (ISO 8601 format)
     """
@@ -194,9 +194,9 @@ class FeedItem:
     item_id: str
     title: str
     link: str
-    published: str
-    summary: str
-    content: str
+    published: str | None
+    summary: str | None
+    content: str | None
     author: str | None
     fetched_at: str
 

--- a/tests/rss/unit/core/test_parser.py
+++ b/tests/rss/unit/core/test_parser.py
@@ -1,0 +1,292 @@
+"""Unit tests for FeedParser."""
+
+import uuid
+
+import pytest
+
+from rss.core.parser import FeedParser
+from rss.exceptions import FeedParseError
+from rss.types import FeedItem
+
+# Sample RSS 2.0 feed
+RSS_SAMPLE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Sample RSS Feed</title>
+    <link>https://example.com</link>
+    <description>This is a sample RSS feed</description>
+    <item>
+      <title>First Article</title>
+      <link>https://example.com/article1</link>
+      <pubDate>Mon, 14 Jan 2026 10:00:00 GMT</pubDate>
+      <description>This is the first article summary.</description>
+      <author>author@example.com</author>
+    </item>
+    <item>
+      <title>Second Article</title>
+      <link>https://example.com/article2</link>
+      <pubDate>Mon, 14 Jan 2026 11:00:00 GMT</pubDate>
+      <description>This is the second article summary.</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+# Sample Atom feed
+ATOM_SAMPLE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Sample Atom Feed</title>
+  <link href="https://example.com"/>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <updated>2026-01-14T12:00:00Z</updated>
+  <entry>
+    <title>Atom Entry 1</title>
+    <link href="https://example.com/atom1"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2026-01-14T10:00:00Z</updated>
+    <summary>Atom entry summary</summary>
+    <content type="html">&lt;p&gt;Atom entry content&lt;/p&gt;</content>
+    <author>
+      <name>John Doe</name>
+    </author>
+  </entry>
+  <entry>
+    <title>Atom Entry 2</title>
+    <link href="https://example.com/atom2"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-bbbb-80da344efa6a</id>
+    <published>2026-01-14T11:00:00Z</published>
+    <summary>Second Atom entry</summary>
+  </entry>
+</feed>
+"""
+
+# Minimal RSS feed (without optional fields)
+MINIMAL_RSS_SAMPLE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Minimal Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Minimal Item</title>
+      <link>https://example.com/minimal</link>
+    </item>
+  </channel>
+</rss>
+"""
+
+# Invalid XML
+INVALID_XML = b"""<not valid xml"""
+
+# HTML (not a feed)
+HTML_CONTENT = b"""<!DOCTYPE html>
+<html>
+<head><title>Not a Feed</title></head>
+<body><p>This is HTML, not RSS or Atom</p></body>
+</html>
+"""
+
+
+def is_valid_uuid4(value: str) -> bool:
+    """Check if a string is a valid UUID v4."""
+    try:
+        parsed = uuid.UUID(value, version=4)
+        return str(parsed) == value
+    except ValueError:
+        return False
+
+
+class TestFeedParserInit:
+    """Test FeedParser initialization."""
+
+    def test_init(self) -> None:
+        """Test initialization."""
+        parser = FeedParser()
+        assert parser is not None
+
+
+class TestParseRSS:
+    """Test parsing RSS 2.0 feeds."""
+
+    def test_parse_rss_feed(self) -> None:
+        """Test parsing a valid RSS 2.0 feed."""
+        parser = FeedParser()
+        items = parser.parse(RSS_SAMPLE)
+
+        assert len(items) == 2
+
+        # Check first item
+        item1 = items[0]
+        assert item1.title == "First Article"
+        assert item1.link == "https://example.com/article1"
+        assert item1.summary == "This is the first article summary."
+        assert item1.author == "author@example.com"
+        assert item1.published is not None
+        assert is_valid_uuid4(item1.item_id)
+        assert item1.fetched_at is not None
+
+        # Check second item
+        item2 = items[1]
+        assert item2.title == "Second Article"
+        assert item2.link == "https://example.com/article2"
+        assert item2.author is None  # No author in second item
+
+    def test_parse_rss_returns_feeditem_type(self) -> None:
+        """Test that parse returns FeedItem instances."""
+        parser = FeedParser()
+        items = parser.parse(RSS_SAMPLE)
+
+        for item in items:
+            assert isinstance(item, FeedItem)
+
+
+class TestParseAtom:
+    """Test parsing Atom feeds."""
+
+    def test_parse_atom_feed(self) -> None:
+        """Test parsing a valid Atom feed."""
+        parser = FeedParser()
+        items = parser.parse(ATOM_SAMPLE)
+
+        assert len(items) == 2
+
+        # Check first item
+        item1 = items[0]
+        assert item1.title == "Atom Entry 1"
+        assert item1.link == "https://example.com/atom1"
+        assert item1.summary == "Atom entry summary"
+        assert item1.content == "<p>Atom entry content</p>"
+        assert item1.author == "John Doe"
+        assert item1.published is not None
+        assert is_valid_uuid4(item1.item_id)
+
+        # Check second item
+        item2 = items[1]
+        assert item2.title == "Atom Entry 2"
+        assert item2.author is None  # No author in second entry
+
+
+class TestParseOptionalFields:
+    """Test handling of optional fields."""
+
+    def test_parse_minimal_feed(self) -> None:
+        """Test parsing a feed with minimal fields."""
+        parser = FeedParser()
+        items = parser.parse(MINIMAL_RSS_SAMPLE)
+
+        assert len(items) == 1
+
+        item = items[0]
+        assert item.title == "Minimal Item"
+        assert item.link == "https://example.com/minimal"
+        # Optional fields should be None
+        assert item.published is None
+        assert item.summary is None
+        assert item.content is None
+        assert item.author is None
+
+    def test_published_none_when_not_provided(self) -> None:
+        """Test that published is None when not provided."""
+        parser = FeedParser()
+        items = parser.parse(MINIMAL_RSS_SAMPLE)
+
+        assert items[0].published is None
+
+    def test_summary_none_when_not_provided(self) -> None:
+        """Test that summary is None when not provided."""
+        parser = FeedParser()
+        items = parser.parse(MINIMAL_RSS_SAMPLE)
+
+        assert items[0].summary is None
+
+    def test_content_none_when_not_provided(self) -> None:
+        """Test that content is None when not provided."""
+        parser = FeedParser()
+        items = parser.parse(MINIMAL_RSS_SAMPLE)
+
+        assert items[0].content is None
+
+    def test_author_none_when_not_provided(self) -> None:
+        """Test that author is None when not provided."""
+        parser = FeedParser()
+        items = parser.parse(MINIMAL_RSS_SAMPLE)
+
+        assert items[0].author is None
+
+
+class TestItemIdGeneration:
+    """Test UUID v4 item_id generation."""
+
+    def test_item_id_is_uuid4(self) -> None:
+        """Test that item_id is a valid UUID v4."""
+        parser = FeedParser()
+        items = parser.parse(RSS_SAMPLE)
+
+        for item in items:
+            assert is_valid_uuid4(item.item_id)
+
+    def test_item_ids_are_unique(self) -> None:
+        """Test that each item gets a unique item_id."""
+        parser = FeedParser()
+        items = parser.parse(RSS_SAMPLE)
+
+        item_ids = [item.item_id for item in items]
+        assert len(item_ids) == len(set(item_ids))
+
+
+class TestParseErrors:
+    """Test error handling."""
+
+    def test_parse_invalid_xml_raises_error(self) -> None:
+        """Test that invalid XML raises FeedParseError."""
+        parser = FeedParser()
+
+        with pytest.raises(FeedParseError):
+            parser.parse(INVALID_XML)
+
+    def test_parse_html_raises_error(self) -> None:
+        """Test that HTML content raises FeedParseError."""
+        parser = FeedParser()
+
+        with pytest.raises(FeedParseError):
+            parser.parse(HTML_CONTENT)
+
+    def test_parse_empty_content_raises_error(self) -> None:
+        """Test that empty content raises FeedParseError."""
+        parser = FeedParser()
+
+        with pytest.raises(FeedParseError):
+            parser.parse(b"")
+
+    def test_parse_random_bytes_raises_error(self) -> None:
+        """Test that random bytes raise FeedParseError."""
+        parser = FeedParser()
+
+        with pytest.raises(FeedParseError):
+            parser.parse(b"\x00\x01\x02\x03\x04\x05")
+
+
+class TestParseLogging:
+    """Test logging behavior of parse method.
+
+    Note: Logging tests verify that the method executes without errors.
+    Actual log output is verified through manual testing and code review.
+    """
+
+    def test_parse_executes_with_logging(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that parse executes with logging."""
+        parser = FeedParser()
+
+        # Execute method - should not raise any exceptions
+        items = parser.parse(RSS_SAMPLE)
+
+        # Verify the method executed correctly
+        assert len(items) == 2
+
+        # Verify logs were written to stdout (structlog output)
+        captured = capsys.readouterr()
+        assert (
+            "Parsing feed content started" in captured.out
+            or "Feed parsing completed" in captured.out
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -481,6 +481,18 @@ wheels = [
 ]
 
 [[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
@@ -495,6 +507,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
+    { name = "feedparser" },
     { name = "filelock" },
     { name = "fredapi" },
     { name = "jinja2" },
@@ -546,6 +559,7 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "duckdb", specifier = ">=1.0.0" },
+    { name = "feedparser", specifier = ">=6.0.12" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "fredapi", specifier = ">=0.5.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
@@ -582,8 +596,8 @@ dev = [
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pyright", specifier = ">=1.1.403" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "virtualenv", specifier = ">=20.36.1" },
 ]
 
@@ -1801,6 +1815,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/58/a8/a66a75c3d8f1fb2b83f66007d6455a06a6f6cf5618c3dc35bc9b69dd096e/scipy-1.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1ff269abf702f6c7e67a4b7aad981d42871a11b9dd83c58d2d2ea624efbd1088", size = 37098574, upload-time = "2026-01-10T21:30:40.782Z" },
     { url = "https://files.pythonhosted.org/packages/56/a5/df8f46ef7da168f1bc52cd86e09a9de5c6f19cc1da04454d51b7d4f43408/scipy-1.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:031121914e295d9791319a1875444d55079885bbae5bdc9c5e0f2ee5f09d34ff", size = 25246266, upload-time = "2026-01-10T21:30:45.923Z" },
 ]
+
+[[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
 name = "simplejson"


### PR DESCRIPTION
## 概要
- feedparserパッケージを依存関係に追加
- `FeedParser`クラスを実装（RSS 2.0/Atom両対応）
- `FeedItem`の型定義を更新（published, summary, contentをOptionalに）
- UUID v4形式でitem_idを自動生成
- パースエラー時に`FeedParseError`を発生
- 構造化ロギング（DEBUG/INFO/ERROR）を実装
- ユニットテスト16件を追加

## 実装内容
### 新規ファイル
- `src/rss/core/parser.py` - FeedParserクラス
- `tests/rss/unit/core/test_parser.py` - ユニットテスト

### 変更ファイル
- `src/rss/types.py` - FeedItemの型定義更新
- `src/rss/core/__init__.py` - FeedParserエクスポート追加
- `pyproject.toml` - feedparser依存関係追加

## テストプラン
- [x] make check-all が成功することを確認
- [x] 632件のテストがすべてパス
- [x] RSS 2.0フォーマットのパーステスト
- [x] Atomフォーマットのパーステスト
- [x] オプションフィールド（published, summary, content, author）のNone処理テスト
- [x] UUID v4形式のitem_id生成テスト
- [x] 不正なXML/HTMLでのエラー発生テスト

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)