### PR TITLE
feat: アイテム読込サービス（FeedReader）を実装 (#63)

### DIFF
--- a/src/rss/services/__init__.py
+++ b/src/rss/services/__init__.py
@@ -1,5 +1,6 @@
 """Services for RSS feed management."""
 
 from .feed_manager import FeedManager
+from .feed_reader import FeedReader
 
-__all__ = ["FeedManager"]
+__all__ = ["FeedManager", "FeedReader"]

--- a/src/rss/services/feed_reader.py
+++ b/src/rss/services/feed_reader.py
@@ -1,0 +1,296 @@
+"""Feed reading service for RSS feed items.
+
+This module provides the FeedReader class for retrieving, searching,
+and filtering feed items from the JSON storage.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from ..storage.json_storage import JSONStorage
+from ..types import FeedItem
+
+
+def _get_logger() -> Any:
+    """Get logger with lazy initialization to avoid circular imports."""
+    try:
+        from ..utils.logging_config import get_logger
+
+        return get_logger(__name__, module="feed_reader")
+    except ImportError:
+        import logging
+
+        return logging.getLogger(__name__)
+
+
+logger: Any = _get_logger()
+
+
+class FeedReader:
+    """Service for reading and searching RSS feed items.
+
+    This class provides methods for retrieving feed items with pagination
+    and keyword search functionality.
+
+    Parameters
+    ----------
+    data_dir : Path
+        Root directory for RSS feed data (e.g., data/raw/rss/)
+
+    Attributes
+    ----------
+    data_dir : Path
+        Root directory for RSS feed data
+    storage : JSONStorage
+        JSON storage for persistence
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> reader = FeedReader(Path("data/raw/rss"))
+    >>> items = reader.get_items(feed_id="550e8400-e29b-41d4-a716-446655440000")
+    >>> for item in items:
+    ...     print(item.title)
+    """
+
+    def __init__(self, data_dir: Path) -> None:
+        """Initialize FeedReader.
+
+        Parameters
+        ----------
+        data_dir : Path
+            Root directory for RSS feed data
+
+        Raises
+        ------
+        ValueError
+            If data_dir is not a Path object
+        """
+        if not isinstance(data_dir, Path):
+            logger.error(
+                "Invalid data_dir type",
+                data_dir=str(data_dir),
+                expected_type="Path",
+                actual_type=type(data_dir).__name__,
+            )
+            raise ValueError(f"data_dir must be a Path object, got {type(data_dir)}")
+
+        self.data_dir = data_dir
+        self.storage = JSONStorage(data_dir)
+        logger.debug("FeedReader initialized", data_dir=str(data_dir))
+
+    def get_items(
+        self,
+        feed_id: str | None = None,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[FeedItem]:
+        """Get feed items with optional pagination.
+
+        Retrieves items from a specific feed or all feeds, sorted by
+        published date in descending order (newest first).
+
+        Parameters
+        ----------
+        feed_id : str | None, default=None
+            Feed identifier. If None, returns items from all feeds.
+        limit : int | None, default=None
+            Maximum number of items to return. If None, returns all items.
+        offset : int, default=0
+            Number of items to skip before returning results.
+
+        Returns
+        -------
+        list[FeedItem]
+            List of feed items sorted by published date descending
+
+        Examples
+        --------
+        >>> reader = FeedReader(Path("data/raw/rss"))
+        >>> # Get all items from a specific feed
+        >>> items = reader.get_items(feed_id="feed-001")
+        >>> # Get first 10 items from all feeds
+        >>> items = reader.get_items(limit=10)
+        >>> # Pagination: skip first 20, get next 10
+        >>> items = reader.get_items(limit=10, offset=20)
+        """
+        logger.debug(
+            "Getting items",
+            feed_id=feed_id,
+            limit=limit,
+            offset=offset,
+        )
+
+        items: list[FeedItem] = []
+
+        if feed_id is not None:
+            # Get items from specific feed
+            items_data = self.storage.load_items(feed_id)
+            items = list(items_data.items)
+        else:
+            # Get items from all feeds
+            feeds_data = self.storage.load_feeds()
+            for feed in feeds_data.feeds:
+                items_data = self.storage.load_items(feed.feed_id)
+                items.extend(items_data.items)
+
+        # Sort by published date descending (None values go to the end)
+        items = self._sort_by_published_desc(items)
+
+        # Apply pagination
+        if offset > 0:
+            items = items[offset:]
+        if limit is not None:
+            items = items[:limit]
+
+        logger.info(
+            "Items retrieved",
+            feed_id=feed_id,
+            total_items=len(items),
+            limit=limit,
+            offset=offset,
+        )
+
+        return items
+
+    def search_items(
+        self,
+        query: str,
+        *,
+        category: str | None = None,
+        fields: list[str] | None = None,
+        limit: int | None = None,
+    ) -> list[FeedItem]:
+        """Search feed items by keyword.
+
+        Performs case-insensitive partial matching on specified fields.
+        By default, searches in title, summary, and content fields.
+
+        Parameters
+        ----------
+        query : str
+            Search query string (case-insensitive partial match)
+        category : str | None, default=None
+            Filter by feed category. If None, searches all categories.
+        fields : list[str] | None, default=None
+            Fields to search in. If None, defaults to ["title", "summary", "content"].
+        limit : int | None, default=None
+            Maximum number of results to return.
+
+        Returns
+        -------
+        list[FeedItem]
+            List of matching items sorted by published date descending
+
+        Examples
+        --------
+        >>> reader = FeedReader(Path("data/raw/rss"))
+        >>> # Search in all fields
+        >>> items = reader.search_items(query="Bitcoin")
+        >>> # Search only in title field
+        >>> items = reader.search_items(query="Bitcoin", fields=["title"])
+        >>> # Filter by category
+        >>> items = reader.search_items(query="market", category="finance")
+        """
+        logger.debug(
+            "Searching items",
+            query=query,
+            category=category,
+            fields=fields,
+            limit=limit,
+        )
+
+        if fields is None:
+            fields = ["title", "summary", "content"]
+
+        # Get feeds filtered by category if specified
+        feeds_data = self.storage.load_feeds()
+        target_feeds = feeds_data.feeds
+        if category is not None:
+            target_feeds = [f for f in target_feeds if f.category == category]
+
+        # Collect items from target feeds
+        all_items: list[FeedItem] = []
+        for feed in target_feeds:
+            items_data = self.storage.load_items(feed.feed_id)
+            all_items.extend(items_data.items)
+
+        # Filter by query
+        query_lower = query.lower()
+        matched_items: list[FeedItem] = []
+
+        for item in all_items:
+            if self._item_matches_query(item, query_lower, fields):
+                matched_items.append(item)
+
+        # Sort by published date descending
+        matched_items = self._sort_by_published_desc(matched_items)
+
+        # Apply limit
+        if limit is not None:
+            matched_items = matched_items[:limit]
+
+        logger.info(
+            "Search completed",
+            query=query,
+            category=category,
+            fields=fields,
+            matched_count=len(matched_items),
+            limit=limit,
+        )
+
+        return matched_items
+
+    def _item_matches_query(
+        self,
+        item: FeedItem,
+        query_lower: str,
+        fields: list[str],
+    ) -> bool:
+        """Check if an item matches the search query.
+
+        Parameters
+        ----------
+        item : FeedItem
+            Feed item to check
+        query_lower : str
+            Lowercase search query
+        fields : list[str]
+            Fields to search in
+
+        Returns
+        -------
+        bool
+            True if item matches the query in any of the specified fields
+        """
+        for field in fields:
+            value = getattr(item, field, None)
+            if value is not None and query_lower in value.lower():
+                return True
+        return False
+
+    def _sort_by_published_desc(self, items: list[FeedItem]) -> list[FeedItem]:
+        """Sort items by published date in descending order.
+
+        Items with None published date are placed at the end.
+
+        Parameters
+        ----------
+        items : list[FeedItem]
+            Items to sort
+
+        Returns
+        -------
+        list[FeedItem]
+            Sorted items (newest first, None published at end)
+        """
+        # Split into items with and without published date
+        with_date = [x for x in items if x.published is not None]
+        without_date = [x for x in items if x.published is None]
+
+        # Sort those with dates in descending order
+        with_date.sort(key=lambda x: x.published, reverse=True)  # type: ignore[arg-type]
+
+        # Append those without dates at the end
+        return with_date + without_date

--- a/tests/rss/unit/services/test_feed_reader.py
+++ b/tests/rss/unit/services/test_feed_reader.py
@@ -1,0 +1,475 @@
+"""Unit tests for FeedReader class."""
+
+from pathlib import Path
+
+import pytest
+
+from rss.services.feed_reader import FeedReader
+from rss.storage.json_storage import JSONStorage
+from rss.types import (
+    Feed,
+    FeedItem,
+    FeedItemsData,
+    FeedsData,
+    FetchInterval,
+    FetchStatus,
+)
+
+
+def _create_test_feed(
+    feed_id: str = "feed-001",
+    url: str = "https://example.com/feed.xml",
+    title: str = "Test Feed",
+    category: str = "finance",
+) -> Feed:
+    """Create a test feed."""
+    return Feed(
+        feed_id=feed_id,
+        url=url,
+        title=title,
+        category=category,
+        fetch_interval=FetchInterval.DAILY,
+        created_at="2026-01-14T10:00:00Z",
+        updated_at="2026-01-14T10:00:00Z",
+        last_fetched="2026-01-14T10:00:00Z",
+        last_status=FetchStatus.SUCCESS,
+        enabled=True,
+    )
+
+
+def _create_test_item(
+    item_id: str = "item-001",
+    title: str = "Test Article",
+    link: str = "https://example.com/article",
+    published: str | None = "2026-01-14T10:00:00Z",
+    summary: str | None = "Test summary",
+    content: str | None = "Test content",
+    author: str | None = "Test Author",
+) -> FeedItem:
+    """Create a test feed item."""
+    return FeedItem(
+        item_id=item_id,
+        title=title,
+        link=link,
+        published=published,
+        summary=summary,
+        content=content,
+        author=author,
+        fetched_at="2026-01-14T10:00:00Z",
+    )
+
+
+class TestFeedReaderInit:
+    """Test FeedReader initialization."""
+
+    def test_init_success(self, tmp_path: Path) -> None:
+        """Test successful initialization."""
+        reader = FeedReader(tmp_path)
+        assert reader.data_dir == tmp_path
+        assert reader.storage is not None
+
+    def test_init_invalid_data_dir_type(self) -> None:
+        """Test initialization with invalid data_dir type."""
+        with pytest.raises(ValueError, match="data_dir must be a Path object"):
+            FeedReader("invalid")  # type: ignore[arg-type]
+
+
+class TestGetItems:
+    """Test get_items method."""
+
+    def test_get_items_empty_storage(self, tmp_path: Path) -> None:
+        """Test get_items returns empty list when no items exist."""
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id="non-existent")
+        assert result == []
+
+    def test_get_items_single_feed(self, tmp_path: Path) -> None:
+        """Test get_items returns items from a single feed."""
+        # Setup storage with items
+        storage = JSONStorage(tmp_path)
+        feed_id = "feed-001"
+        items = [
+            _create_test_item(item_id="item-001", title="Article 1"),
+            _create_test_item(item_id="item-002", title="Article 2"),
+        ]
+        storage.save_items(
+            feed_id, FeedItemsData(version="1.0", feed_id=feed_id, items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id=feed_id)
+
+        assert len(result) == 2
+        assert result[0].title == "Article 1"
+        assert result[1].title == "Article 2"
+
+    def test_get_items_sorted_by_published_desc(self, tmp_path: Path) -> None:
+        """Test get_items returns items sorted by published date descending."""
+        storage = JSONStorage(tmp_path)
+        feed_id = "feed-001"
+        items = [
+            _create_test_item(item_id="item-001", published="2026-01-10T10:00:00Z"),
+            _create_test_item(item_id="item-002", published="2026-01-14T10:00:00Z"),
+            _create_test_item(item_id="item-003", published="2026-01-12T10:00:00Z"),
+        ]
+        storage.save_items(
+            feed_id, FeedItemsData(version="1.0", feed_id=feed_id, items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id=feed_id)
+
+        assert len(result) == 3
+        assert result[0].published == "2026-01-14T10:00:00Z"
+        assert result[1].published == "2026-01-12T10:00:00Z"
+        assert result[2].published == "2026-01-10T10:00:00Z"
+
+    def test_get_items_with_limit(self, tmp_path: Path) -> None:
+        """Test get_items respects limit parameter."""
+        storage = JSONStorage(tmp_path)
+        feed_id = "feed-001"
+        items = [
+            _create_test_item(
+                item_id=f"item-{i:03d}", published=f"2026-01-{10+i:02d}T10:00:00Z"
+            )
+            for i in range(5)
+        ]
+        storage.save_items(
+            feed_id, FeedItemsData(version="1.0", feed_id=feed_id, items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id=feed_id, limit=2)
+
+        assert len(result) == 2
+
+    def test_get_items_with_offset(self, tmp_path: Path) -> None:
+        """Test get_items respects offset parameter."""
+        storage = JSONStorage(tmp_path)
+        feed_id = "feed-001"
+        items = [
+            _create_test_item(item_id="item-001", published="2026-01-14T10:00:00Z"),
+            _create_test_item(item_id="item-002", published="2026-01-13T10:00:00Z"),
+            _create_test_item(item_id="item-003", published="2026-01-12T10:00:00Z"),
+        ]
+        storage.save_items(
+            feed_id, FeedItemsData(version="1.0", feed_id=feed_id, items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id=feed_id, offset=1)
+
+        assert len(result) == 2
+        assert result[0].published == "2026-01-13T10:00:00Z"
+
+    def test_get_items_with_limit_and_offset(self, tmp_path: Path) -> None:
+        """Test get_items respects both limit and offset parameters."""
+        storage = JSONStorage(tmp_path)
+        feed_id = "feed-001"
+        items = [
+            _create_test_item(
+                item_id=f"item-{i:03d}", published=f"2026-01-{14-i:02d}T10:00:00Z"
+            )
+            for i in range(5)
+        ]
+        storage.save_items(
+            feed_id, FeedItemsData(version="1.0", feed_id=feed_id, items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id=feed_id, limit=2, offset=1)
+
+        assert len(result) == 2
+        # After sorting desc and offset=1, should get 2nd and 3rd items
+        assert result[0].published == "2026-01-13T10:00:00Z"
+        assert result[1].published == "2026-01-12T10:00:00Z"
+
+    def test_get_items_all_feeds(self, tmp_path: Path) -> None:
+        """Test get_items with feed_id=None returns items from all feeds."""
+        storage = JSONStorage(tmp_path)
+
+        # Setup feeds registry
+        feed1 = _create_test_feed(feed_id="feed-001", category="finance")
+        feed2 = _create_test_feed(feed_id="feed-002", category="economics")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed1, feed2]))
+
+        # Setup items for each feed
+        items1 = [_create_test_item(item_id="item-001", title="Finance Article")]
+        items2 = [_create_test_item(item_id="item-002", title="Economics Article")]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items1)
+        )
+        storage.save_items(
+            "feed-002", FeedItemsData(version="1.0", feed_id="feed-002", items=items2)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id=None)
+
+        assert len(result) == 2
+        titles = {item.title for item in result}
+        assert "Finance Article" in titles
+        assert "Economics Article" in titles
+
+    def test_get_items_handles_none_published(self, tmp_path: Path) -> None:
+        """Test get_items handles items with None published date."""
+        storage = JSONStorage(tmp_path)
+        feed_id = "feed-001"
+        items = [
+            _create_test_item(item_id="item-001", published="2026-01-14T10:00:00Z"),
+            _create_test_item(item_id="item-002", published=None),
+            _create_test_item(item_id="item-003", published="2026-01-12T10:00:00Z"),
+        ]
+        storage.save_items(
+            feed_id, FeedItemsData(version="1.0", feed_id=feed_id, items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.get_items(feed_id=feed_id)
+
+        # None published should be sorted to the end
+        assert len(result) == 3
+        assert result[0].published == "2026-01-14T10:00:00Z"
+        assert result[1].published == "2026-01-12T10:00:00Z"
+        assert result[2].published is None
+
+
+class TestSearchItems:
+    """Test search_items method."""
+
+    def test_search_items_empty_storage(self, tmp_path: Path) -> None:
+        """Test search_items returns empty list when no items exist."""
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="test")
+        assert result == []
+
+    def test_search_items_title_match(self, tmp_path: Path) -> None:
+        """Test search_items matches in title field."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(item_id="item-001", title="Bitcoin reaches new high"),
+            _create_test_item(item_id="item-002", title="Stock market update"),
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="Bitcoin")
+
+        assert len(result) == 1
+        assert result[0].title == "Bitcoin reaches new high"
+
+    def test_search_items_summary_match(self, tmp_path: Path) -> None:
+        """Test search_items matches in summary field."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(
+                item_id="item-001", title="Article 1", summary="Bitcoin price analysis"
+            ),
+            _create_test_item(
+                item_id="item-002", title="Article 2", summary="Weather forecast"
+            ),
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="Bitcoin")
+
+        assert len(result) == 1
+        assert result[0].item_id == "item-001"
+
+    def test_search_items_content_match(self, tmp_path: Path) -> None:
+        """Test search_items matches in content field."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(
+                item_id="item-001", content="Full article about cryptocurrency trading"
+            ),
+            _create_test_item(
+                item_id="item-002", content="Weather report for tomorrow"
+            ),
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="cryptocurrency")
+
+        assert len(result) == 1
+        assert result[0].item_id == "item-001"
+
+    def test_search_items_case_insensitive(self, tmp_path: Path) -> None:
+        """Test search_items is case insensitive."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [_create_test_item(item_id="item-001", title="BITCOIN news")]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="bitcoin")
+
+        assert len(result) == 1
+
+    def test_search_items_with_fields(self, tmp_path: Path) -> None:
+        """Test search_items respects fields parameter."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(
+                item_id="item-001",
+                title="Regular article",
+                summary="Bitcoin mentioned in summary",
+            ),
+            _create_test_item(
+                item_id="item-002",
+                title="Bitcoin in title",
+                summary="No match here",
+            ),
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        # Only search in title field
+        result = reader.search_items(query="Bitcoin", fields=["title"])
+
+        assert len(result) == 1
+        assert result[0].item_id == "item-002"
+
+    def test_search_items_with_category_filter(self, tmp_path: Path) -> None:
+        """Test search_items respects category filter."""
+        storage = JSONStorage(tmp_path)
+        feed1 = _create_test_feed(feed_id="feed-001", category="finance")
+        feed2 = _create_test_feed(feed_id="feed-002", category="economics")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed1, feed2]))
+
+        items1 = [
+            _create_test_item(item_id="item-001", title="Bitcoin finance article")
+        ]
+        items2 = [
+            _create_test_item(item_id="item-002", title="Bitcoin economics article")
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items1)
+        )
+        storage.save_items(
+            "feed-002", FeedItemsData(version="1.0", feed_id="feed-002", items=items2)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="Bitcoin", category="finance")
+
+        assert len(result) == 1
+        assert result[0].item_id == "item-001"
+
+    def test_search_items_with_limit(self, tmp_path: Path) -> None:
+        """Test search_items respects limit parameter."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(item_id=f"item-{i:03d}", title=f"Bitcoin article {i}")
+            for i in range(5)
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="Bitcoin", limit=2)
+
+        assert len(result) == 2
+
+    def test_search_items_sorted_by_published_desc(self, tmp_path: Path) -> None:
+        """Test search_items returns results sorted by published date descending."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(
+                item_id="item-001",
+                title="Bitcoin old",
+                published="2026-01-10T10:00:00Z",
+            ),
+            _create_test_item(
+                item_id="item-002",
+                title="Bitcoin new",
+                published="2026-01-14T10:00:00Z",
+            ),
+            _create_test_item(
+                item_id="item-003",
+                title="Bitcoin mid",
+                published="2026-01-12T10:00:00Z",
+            ),
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="Bitcoin")
+
+        assert len(result) == 3
+        assert result[0].published == "2026-01-14T10:00:00Z"
+        assert result[1].published == "2026-01-12T10:00:00Z"
+        assert result[2].published == "2026-01-10T10:00:00Z"
+
+    def test_search_items_partial_match(self, tmp_path: Path) -> None:
+        """Test search_items supports partial matching."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(item_id="item-001", title="Cryptocurrency trading guide")
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="crypto")
+
+        assert len(result) == 1
+
+    def test_search_items_handles_none_fields(self, tmp_path: Path) -> None:
+        """Test search_items handles items with None summary/content."""
+        storage = JSONStorage(tmp_path)
+        feed = _create_test_feed(feed_id="feed-001")
+        storage.save_feeds(FeedsData(version="1.0", feeds=[feed]))
+
+        items = [
+            _create_test_item(
+                item_id="item-001", title="Bitcoin article", summary=None, content=None
+            ),
+        ]
+        storage.save_items(
+            "feed-001", FeedItemsData(version="1.0", feed_id="feed-001", items=items)
+        )
+
+        reader = FeedReader(tmp_path)
+        result = reader.search_items(query="Bitcoin")
+
+        assert len(result) == 1


### PR DESCRIPTION
## 概要
- FeedReaderクラスを追加し、フィードアイテムの読込・検索機能を実装
- `get_items()`: ページネーション付きアイテム取得（feed_id, limit, offset）
- `search_items()`: キーワード検索（title/summary/content対応、カテゴリフィルタ）
- published降順ソート（None値は末尾に配置）

## 実装内容
- `src/rss/services/feed_reader.py` - FeedReaderクラス
- `tests/rss/unit/services/test_feed_reader.py` - ユニットテスト（21テスト）

## テストプラン
- [x] make check-all が成功することを確認
- [x] 全21テストがパスすることを確認
- [x] pre-commitフック（ruff, pyright, bandit等）がパスすることを確認

Closes #63

🤖 Generated with [Claude Code](https://claude.ai/code)