### PR TITLE
feat: フィード取得サービス（FeedFetcher）を実装 (#62)

### DIFF
--- a/src/rss/services/__init__.py
+++ b/src/rss/services/__init__.py
@@ -1,6 +1,7 @@
 """Services for RSS feed management."""
 
+from .feed_fetcher import FeedFetcher
 from .feed_manager import FeedManager
 from .feed_reader import FeedReader
 
-__all__ = ["FeedManager", "FeedReader"]
+__all__ = ["FeedFetcher", "FeedManager", "FeedReader"]

--- a/src/rss/services/feed_fetcher.py
+++ b/src/rss/services/feed_fetcher.py
@@ -1,0 +1,497 @@
+"""Feed fetching service for RSS feeds.
+
+This module provides the FeedFetcher class that integrates feed fetching,
+parsing, diff detection, and storage operations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from ..core.diff_detector import DiffDetector
+from ..core.http_client import HTTPClient
+from ..core.parser import FeedParser
+from ..exceptions import FeedFetchError, FeedParseError
+from ..storage.json_storage import JSONStorage
+from ..types import Feed, FeedItemsData, FetchResult, FetchStatus
+
+
+def _get_logger() -> Any:
+    """Get logger with lazy initialization to avoid circular imports."""
+    try:
+        from ..utils.logging_config import get_logger
+
+        return get_logger(__name__, module="feed_fetcher")
+    except ImportError:
+        import logging
+
+        return logging.getLogger(__name__)
+
+
+logger: Any = _get_logger()
+
+DEFAULT_MAX_CONCURRENT = 5
+MAX_CONCURRENT_LIMIT = 10
+
+
+class FeedFetcher:
+    """Service for fetching, parsing, and storing RSS feeds.
+
+    This class integrates HTTPClient, FeedParser, DiffDetector, and JSONStorage
+    to provide a complete feed fetching workflow.
+
+    Parameters
+    ----------
+    data_dir : Path
+        Root directory for RSS feed data (e.g., data/raw/rss/)
+    http_client : HTTPClient | None, default=None
+        HTTP client instance (creates new one if None)
+    parser : FeedParser | None, default=None
+        Feed parser instance (creates new one if None)
+    diff_detector : DiffDetector | None, default=None
+        Diff detector instance (creates new one if None)
+
+    Attributes
+    ----------
+    data_dir : Path
+        Root directory for RSS feed data
+    storage : JSONStorage
+        JSON storage for persistence
+    http_client : HTTPClient
+        HTTP client for fetching feeds
+    parser : FeedParser
+        Feed parser for parsing content
+    diff_detector : DiffDetector
+        Diff detector for finding new items
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> fetcher = FeedFetcher(Path("data/raw/rss"))
+    >>> result = await fetcher.fetch_feed("feed-id-123")
+    >>> print(result.success)
+    True
+    """
+
+    def __init__(
+        self,
+        data_dir: Path,
+        http_client: HTTPClient | None = None,
+        parser: FeedParser | None = None,
+        diff_detector: DiffDetector | None = None,
+    ) -> None:
+        """Initialize FeedFetcher.
+
+        Parameters
+        ----------
+        data_dir : Path
+            Root directory for RSS feed data
+        http_client : HTTPClient | None, default=None
+            HTTP client instance (creates new one if None)
+        parser : FeedParser | None, default=None
+            Feed parser instance (creates new one if None)
+        diff_detector : DiffDetector | None, default=None
+            Diff detector instance (creates new one if None)
+
+        Raises
+        ------
+        ValueError
+            If data_dir is not a Path object
+        """
+        if not isinstance(data_dir, Path):
+            logger.error(
+                "Invalid data_dir type",
+                data_dir=str(data_dir),
+                expected_type="Path",
+                actual_type=type(data_dir).__name__,
+            )
+            raise ValueError(f"data_dir must be a Path object, got {type(data_dir)}")
+
+        self.data_dir = data_dir
+        self.storage = JSONStorage(data_dir)
+        self.http_client = http_client or HTTPClient()
+        self.parser = parser or FeedParser()
+        self.diff_detector = diff_detector or DiffDetector()
+
+        logger.debug("FeedFetcher initialized", data_dir=str(data_dir))
+
+    async def fetch_feed(self, feed_id: str) -> FetchResult:
+        """Fetch a single feed by its ID.
+
+        This method performs the complete fetch workflow:
+        1. Get feed information from storage
+        2. Fetch content via HTTPClient
+        3. Parse content via FeedParser
+        4. Detect new items via DiffDetector
+        5. Merge and save items
+        6. Update feed status (last_fetched, last_status)
+
+        Parameters
+        ----------
+        feed_id : str
+            Feed identifier (UUID format)
+
+        Returns
+        -------
+        FetchResult
+            Result containing success status, item counts, and error message
+
+        Examples
+        --------
+        >>> fetcher = FeedFetcher(Path("data/raw/rss"))
+        >>> result = await fetcher.fetch_feed("550e8400-e29b-41d4-a716-446655440000")
+        >>> if result.success:
+        ...     print(f"Fetched {result.items_count} items, {result.new_items} new")
+        """
+        logger.debug("Fetching feed", feed_id=feed_id)
+
+        try:
+            # 1. Get feed information
+            feed = self._get_feed(feed_id)
+            if feed is None:
+                logger.error("Feed not found", feed_id=feed_id)
+                return FetchResult(
+                    feed_id=feed_id,
+                    success=False,
+                    items_count=0,
+                    new_items=0,
+                    error_message=f"Feed with ID '{feed_id}' not found",
+                )
+
+            logger.debug(
+                "Feed found",
+                feed_id=feed_id,
+                url=feed.url,
+                title=feed.title,
+            )
+
+            # 2. Fetch content
+            response = await self.http_client.fetch(feed.url)
+            logger.debug(
+                "Content fetched",
+                feed_id=feed_id,
+                status_code=response.status_code,
+                content_length=len(response.content),
+            )
+
+            # 3. Parse content
+            fetched_items = self.parser.parse(response.content.encode("utf-8"))
+            logger.debug(
+                "Content parsed",
+                feed_id=feed_id,
+                fetched_count=len(fetched_items),
+            )
+
+            # 4. Load existing items and detect new ones
+            existing_data = self.storage.load_items(feed_id)
+            new_items = self.diff_detector.detect_new_items(
+                existing_data.items, fetched_items
+            )
+            logger.debug(
+                "Diff detected",
+                feed_id=feed_id,
+                existing_count=len(existing_data.items),
+                new_count=len(new_items),
+            )
+
+            # 5. Merge and save items (new items at the beginning)
+            merged_items = new_items + existing_data.items
+            items_data = FeedItemsData(
+                version="1.0",
+                feed_id=feed_id,
+                items=merged_items,
+            )
+            self.storage.save_items(feed_id, items_data)
+
+            # 6. Update feed status
+            self._update_feed_status(feed_id, FetchStatus.SUCCESS)
+
+            logger.info(
+                "Feed fetched successfully",
+                feed_id=feed_id,
+                title=feed.title,
+                items_count=len(merged_items),
+                new_items=len(new_items),
+            )
+
+            return FetchResult(
+                feed_id=feed_id,
+                success=True,
+                items_count=len(merged_items),
+                new_items=len(new_items),
+                error_message=None,
+            )
+
+        except FeedFetchError as e:
+            return self._handle_fetch_error(
+                feed_id=feed_id,
+                error=e,
+                log_message="Feed fetch failed",
+                include_traceback=False,
+            )
+
+        except FeedParseError as e:
+            return self._handle_fetch_error(
+                feed_id=feed_id,
+                error=e,
+                log_message="Feed parse failed",
+                include_traceback=False,
+            )
+
+        except Exception as e:
+            return self._handle_fetch_error(
+                feed_id=feed_id,
+                error=e,
+                log_message="Unexpected error during feed fetch",
+                include_traceback=True,
+            )
+
+    async def fetch_all_async(
+        self,
+        *,
+        category: str | None = None,
+        max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+    ) -> list[FetchResult]:
+        """Fetch all feeds asynchronously with concurrency control.
+
+        This method fetches multiple feeds in parallel using asyncio.gather
+        with semaphore-based concurrency control.
+
+        Parameters
+        ----------
+        category : str | None, default=None
+            Filter feeds by category (None for all feeds)
+        max_concurrent : int, default=5
+            Maximum number of concurrent fetches (capped at 10)
+
+        Returns
+        -------
+        list[FetchResult]
+            List of fetch results for each feed
+
+        Examples
+        --------
+        >>> fetcher = FeedFetcher(Path("data/raw/rss"))
+        >>> results = await fetcher.fetch_all_async(category="finance")
+        >>> successful = [r for r in results if r.success]
+        >>> print(f"{len(successful)}/{len(results)} feeds fetched successfully")
+        """
+        # Cap max_concurrent at MAX_CONCURRENT_LIMIT
+        effective_max = min(max_concurrent, MAX_CONCURRENT_LIMIT)
+        if max_concurrent > MAX_CONCURRENT_LIMIT:
+            logger.warning(
+                "max_concurrent capped",
+                requested=max_concurrent,
+                effective=effective_max,
+                limit=MAX_CONCURRENT_LIMIT,
+            )
+
+        logger.debug(
+            "Starting parallel fetch",
+            category=category,
+            max_concurrent=effective_max,
+        )
+
+        # Get feeds to fetch
+        feeds_data = self.storage.load_feeds()
+        feeds = feeds_data.feeds
+
+        # Filter by category if specified
+        if category is not None:
+            feeds = [f for f in feeds if f.category == category]
+
+        # Filter enabled feeds only
+        feeds = [f for f in feeds if f.enabled]
+
+        if not feeds:
+            logger.info(
+                "No feeds to fetch",
+                category=category,
+                total_feeds=len(feeds_data.feeds),
+            )
+            return []
+
+        logger.info(
+            "Fetching feeds",
+            feed_count=len(feeds),
+            category=category,
+            max_concurrent=effective_max,
+        )
+
+        # Create semaphore for concurrency control
+        semaphore = asyncio.Semaphore(effective_max)
+
+        async def fetch_with_semaphore(feed_id: str) -> FetchResult:
+            """Fetch a feed with semaphore control."""
+            async with semaphore:
+                return await self.fetch_feed(feed_id)
+
+        # Create tasks for all feeds
+        tasks = [fetch_with_semaphore(feed.feed_id) for feed in feeds]
+
+        # Execute all tasks concurrently
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+
+        # Count successes and failures
+        success_count = sum(1 for r in results if r.success)
+        failure_count = len(results) - success_count
+
+        logger.info(
+            "Parallel fetch completed",
+            total=len(results),
+            success=success_count,
+            failure=failure_count,
+            category=category,
+        )
+
+        return list(results)
+
+    def fetch_all(
+        self,
+        *,
+        category: str | None = None,
+        max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+    ) -> list[FetchResult]:
+        """Fetch all feeds synchronously (wrapper for fetch_all_async).
+
+        This is a convenience method that runs fetch_all_async in the
+        event loop for synchronous contexts.
+
+        Parameters
+        ----------
+        category : str | None, default=None
+            Filter feeds by category (None for all feeds)
+        max_concurrent : int, default=5
+            Maximum number of concurrent fetches (capped at 10)
+
+        Returns
+        -------
+        list[FetchResult]
+            List of fetch results for each feed
+
+        Examples
+        --------
+        >>> fetcher = FeedFetcher(Path("data/raw/rss"))
+        >>> results = fetcher.fetch_all(category="economics")
+        >>> for result in results:
+        ...     status = "OK" if result.success else "FAIL"
+        ...     print(f"{result.feed_id}: {status}")
+        """
+        logger.debug(
+            "Starting synchronous fetch_all",
+            category=category,
+            max_concurrent=max_concurrent,
+        )
+
+        return asyncio.run(
+            self.fetch_all_async(category=category, max_concurrent=max_concurrent)
+        )
+
+    def _get_feed(self, feed_id: str) -> Feed | None:
+        """Get feed by ID from storage.
+
+        Parameters
+        ----------
+        feed_id : str
+            Feed identifier
+
+        Returns
+        -------
+        Feed | None
+            Feed object if found, None otherwise
+        """
+        feeds_data = self.storage.load_feeds()
+        for feed in feeds_data.feeds:
+            if feed.feed_id == feed_id:
+                return feed
+        return None
+
+    def _handle_fetch_error(
+        self,
+        *,
+        feed_id: str,
+        error: Exception,
+        log_message: str,
+        include_traceback: bool,
+    ) -> FetchResult:
+        """Handle fetch error by logging and updating status.
+
+        Parameters
+        ----------
+        feed_id : str
+            Feed identifier
+        error : Exception
+            The exception that occurred
+        log_message : str
+            Log message describing the error
+        include_traceback : bool
+            Whether to include traceback in logs
+
+        Returns
+        -------
+        FetchResult
+            Failed fetch result with error message
+        """
+        error_msg = str(error)
+        logger.error(
+            log_message,
+            feed_id=feed_id,
+            error=error_msg,
+            error_type=type(error).__name__,
+            exc_info=include_traceback,
+        )
+        self._update_feed_status(feed_id, FetchStatus.FAILURE)
+        return FetchResult(
+            feed_id=feed_id,
+            success=False,
+            items_count=0,
+            new_items=0,
+            error_message=error_msg,
+        )
+
+    def _update_feed_status(self, feed_id: str, status: FetchStatus) -> None:
+        """Update feed's last_fetched and last_status.
+
+        Parameters
+        ----------
+        feed_id : str
+            Feed identifier
+        status : FetchStatus
+            New fetch status
+        """
+        try:
+            feeds_data = self.storage.load_feeds()
+
+            for i, feed in enumerate(feeds_data.feeds):
+                if feed.feed_id == feed_id:
+                    feed.last_fetched = datetime.now(UTC).isoformat()
+                    feed.last_status = status
+                    feed.updated_at = datetime.now(UTC).isoformat()
+                    feeds_data.feeds[i] = feed
+                    self.storage.save_feeds(feeds_data)
+
+                    logger.debug(
+                        "Feed status updated",
+                        feed_id=feed_id,
+                        status=status.value,
+                        last_fetched=feed.last_fetched,
+                    )
+                    return
+
+            logger.warning(
+                "Feed not found for status update",
+                feed_id=feed_id,
+                status=status.value,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Failed to update feed status",
+                feed_id=feed_id,
+                status=status.value,
+                error=str(e),
+                exc_info=True,
+            )

--- a/tests/rss/unit/services/test_feed_fetcher.py
+++ b/tests/rss/unit/services/test_feed_fetcher.py
@@ -1,0 +1,867 @@
+"""Unit tests for FeedFetcher class."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from rss.core.diff_detector import DiffDetector
+from rss.core.http_client import HTTPClient
+from rss.core.parser import FeedParser
+from rss.exceptions import FeedFetchError, FeedParseError
+from rss.services.feed_fetcher import (
+    DEFAULT_MAX_CONCURRENT,
+    MAX_CONCURRENT_LIMIT,
+    FeedFetcher,
+)
+from rss.storage.json_storage import JSONStorage
+from rss.types import (
+    Feed,
+    FeedItem,
+    FeedItemsData,
+    FeedsData,
+    FetchInterval,
+    FetchStatus,
+    HTTPResponse,
+)
+
+
+class TestFeedFetcherInit:
+    """Test FeedFetcher initialization."""
+
+    def test_init_success(self, tmp_path: Path) -> None:
+        """Test successful initialization with default parameters."""
+        fetcher = FeedFetcher(tmp_path)
+
+        assert fetcher.data_dir == tmp_path
+        assert isinstance(fetcher.storage, JSONStorage)
+        assert isinstance(fetcher.http_client, HTTPClient)
+        assert isinstance(fetcher.parser, FeedParser)
+        assert isinstance(fetcher.diff_detector, DiffDetector)
+
+    def test_init_with_custom_dependencies(self, tmp_path: Path) -> None:
+        """Test initialization with custom dependency injection."""
+        mock_http_client = Mock(spec=HTTPClient)
+        mock_parser = Mock(spec=FeedParser)
+        mock_diff_detector = Mock(spec=DiffDetector)
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        assert fetcher.http_client is mock_http_client
+        assert fetcher.parser is mock_parser
+        assert fetcher.diff_detector is mock_diff_detector
+
+    def test_init_invalid_data_dir_type(self) -> None:
+        """Test initialization with invalid data_dir type."""
+        with pytest.raises(ValueError, match="data_dir must be a Path object"):
+            FeedFetcher("invalid")  # type: ignore[arg-type]
+
+
+class TestFetchFeed:
+    """Test fetch_feed method."""
+
+    @pytest.fixture
+    def sample_feed(self) -> Feed:
+        """Create a sample feed for testing."""
+        return Feed(
+            feed_id="test-feed-id-123",
+            url="https://example.com/feed.xml",
+            title="Test Feed",
+            category="finance",
+            fetch_interval=FetchInterval.DAILY,
+            created_at="2026-01-14T10:00:00+00:00",
+            updated_at="2026-01-14T10:00:00+00:00",
+            last_fetched=None,
+            last_status=FetchStatus.PENDING,
+            enabled=True,
+        )
+
+    @pytest.fixture
+    def sample_feed_items(self) -> list[FeedItem]:
+        """Create sample feed items for testing."""
+        return [
+            FeedItem(
+                item_id="item-1",
+                title="Article 1",
+                link="https://example.com/article1",
+                published="2026-01-14T09:00:00+00:00",
+                summary="Summary 1",
+                content=None,
+                author="Author 1",
+                fetched_at="2026-01-14T10:00:00+00:00",
+            ),
+            FeedItem(
+                item_id="item-2",
+                title="Article 2",
+                link="https://example.com/article2",
+                published="2026-01-14T08:00:00+00:00",
+                summary="Summary 2",
+                content=None,
+                author="Author 2",
+                fetched_at="2026-01-14T10:00:00+00:00",
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_success(
+        self, tmp_path: Path, sample_feed: Feed, sample_feed_items: list[FeedItem]
+    ) -> None:
+        """Test successful feed fetch."""
+        # Setup mocks
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = sample_feed_items
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = sample_feed_items
+
+        # Create fetcher with mocks
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feed in storage
+        feeds_data = FeedsData(version="1.0", feeds=[sample_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        result = await fetcher.fetch_feed(sample_feed.feed_id)
+
+        # Verify
+        assert result.success is True
+        assert result.feed_id == sample_feed.feed_id
+        assert result.items_count == 2
+        assert result.new_items == 2
+        assert result.error_message is None
+
+        # Verify HTTP client was called
+        mock_http_client.fetch.assert_called_once_with(sample_feed.url)
+
+        # Verify parser was called
+        mock_parser.parse.assert_called_once()
+
+        # Verify diff detector was called
+        mock_diff_detector.detect_new_items.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_updates_status(
+        self, tmp_path: Path, sample_feed: Feed, sample_feed_items: list[FeedItem]
+    ) -> None:
+        """Test that feed status is updated after fetch."""
+        # Setup mocks
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = sample_feed_items
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = sample_feed_items
+
+        # Create fetcher with mocks
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feed in storage
+        feeds_data = FeedsData(version="1.0", feeds=[sample_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        await fetcher.fetch_feed(sample_feed.feed_id)
+
+        # Verify feed status was updated
+        updated_feeds = fetcher.storage.load_feeds()
+        updated_feed = updated_feeds.feeds[0]
+        assert updated_feed.last_status == FetchStatus.SUCCESS
+        assert updated_feed.last_fetched is not None
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_saves_items(
+        self, tmp_path: Path, sample_feed: Feed, sample_feed_items: list[FeedItem]
+    ) -> None:
+        """Test that fetched items are saved to storage."""
+        # Setup mocks
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = sample_feed_items
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = sample_feed_items
+
+        # Create fetcher with mocks
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feed in storage
+        feeds_data = FeedsData(version="1.0", feeds=[sample_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        await fetcher.fetch_feed(sample_feed.feed_id)
+
+        # Verify items were saved
+        items_data = fetcher.storage.load_items(sample_feed.feed_id)
+        assert len(items_data.items) == 2
+        assert items_data.feed_id == sample_feed.feed_id
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_merges_with_existing_items(
+        self, tmp_path: Path, sample_feed: Feed
+    ) -> None:
+        """Test that new items are merged with existing items."""
+        existing_item = FeedItem(
+            item_id="existing-1",
+            title="Existing Article",
+            link="https://example.com/existing",
+            published="2026-01-13T09:00:00+00:00",
+            summary="Existing summary",
+            content=None,
+            author="Author",
+            fetched_at="2026-01-13T10:00:00+00:00",
+        )
+
+        new_item = FeedItem(
+            item_id="new-1",
+            title="New Article",
+            link="https://example.com/new",
+            published="2026-01-14T09:00:00+00:00",
+            summary="New summary",
+            content=None,
+            author="Author",
+            fetched_at="2026-01-14T10:00:00+00:00",
+        )
+
+        # Setup mocks
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = [new_item, existing_item]
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = [new_item]
+
+        # Create fetcher with mocks
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feed and existing items in storage
+        feeds_data = FeedsData(version="1.0", feeds=[sample_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        existing_items_data = FeedItemsData(
+            version="1.0",
+            feed_id=sample_feed.feed_id,
+            items=[existing_item],
+        )
+        fetcher.storage.save_items(sample_feed.feed_id, existing_items_data)
+
+        # Execute
+        result = await fetcher.fetch_feed(sample_feed.feed_id)
+
+        # Verify
+        assert result.success is True
+        assert result.items_count == 2  # New + Existing
+        assert result.new_items == 1  # Only the new one
+
+        # Verify merged items (new items at the beginning)
+        items_data = fetcher.storage.load_items(sample_feed.feed_id)
+        assert len(items_data.items) == 2
+        assert items_data.items[0].item_id == "new-1"
+        assert items_data.items[1].item_id == "existing-1"
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_not_found(self, tmp_path: Path) -> None:
+        """Test fetch_feed with non-existent feed ID."""
+        fetcher = FeedFetcher(tmp_path)
+
+        result = await fetcher.fetch_feed("non-existent-id")
+
+        assert result.success is False
+        assert result.feed_id == "non-existent-id"
+        assert result.items_count == 0
+        assert result.new_items == 0
+        assert result.error_message is not None
+        assert "not found" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_http_error(
+        self, tmp_path: Path, sample_feed: Feed
+    ) -> None:
+        """Test fetch_feed handles HTTP errors gracefully."""
+        # Setup mock that raises FeedFetchError
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.side_effect = FeedFetchError("Failed to fetch: HTTP 500")
+
+        fetcher = FeedFetcher(tmp_path, http_client=mock_http_client)
+
+        # Create feed in storage
+        feeds_data = FeedsData(version="1.0", feeds=[sample_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        result = await fetcher.fetch_feed(sample_feed.feed_id)
+
+        # Verify error handling
+        assert result.success is False
+        assert result.feed_id == sample_feed.feed_id
+        assert result.items_count == 0
+        assert result.new_items == 0
+        assert result.error_message is not None
+        assert "HTTP 500" in result.error_message
+
+        # Verify status was updated to FAILURE
+        updated_feeds = fetcher.storage.load_feeds()
+        assert updated_feeds.feeds[0].last_status == FetchStatus.FAILURE
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_parse_error(
+        self, tmp_path: Path, sample_feed: Feed
+    ) -> None:
+        """Test fetch_feed handles parse errors gracefully."""
+        # Setup mocks
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<html>Not RSS</html>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.side_effect = FeedParseError("Invalid RSS format")
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+        )
+
+        # Create feed in storage
+        feeds_data = FeedsData(version="1.0", feeds=[sample_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        result = await fetcher.fetch_feed(sample_feed.feed_id)
+
+        # Verify error handling
+        assert result.success is False
+        assert result.error_message is not None
+        assert "Invalid RSS" in result.error_message
+
+        # Verify status was updated to FAILURE
+        updated_feeds = fetcher.storage.load_feeds()
+        assert updated_feeds.feeds[0].last_status == FetchStatus.FAILURE
+
+    @pytest.mark.asyncio
+    async def test_fetch_feed_unexpected_error(
+        self, tmp_path: Path, sample_feed: Feed
+    ) -> None:
+        """Test fetch_feed handles unexpected errors gracefully."""
+        # Setup mock that raises unexpected error
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.side_effect = RuntimeError("Unexpected error")
+
+        fetcher = FeedFetcher(tmp_path, http_client=mock_http_client)
+
+        # Create feed in storage
+        feeds_data = FeedsData(version="1.0", feeds=[sample_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        result = await fetcher.fetch_feed(sample_feed.feed_id)
+
+        # Verify error handling
+        assert result.success is False
+        assert result.error_message is not None
+        assert "Unexpected error" in result.error_message
+
+
+class TestFetchAllAsync:
+    """Test fetch_all_async method."""
+
+    @pytest.fixture
+    def sample_feeds(self) -> list[Feed]:
+        """Create sample feeds for testing."""
+        return [
+            Feed(
+                feed_id=f"feed-{i}",
+                url=f"https://example.com/feed{i}.xml",
+                title=f"Feed {i}",
+                category="finance" if i % 2 == 0 else "tech",
+                fetch_interval=FetchInterval.DAILY,
+                created_at="2026-01-14T10:00:00+00:00",
+                updated_at="2026-01-14T10:00:00+00:00",
+                last_fetched=None,
+                last_status=FetchStatus.PENDING,
+                enabled=i != 3,  # feed-3 is disabled
+            )
+            for i in range(5)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_async_success(
+        self, tmp_path: Path, sample_feeds: list[Feed]
+    ) -> None:
+        """Test fetching all feeds successfully."""
+        # Setup mocks
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = []
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = []
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feeds in storage
+        feeds_data = FeedsData(version="1.0", feeds=sample_feeds)
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        results = await fetcher.fetch_all_async()
+
+        # Verify (4 enabled feeds)
+        assert len(results) == 4
+        assert all(r.success for r in results)
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_async_filter_by_category(
+        self, tmp_path: Path, sample_feeds: list[Feed]
+    ) -> None:
+        """Test fetching feeds filtered by category."""
+        # Setup mocks
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = []
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = []
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feeds in storage
+        feeds_data = FeedsData(version="1.0", feeds=sample_feeds)
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute with category filter
+        results = await fetcher.fetch_all_async(category="finance")
+
+        # Verify (finance feeds: 0, 2, 4 - but 0, 2, 4 are enabled)
+        assert len(results) == 3
+        assert all(r.success for r in results)
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_async_respects_max_concurrent(
+        self, tmp_path: Path, sample_feeds: list[Feed]
+    ) -> None:
+        """Test that max_concurrent limits parallel fetches."""
+        concurrent_count = 0
+        max_observed_concurrent = 0
+
+        async def mock_fetch(url: str) -> HTTPResponse:
+            nonlocal concurrent_count, max_observed_concurrent
+            concurrent_count += 1
+            max_observed_concurrent = max(max_observed_concurrent, concurrent_count)
+            await asyncio.sleep(0.05)  # Simulate network delay
+            concurrent_count -= 1
+            return HTTPResponse(
+                status_code=200,
+                content="<rss>...</rss>",
+                headers={},
+            )
+
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.side_effect = mock_fetch
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = []
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = []
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feeds in storage
+        feeds_data = FeedsData(version="1.0", feeds=sample_feeds)
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute with max_concurrent=2
+        await fetcher.fetch_all_async(max_concurrent=2)
+
+        # Verify concurrency was limited
+        assert max_observed_concurrent <= 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_async_caps_max_concurrent(self, tmp_path: Path) -> None:
+        """Test that max_concurrent is capped at MAX_CONCURRENT_LIMIT."""
+        fetcher = FeedFetcher(tmp_path)
+
+        # Create a simple feed
+        feed = Feed(
+            feed_id="test-feed",
+            url="https://example.com/feed.xml",
+            title="Test Feed",
+            category="finance",
+            fetch_interval=FetchInterval.DAILY,
+            created_at="2026-01-14T10:00:00+00:00",
+            updated_at="2026-01-14T10:00:00+00:00",
+            last_fetched=None,
+            last_status=FetchStatus.PENDING,
+            enabled=True,
+        )
+        feeds_data = FeedsData(version="1.0", feeds=[feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Patch fetch_feed to verify semaphore behavior
+        with patch.object(fetcher, "fetch_feed", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = Mock(success=True)
+
+            # Request more than allowed
+            await fetcher.fetch_all_async(max_concurrent=100)
+
+            # Verify fetch was called (test doesn't directly verify cap,
+            # but verifies no error with high value)
+            assert mock_fetch.called
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_async_one_failure_doesnt_stop_others(
+        self, tmp_path: Path, sample_feeds: list[Feed]
+    ) -> None:
+        """Test that one feed failure doesn't affect other feeds."""
+        call_count = 0
+
+        async def mock_fetch(url: str) -> HTTPResponse:
+            nonlocal call_count
+            call_count += 1
+            if "feed0" in url:
+                raise FeedFetchError("Network error")
+            return HTTPResponse(
+                status_code=200,
+                content="<rss>...</rss>",
+                headers={},
+            )
+
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.side_effect = mock_fetch
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = []
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = []
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        # Create feeds in storage
+        feeds_data = FeedsData(version="1.0", feeds=sample_feeds)
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute
+        results = await fetcher.fetch_all_async()
+
+        # Verify all feeds were attempted (4 enabled)
+        assert len(results) == 4
+
+        # Verify one failed and others succeeded
+        failed = [r for r in results if not r.success]
+        succeeded = [r for r in results if r.success]
+
+        assert len(failed) == 1
+        assert len(succeeded) == 3
+        assert failed[0].feed_id == "feed-0"
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_async_empty_feeds(self, tmp_path: Path) -> None:
+        """Test fetch_all_async with no feeds."""
+        fetcher = FeedFetcher(tmp_path)
+
+        results = await fetcher.fetch_all_async()
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_async_no_enabled_feeds(self, tmp_path: Path) -> None:
+        """Test fetch_all_async with only disabled feeds."""
+        disabled_feed = Feed(
+            feed_id="disabled-feed",
+            url="https://example.com/feed.xml",
+            title="Disabled Feed",
+            category="finance",
+            fetch_interval=FetchInterval.DAILY,
+            created_at="2026-01-14T10:00:00+00:00",
+            updated_at="2026-01-14T10:00:00+00:00",
+            last_fetched=None,
+            last_status=FetchStatus.PENDING,
+            enabled=False,
+        )
+
+        fetcher = FeedFetcher(tmp_path)
+        feeds_data = FeedsData(version="1.0", feeds=[disabled_feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        results = await fetcher.fetch_all_async()
+
+        assert results == []
+
+
+class TestFetchAll:
+    """Test fetch_all (synchronous wrapper) method."""
+
+    def test_fetch_all_success(self, tmp_path: Path) -> None:
+        """Test synchronous fetch_all wrapper."""
+        feed = Feed(
+            feed_id="test-feed",
+            url="https://example.com/feed.xml",
+            title="Test Feed",
+            category="finance",
+            fetch_interval=FetchInterval.DAILY,
+            created_at="2026-01-14T10:00:00+00:00",
+            updated_at="2026-01-14T10:00:00+00:00",
+            last_fetched=None,
+            last_status=FetchStatus.PENDING,
+            enabled=True,
+        )
+
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = []
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = []
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        feeds_data = FeedsData(version="1.0", feeds=[feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute synchronous method
+        results = fetcher.fetch_all()
+
+        assert len(results) == 1
+        assert results[0].success is True
+
+    def test_fetch_all_with_category(self, tmp_path: Path) -> None:
+        """Test synchronous fetch_all with category filter."""
+        feeds = [
+            Feed(
+                feed_id=f"feed-{i}",
+                url=f"https://example.com/feed{i}.xml",
+                title=f"Feed {i}",
+                category="finance" if i == 0 else "tech",
+                fetch_interval=FetchInterval.DAILY,
+                created_at="2026-01-14T10:00:00+00:00",
+                updated_at="2026-01-14T10:00:00+00:00",
+                last_fetched=None,
+                last_status=FetchStatus.PENDING,
+                enabled=True,
+            )
+            for i in range(3)
+        ]
+
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = []
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = []
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        feeds_data = FeedsData(version="1.0", feeds=feeds)
+        fetcher.storage.save_feeds(feeds_data)
+
+        # Execute with category filter
+        results = fetcher.fetch_all(category="finance")
+
+        assert len(results) == 1
+        assert results[0].feed_id == "feed-0"
+
+
+class TestDefaultConstants:
+    """Test default constants."""
+
+    def test_default_max_concurrent(self) -> None:
+        """Test DEFAULT_MAX_CONCURRENT value."""
+        assert DEFAULT_MAX_CONCURRENT == 5
+
+    def test_max_concurrent_limit(self) -> None:
+        """Test MAX_CONCURRENT_LIMIT value."""
+        assert MAX_CONCURRENT_LIMIT == 10
+
+
+class TestLogging:
+    """Test structured logging behavior."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_success_logs_info(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that successful fetch logs at INFO level."""
+        feed = Feed(
+            feed_id="test-feed",
+            url="https://example.com/feed.xml",
+            title="Test Feed",
+            category="finance",
+            fetch_interval=FetchInterval.DAILY,
+            created_at="2026-01-14T10:00:00+00:00",
+            updated_at="2026-01-14T10:00:00+00:00",
+            last_fetched=None,
+            last_status=FetchStatus.PENDING,
+            enabled=True,
+        )
+
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.return_value = HTTPResponse(
+            status_code=200,
+            content="<rss>...</rss>",
+            headers={},
+        )
+
+        mock_parser = Mock(spec=FeedParser)
+        mock_parser.parse.return_value = []
+
+        mock_diff_detector = Mock(spec=DiffDetector)
+        mock_diff_detector.detect_new_items.return_value = []
+
+        fetcher = FeedFetcher(
+            tmp_path,
+            http_client=mock_http_client,
+            parser=mock_parser,
+            diff_detector=mock_diff_detector,
+        )
+
+        feeds_data = FeedsData(version="1.0", feeds=[feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        await fetcher.fetch_feed(feed.feed_id)
+
+        captured = capsys.readouterr()
+        # Verify info log was produced
+        assert "successfully" in captured.out.lower() or "info" in captured.out.lower()
+
+    @pytest.mark.asyncio
+    async def test_fetch_error_logs_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that fetch error logs at ERROR level."""
+        feed = Feed(
+            feed_id="test-feed",
+            url="https://example.com/feed.xml",
+            title="Test Feed",
+            category="finance",
+            fetch_interval=FetchInterval.DAILY,
+            created_at="2026-01-14T10:00:00+00:00",
+            updated_at="2026-01-14T10:00:00+00:00",
+            last_fetched=None,
+            last_status=FetchStatus.PENDING,
+            enabled=True,
+        )
+
+        mock_http_client = AsyncMock(spec=HTTPClient)
+        mock_http_client.fetch.side_effect = FeedFetchError("Connection failed")
+
+        fetcher = FeedFetcher(tmp_path, http_client=mock_http_client)
+
+        feeds_data = FeedsData(version="1.0", feeds=[feed])
+        fetcher.storage.save_feeds(feeds_data)
+
+        await fetcher.fetch_feed(feed.feed_id)
+
+        captured = capsys.readouterr()
+        # Verify error log was produced
+        assert "failed" in captured.out.lower() or "error" in captured.out.lower()


### PR DESCRIPTION
## 概要
フィードの取得、パース、差分検出、保存を統合したFeedFetcherサービスを実装しました。

### 実装内容
- `FeedFetcher` クラスの実装
- `fetch_feed()`: 単一フィード取得（HTTPClient→FeedParser→DiffDetector→Storage）
- `fetch_all_async()`: asyncio.gather + セマフォによる並列取得（最大10同時実行）
- `fetch_all()`: 同期ラッパー
- 1フィードの失敗が他フィードに影響しない設計
- 構造化ロギング（INFO: 取得成功、ERROR: 取得失敗）

### 受け入れ条件
- [x] `fetch_feed()` が指定フィードを取得する
- [x] HTTPClientでコンテンツを取得する
- [x] FeedParserでパースする
- [x] DiffDetectorで新規アイテムを検出する
- [x] 既存アイテムと新規アイテムを統合して保存する
- [x] last_fetched, last_statusを更新する
- [x] `FetchResult` を返す
- [x] エラー時に `FetchResult(success=False)` を返す
- [x] `fetch_all_async()` が並列実行する（最大max_concurrent）
- [x] 1フィードの失敗が他フィードに影響しない
- [x] `fetch_all()` が同期ラッパーとして動作する
- [x] 構造化ロギング（INFO: 取得成功、ERROR: 取得失敗）

## テストプラン
- [x] make check-all が成功することを確認
- [x] 24テストケースを追加（715テスト全てパス）

Closes #62

🤖 Generated with [Claude Code](https://claude.ai/code)