### PR TITLE
feat: Python API エクスポート（__init__.py）を実装 (#64)

### DIFF
--- a/src/rss/__init__.py
+++ b/src/rss/__init__.py
@@ -1,8 +1,82 @@
-"""rss package."""
+"""RSS feed management package.
 
+This package provides functionality for managing, fetching, and reading RSS feeds.
+
+Main Components
+---------------
+FeedManager
+    Manages feed registration, updates, and deletion.
+FeedFetcher
+    Fetches RSS/Atom feeds from URLs and parses content.
+FeedReader
+    Reads and filters stored feed items.
+
+Data Models
+-----------
+Feed
+    Feed information model.
+FeedItem
+    Feed item (article/entry) model.
+FetchResult
+    Result of a feed fetch operation.
+FetchInterval
+    Enum for feed fetch intervals (daily, weekly, manual).
+FetchStatus
+    Enum for fetch status (success, failure, pending).
+
+Exceptions
+----------
+RSSError
+    Base exception for all RSS package errors.
+FeedNotFoundError
+    Raised when a feed is not found.
+FeedAlreadyExistsError
+    Raised when attempting to add a duplicate feed.
+FeedFetchError
+    Raised when fetching a feed fails.
+FeedParseError
+    Raised when parsing a feed fails.
+InvalidURLError
+    Raised when a URL is invalid.
+FileLockError
+    Raised when file lock acquisition fails.
+
+Examples
+--------
+>>> from rss import FeedManager, FeedFetcher, FeedReader
+>>> from rss import Feed, FeedItem, FetchResult
+>>> from rss import RSSError, FeedNotFoundError
+"""
+
+from .exceptions import (
+    FeedAlreadyExistsError,
+    FeedFetchError,
+    FeedNotFoundError,
+    FeedParseError,
+    FileLockError,
+    InvalidURLError,
+    RSSError,
+)
+from .services import FeedFetcher, FeedManager, FeedReader
+from .types import Feed, FeedItem, FetchInterval, FetchResult, FetchStatus
 from .utils.logging_config import get_logger
 
 __all__ = [
+    "Feed",
+    "FeedAlreadyExistsError",
+    "FeedFetchError",
+    "FeedFetcher",
+    "FeedItem",
+    "FeedManager",
+    "FeedNotFoundError",
+    "FeedParseError",
+    "FeedReader",
+    "FetchInterval",
+    "FetchResult",
+    "FetchStatus",
+    "FileLockError",
+    "InvalidURLError",
+    "RSSError",
     "get_logger",
 ]
 


### PR DESCRIPTION
## 概要
- rssパッケージの公開APIをエクスポート
- パッケージdocstringを記述
- `__all__` を定義

## エクスポート内容
| カテゴリ | エクスポート |
|---------|-------------|
| Services | `FeedManager`, `FeedFetcher`, `FeedReader` |
| Data Models | `Feed`, `FeedItem`, `FetchInterval`, `FetchStatus`, `FetchResult` |
| Exceptions | `RSSError`, `FeedNotFoundError`, `FeedAlreadyExistsError`, `FeedFetchError`, `FeedParseError`, `InvalidURLError`, `FileLockError` |
| Utilities | `get_logger` |

## 受け入れ条件
- [x] `FeedManager`, `FeedFetcher`, `FeedReader` がエクスポートされる
- [x] `Feed`, `FeedItem`, `FetchInterval`, `FetchStatus`, `FetchResult` がエクスポートされる
- [x] 全カスタム例外クラスがエクスポートされる
- [x] `__all__` が定義される
- [x] パッケージdocstringが記述される
- [x] `from rss import FeedManager` でインポート可能
- [x] pyrightで型チェックエラー0件

## テストプラン
- [x] make check-all が成功することを確認
- [x] pyright 型チェック: 0 errors
- [x] インポートテスト: 全API正常にインポート可能

Closes #64

🤖 Generated with [Claude Code](https://claude.ai/code)