### PR TITLE
feat: CLIインターフェース（rss-cli）を実装 (#66)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,13 @@ scheduler = ["apscheduler>=3.10.0"]
 mcp = [
     "mcp>=1.0.0",
 ]
+cli = [
+    "click>=8.1.0",
+]
 
 [project.scripts]
 rss-mcp = "rss.mcp.server:main"
+rss-cli = "rss.cli.main:cli"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/rss/cli/__init__.py
+++ b/src/rss/cli/__init__.py
@@ -1,0 +1,8 @@
+"""RSS CLI module.
+
+This module provides a command-line interface for managing RSS feeds.
+"""
+
+from .main import cli
+
+__all__ = ["cli"]

--- a/src/rss/cli/main.py
+++ b/src/rss/cli/main.py
@@ -1,0 +1,632 @@
+"""RSS CLI main module.
+
+This module provides the command-line interface for RSS feed management.
+Implements 7 subcommands: add, list, update, remove, fetch, items, search.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from ..exceptions import (
+    FeedAlreadyExistsError,
+    FeedFetchError,
+    FeedNotFoundError,
+    FeedParseError,
+    InvalidURLError,
+    RSSError,
+)
+from ..services.feed_fetcher import FeedFetcher
+from ..services.feed_manager import FeedManager
+from ..services.feed_reader import FeedReader
+from ..types import Feed, FeedItem, FetchInterval, FetchResult
+
+
+def _get_logger() -> Any:
+    """Get logger with lazy initialization to avoid circular imports."""
+    try:
+        from ..utils.logging_config import get_logger
+
+        return get_logger(__name__, module="cli")
+    except ImportError:
+        import logging
+
+        return logging.getLogger(__name__)
+
+
+logger: Any = _get_logger()
+
+# Default data directory
+DEFAULT_DATA_DIR = Path("data/raw/rss")
+
+# Console for rich output
+console = Console()
+
+
+def _get_data_dir(ctx: click.Context) -> Path:
+    """Get data directory from context.
+
+    Parameters
+    ----------
+    ctx : click.Context
+        Click context
+
+    Returns
+    -------
+    Path
+        Data directory path
+    """
+    return ctx.obj.get("data_dir", DEFAULT_DATA_DIR)
+
+
+def _output_json(data: dict[str, Any] | list[dict[str, Any]]) -> None:
+    """Output data as JSON.
+
+    Parameters
+    ----------
+    data : dict[str, Any] | list[dict[str, Any]]
+        Data to output
+    """
+    click.echo(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def _feed_to_dict(feed: Feed) -> dict[str, Any]:
+    """Convert Feed to dictionary.
+
+    Parameters
+    ----------
+    feed : Feed
+        Feed object
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary representation
+    """
+    return {
+        "feed_id": feed.feed_id,
+        "url": feed.url,
+        "title": feed.title,
+        "category": feed.category,
+        "fetch_interval": feed.fetch_interval.value,
+        "created_at": feed.created_at,
+        "updated_at": feed.updated_at,
+        "last_fetched": feed.last_fetched,
+        "last_status": feed.last_status.value,
+        "enabled": feed.enabled,
+    }
+
+
+def _item_to_dict(item: FeedItem) -> dict[str, Any]:
+    """Convert FeedItem to dictionary.
+
+    Parameters
+    ----------
+    item : FeedItem
+        FeedItem object
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary representation
+    """
+    return {
+        "item_id": item.item_id,
+        "title": item.title,
+        "link": item.link,
+        "published": item.published,
+        "summary": item.summary,
+        "content": item.content,
+        "author": item.author,
+        "fetched_at": item.fetched_at,
+    }
+
+
+def _result_to_dict(result: FetchResult) -> dict[str, Any]:
+    """Convert FetchResult to dictionary.
+
+    Parameters
+    ----------
+    result : FetchResult
+        FetchResult object
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary representation
+    """
+    return {
+        "feed_id": result.feed_id,
+        "success": result.success,
+        "items_count": result.items_count,
+        "new_items": result.new_items,
+        "error_message": result.error_message,
+    }
+
+
+def _truncate(text: str | None, max_length: int = 50) -> str:
+    """Truncate text to max length.
+
+    Parameters
+    ----------
+    text : str | None
+        Text to truncate
+    max_length : int, default=50
+        Maximum length
+
+    Returns
+    -------
+    str
+        Truncated text
+    """
+    if text is None:
+        return ""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."
+
+
+def _handle_error(
+    error: RSSError,
+    error_type: str,
+    json_output: bool,
+    **log_context: Any,
+) -> None:
+    """Handle RSS error with consistent logging and output.
+
+    Parameters
+    ----------
+    error : RSSError
+        The error to handle
+    error_type : str
+        Error type description for logging
+    json_output : bool
+        Whether to output as JSON
+    **log_context : Any
+        Additional context for logging
+    """
+    logger.error(error_type, error=str(error), **log_context)
+    if json_output:
+        _output_json({"error": str(error)})
+    else:
+        console.print(f"[red]Error: {error}[/red]")
+    sys.exit(1)
+
+
+@click.group()
+@click.option(
+    "--data-dir",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_DATA_DIR,
+    help="Data directory path (default: data/raw/rss)",
+)
+@click.pass_context
+def cli(ctx: click.Context, data_dir: Path) -> None:
+    """RSS Feed Management CLI.
+
+    Manage RSS feeds: add, list, update, remove, fetch, view items, and search.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["data_dir"] = data_dir
+    logger.debug("CLI started", data_dir=str(data_dir))
+
+
+@cli.command()
+@click.option("--url", required=True, help="Feed URL (HTTP/HTTPS)")
+@click.option("--title", required=True, help="Feed title")
+@click.option("--category", required=True, help="Feed category")
+@click.option(
+    "--interval",
+    type=click.Choice(["daily", "weekly", "manual"]),
+    default="daily",
+    help="Fetch interval (default: daily)",
+)
+@click.option(
+    "--validate/--no-validate",
+    default=False,
+    help="Validate URL reachability",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def add(
+    ctx: click.Context,
+    url: str,
+    title: str,
+    category: str,
+    interval: str,
+    validate: bool,
+    json_output: bool,
+) -> None:
+    """Register a new feed."""
+    logger.info("Adding feed", url=url, title=title, category=category)
+
+    data_dir = _get_data_dir(ctx)
+    manager = FeedManager(data_dir)
+
+    interval_enum = FetchInterval(interval)
+
+    try:
+        feed = manager.add_feed(
+            url=url,
+            title=title,
+            category=category,
+            fetch_interval=interval_enum,
+            validate_url=validate,
+        )
+
+        if json_output:
+            _output_json(_feed_to_dict(feed))
+        else:
+            console.print("[green]Feed registered successfully[/green]")
+            console.print(f"  Feed ID: {feed.feed_id}")
+            console.print(f"  Title: {feed.title}")
+            console.print(f"  URL: {feed.url}")
+
+        logger.info("Feed added successfully", feed_id=feed.feed_id)
+
+    except FeedAlreadyExistsError as e:
+        _handle_error(e, "Feed already exists", json_output, url=url)
+
+    except InvalidURLError as e:
+        _handle_error(e, "Invalid URL", json_output, url=url)
+
+    except FeedFetchError as e:
+        _handle_error(e, "URL validation failed", json_output, url=url)
+
+    except RSSError as e:
+        _handle_error(e, "RSS error", json_output)
+
+
+@cli.command(name="list")
+@click.option("--category", default=None, help="Filter by category")
+@click.option("--enabled-only", is_flag=True, help="Show only enabled feeds")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def list_feeds(
+    ctx: click.Context,
+    category: str | None,
+    enabled_only: bool,
+    json_output: bool,
+) -> None:
+    """List registered feeds."""
+    logger.info("Listing feeds", category=category, enabled_only=enabled_only)
+
+    data_dir = _get_data_dir(ctx)
+    manager = FeedManager(data_dir)
+
+    feeds = manager.list_feeds(category=category, enabled_only=enabled_only)
+
+    if json_output:
+        _output_json([_feed_to_dict(f) for f in feeds])
+    else:
+        if not feeds:
+            console.print("[yellow]No feeds found[/yellow]")
+            return
+
+        table = Table(title="Registered Feeds")
+        table.add_column("ID", style="cyan", max_width=8)
+        table.add_column("Title", style="green")
+        table.add_column("Category")
+        table.add_column("Interval")
+        table.add_column("Status")
+        table.add_column("Enabled")
+
+        for feed in feeds:
+            status_style = "green" if feed.last_status.value == "success" else "red"
+            enabled_text = "Yes" if feed.enabled else "No"
+            table.add_row(
+                feed.feed_id[:8],
+                _truncate(feed.title, 30),
+                feed.category,
+                feed.fetch_interval.value,
+                f"[{status_style}]{feed.last_status.value}[/{status_style}]",
+                enabled_text,
+            )
+
+        console.print(table)
+        console.print(f"\nTotal: {len(feeds)} feeds")
+
+    logger.info("Feeds listed", count=len(feeds))
+
+
+@cli.command()
+@click.argument("feed_id")
+@click.option("--title", default=None, help="New title")
+@click.option("--category", default=None, help="New category")
+@click.option(
+    "--interval",
+    type=click.Choice(["daily", "weekly", "manual"]),
+    default=None,
+    help="New fetch interval",
+)
+@click.option("--enabled/--disabled", default=None, help="Enable/disable feed")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def update(
+    ctx: click.Context,
+    feed_id: str,
+    title: str | None,
+    category: str | None,
+    interval: str | None,
+    enabled: bool | None,
+    json_output: bool,
+) -> None:
+    """Update feed information."""
+    logger.info("Updating feed", feed_id=feed_id)
+
+    data_dir = _get_data_dir(ctx)
+    manager = FeedManager(data_dir)
+
+    interval_enum = FetchInterval(interval) if interval else None
+
+    try:
+        feed = manager.update_feed(
+            feed_id,
+            title=title,
+            category=category,
+            fetch_interval=interval_enum,
+            enabled=enabled,
+        )
+
+        if json_output:
+            _output_json(_feed_to_dict(feed))
+        else:
+            console.print("[green]Feed updated successfully[/green]")
+            console.print(f"  Feed ID: {feed.feed_id}")
+            console.print(f"  Title: {feed.title}")
+            console.print(f"  Category: {feed.category}")
+
+        logger.info("Feed updated successfully", feed_id=feed_id)
+
+    except FeedNotFoundError as e:
+        _handle_error(e, "Feed not found", json_output, feed_id=feed_id)
+
+    except RSSError as e:
+        _handle_error(e, "RSS error", json_output)
+
+
+@cli.command()
+@click.argument("feed_id")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def remove(
+    ctx: click.Context,
+    feed_id: str,
+    json_output: bool,
+) -> None:
+    """Remove a feed."""
+    logger.info("Removing feed", feed_id=feed_id)
+
+    data_dir = _get_data_dir(ctx)
+    manager = FeedManager(data_dir)
+
+    try:
+        manager.remove_feed(feed_id)
+
+        if json_output:
+            _output_json({"status": "removed", "feed_id": feed_id})
+        else:
+            console.print("[green]Feed removed successfully[/green]")
+            console.print(f"  Feed ID: {feed_id}")
+
+        logger.info("Feed removed successfully", feed_id=feed_id)
+
+    except FeedNotFoundError as e:
+        _handle_error(e, "Feed not found", json_output, feed_id=feed_id)
+
+    except RSSError as e:
+        _handle_error(e, "RSS error", json_output)
+
+
+@cli.command()
+@click.argument("feed_id", required=False)
+@click.option("--all", "fetch_all", is_flag=True, help="Fetch all feeds")
+@click.option("--category", default=None, help="Filter by category (with --all)")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def fetch(
+    ctx: click.Context,
+    feed_id: str | None,
+    fetch_all: bool,
+    category: str | None,
+    json_output: bool,
+) -> None:
+    """Fetch feed content."""
+    if not feed_id and not fetch_all:
+        if json_output:
+            _output_json({"error": "Specify feed_id or --all"})
+        else:
+            console.print("[red]Error: Specify feed_id or --all[/red]")
+        sys.exit(1)
+
+    data_dir = _get_data_dir(ctx)
+    fetcher = FeedFetcher(data_dir)
+
+    try:
+        if fetch_all:
+            logger.info("Fetching all feeds", category=category)
+            results = fetcher.fetch_all(category=category)
+
+            if json_output:
+                _output_json([_result_to_dict(r) for r in results])
+            else:
+                if not results:
+                    console.print("[yellow]No feeds to fetch[/yellow]")
+                    return
+
+                table = Table(title="Fetch Results")
+                table.add_column("Feed ID", style="cyan", max_width=8)
+                table.add_column("Status")
+                table.add_column("Items")
+                table.add_column("New")
+                table.add_column("Error")
+
+                for result in results:
+                    status_text = (
+                        "[green]OK[/green]" if result.success else "[red]FAIL[/red]"
+                    )
+                    error_text = _truncate(result.error_message, 30) or ""
+                    table.add_row(
+                        result.feed_id[:8],
+                        status_text,
+                        str(result.items_count),
+                        str(result.new_items),
+                        error_text,
+                    )
+
+                console.print(table)
+                success = sum(1 for r in results if r.success)
+                console.print(f"\nSuccess: {success}/{len(results)}")
+
+            logger.info("Fetch all completed", total=len(results))
+
+        else:
+            logger.info("Fetching feed", feed_id=feed_id)
+            result = asyncio.run(fetcher.fetch_feed(feed_id))  # type: ignore[arg-type]
+
+            if json_output:
+                _output_json(_result_to_dict(result))
+            elif result.success:
+                console.print("[green]Feed fetched successfully[/green]")
+                console.print(f"  Feed ID: {result.feed_id}")
+                console.print(f"  Total items: {result.items_count}")
+                console.print(f"  New items: {result.new_items}")
+            else:
+                console.print("[red]Feed fetch failed[/red]")
+                console.print(f"  Feed ID: {result.feed_id}")
+                console.print(f"  Error: {result.error_message}")
+                sys.exit(1)
+
+            logger.info("Fetch completed", feed_id=feed_id, success=result.success)
+
+    except FeedFetchError as e:
+        _handle_error(e, "Fetch error", json_output)
+
+    except FeedParseError as e:
+        _handle_error(e, "Parse error", json_output)
+
+    except RSSError as e:
+        _handle_error(e, "RSS error", json_output)
+
+
+@cli.command()
+@click.argument("feed_id", required=False)
+@click.option("--limit", type=int, default=10, help="Number of items to show")
+@click.option("--offset", type=int, default=0, help="Number of items to skip")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def items(
+    ctx: click.Context,
+    feed_id: str | None,
+    limit: int,
+    offset: int,
+    json_output: bool,
+) -> None:
+    """List feed items."""
+    logger.info("Listing items", feed_id=feed_id, limit=limit, offset=offset)
+
+    data_dir = _get_data_dir(ctx)
+    reader = FeedReader(data_dir)
+
+    item_list = reader.get_items(feed_id=feed_id, limit=limit, offset=offset)
+
+    if json_output:
+        _output_json([_item_to_dict(item) for item in item_list])
+    else:
+        if not item_list:
+            console.print("[yellow]No items found[/yellow]")
+            return
+
+        table = Table(title="Feed Items")
+        table.add_column("ID", style="cyan", max_width=8)
+        table.add_column("Title", style="green")
+        table.add_column("Published")
+        table.add_column("Author")
+
+        for item in item_list:
+            pub_date = _truncate(item.published, 16) if item.published else "-"
+            table.add_row(
+                item.item_id[:8],
+                _truncate(item.title, 40),
+                pub_date,
+                _truncate(item.author, 15) or "-",
+            )
+
+        console.print(table)
+        console.print(f"\nShowing {len(item_list)} items")
+
+    logger.info("Items listed", count=len(item_list))
+
+
+@cli.command()
+@click.option("--query", "-q", required=True, help="Search query")
+@click.option("--category", default=None, help="Filter by category")
+@click.option(
+    "--fields",
+    default="title,summary,content",
+    help="Fields to search (comma-separated)",
+)
+@click.option("--limit", type=int, default=50, help="Maximum results")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.pass_context
+def search(
+    ctx: click.Context,
+    query: str,
+    category: str | None,
+    fields: str,
+    limit: int,
+    json_output: bool,
+) -> None:
+    """Search feed items."""
+    logger.info("Searching items", query=query, category=category, fields=fields)
+
+    data_dir = _get_data_dir(ctx)
+    reader = FeedReader(data_dir)
+
+    field_list = [f.strip() for f in fields.split(",")]
+
+    item_list = reader.search_items(
+        query=query,
+        category=category,
+        fields=field_list,
+        limit=limit,
+    )
+
+    if json_output:
+        _output_json([_item_to_dict(item) for item in item_list])
+    else:
+        if not item_list:
+            console.print(f"[yellow]No items found for '{query}'[/yellow]")
+            return
+
+        table = Table(title=f"Search Results for '{query}'")
+        table.add_column("ID", style="cyan", max_width=8)
+        table.add_column("Title", style="green")
+        table.add_column("Published")
+        table.add_column("Link")
+
+        for item in item_list:
+            pub_date = _truncate(item.published, 16) if item.published else "-"
+            table.add_row(
+                item.item_id[:8],
+                _truncate(item.title, 35),
+                pub_date,
+                _truncate(item.link, 30),
+            )
+
+        console.print(table)
+        console.print(f"\nFound {len(item_list)} items")
+
+    logger.info("Search completed", query=query, count=len(item_list))
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/rss/unit/cli/__init__.py
+++ b/tests/rss/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for RSS CLI module."""

--- a/tests/rss/unit/cli/test_main.py
+++ b/tests/rss/unit/cli/test_main.py
@@ -1,0 +1,621 @@
+"""Unit tests for RSS CLI main module."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+
+from rss.cli.main import cli
+from rss.services.feed_manager import FeedManager
+from rss.storage.json_storage import JSONStorage
+from rss.types import FeedItem, FeedItemsData
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+def extract_json(output: str) -> Any:
+    """Extract JSON from CLI output, ignoring log lines.
+
+    Parameters
+    ----------
+    output : str
+        CLI output containing JSON and possibly log lines
+
+    Returns
+    -------
+    Any
+        Parsed JSON data
+
+    Raises
+    ------
+    ValueError
+        If no valid JSON found in output
+    """
+    # Filter out log lines first (lines starting with timestamp)
+    lines = output.strip().split("\n")
+    json_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        # Skip log lines (start with timestamp like 2026-01-14)
+        if re.match(r"^\d{4}-\d{2}-\d{2}", stripped):
+            continue
+        json_lines.append(line)
+
+    if json_lines:
+        json_str = "\n".join(json_lines)
+        try:
+            return json.loads(json_str)
+        except json.JSONDecodeError:
+            pass
+
+    # Fallback: try to find JSON starting with { or [
+    # This handles cases where log lines are interspersed
+    for start_idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith(("{", "[")):
+            # Found start of JSON, collect until we find valid JSON
+            for end_idx in range(len(lines), start_idx, -1):
+                candidate = "\n".join(lines[start_idx:end_idx])
+                try:
+                    return json.loads(candidate)
+                except json.JSONDecodeError:
+                    continue
+
+    raise ValueError(f"No valid JSON found in output: {output[:200]}...")
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a CLI runner for testing."""
+    return CliRunner()
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Iterator[Path]:
+    """Create a temporary data directory for testing."""
+    # Initialize storage structure by creating the directory
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    yield tmp_path
+
+
+@pytest.fixture
+def sample_feed(data_dir: Path) -> str:
+    """Create a sample feed for testing."""
+    manager = FeedManager(data_dir)
+    feed = manager.add_feed(
+        url="https://example.com/feed.xml",
+        title="Test Feed",
+        category="test",
+    )
+    return feed.feed_id
+
+
+@pytest.fixture
+def sample_items(data_dir: Path, sample_feed: str) -> list[FeedItem]:
+    """Create sample items for testing."""
+    storage = JSONStorage(data_dir)
+    items = [
+        FeedItem(
+            item_id="item-001",
+            title="Test Article 1",
+            link="https://example.com/article1",
+            published="2026-01-14T10:00:00Z",
+            summary="This is a test summary about finance.",
+            content="Full content here.",
+            author="Author One",
+            fetched_at="2026-01-14T12:00:00Z",
+        ),
+        FeedItem(
+            item_id="item-002",
+            title="Test Article 2",
+            link="https://example.com/article2",
+            published="2026-01-13T10:00:00Z",
+            summary="Another test article about economics.",
+            content="More content.",
+            author="Author Two",
+            fetched_at="2026-01-14T12:00:00Z",
+        ),
+    ]
+    items_data = FeedItemsData(version="1.0", feed_id=sample_feed, items=items)
+    storage.save_items(sample_feed, items_data)
+    return items
+
+
+class TestCli:
+    """Tests for CLI main group."""
+
+    def test_cli_help(self, cli_runner: CliRunner) -> None:
+        """Test CLI help message."""
+        result = cli_runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "RSS Feed Management CLI" in result.output
+        assert "add" in result.output
+        assert "list" in result.output
+
+    def test_cli_version_not_exist(self, cli_runner: CliRunner) -> None:
+        """Test that --version is not implemented (expected behavior)."""
+        result = cli_runner.invoke(cli, ["--version"])
+        # --version is not implemented, should show error
+        assert result.exit_code != 0
+
+
+class TestAddCommand:
+    """Tests for add command."""
+
+    def test_add_feed_success(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test successful feed addition."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "add",
+                "--url",
+                "https://example.com/new-feed.xml",
+                "--title",
+                "New Feed",
+                "--category",
+                "finance",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Feed registered successfully" in result.output
+
+    def test_add_feed_json_output(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test add command with JSON output."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "add",
+                "--url",
+                "https://example.com/json-feed.xml",
+                "--title",
+                "JSON Feed",
+                "--category",
+                "test",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        data = extract_json(result.output)
+        assert "feed_id" in data
+        assert data["title"] == "JSON Feed"
+
+    def test_add_feed_duplicate_error(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test error when adding duplicate feed URL."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "add",
+                "--url",
+                "https://example.com/feed.xml",  # Same as sample_feed
+                "--title",
+                "Duplicate Feed",
+                "--category",
+                "test",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "already exists" in result.output
+
+    def test_add_feed_invalid_url(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test error with invalid URL."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "add",
+                "--url",
+                "not-a-valid-url",
+                "--title",
+                "Invalid Feed",
+                "--category",
+                "test",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+class TestListCommand:
+    """Tests for list command."""
+
+    def test_list_feeds_empty(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test listing feeds when none exist."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "list"],
+        )
+        assert result.exit_code == 0
+        assert "No feeds found" in result.output
+
+    def test_list_feeds_with_data(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test listing feeds with existing data."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "list"],
+        )
+        assert result.exit_code == 0
+        assert "Test Feed" in result.output
+        assert "Total: 1 feeds" in result.output
+
+    def test_list_feeds_json_output(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test list command with JSON output."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "list", "--json"],
+        )
+        assert result.exit_code == 0
+        data = extract_json(result.output)
+        assert len(data) == 1
+        assert data[0]["title"] == "Test Feed"
+
+    def test_list_feeds_filter_category(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test listing feeds filtered by category."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "list", "--category", "nonexistent"],
+        )
+        assert result.exit_code == 0
+        assert "No feeds found" in result.output
+
+
+class TestUpdateCommand:
+    """Tests for update command."""
+
+    def test_update_feed_title(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test updating feed title."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "update",
+                sample_feed,
+                "--title",
+                "Updated Title",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Feed updated successfully" in result.output
+        assert "Updated Title" in result.output
+
+    def test_update_feed_not_found(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test error when updating non-existent feed."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "update",
+                "nonexistent-id",
+                "--title",
+                "New Title",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_update_feed_json_output(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test update command with JSON output."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "update",
+                sample_feed,
+                "--category",
+                "updated",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        data = extract_json(result.output)
+        assert data["category"] == "updated"
+
+
+class TestRemoveCommand:
+    """Tests for remove command."""
+
+    def test_remove_feed_success(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test successful feed removal."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "remove", sample_feed],
+        )
+        assert result.exit_code == 0
+        assert "Feed removed successfully" in result.output
+
+    def test_remove_feed_not_found(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test error when removing non-existent feed."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "remove", "nonexistent-id"],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_remove_feed_json_output(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test remove command with JSON output."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "remove", sample_feed, "--json"],
+        )
+        assert result.exit_code == 0
+        data = extract_json(result.output)
+        assert data["status"] == "removed"
+
+
+class TestFetchCommand:
+    """Tests for fetch command."""
+
+    def test_fetch_requires_arg_or_all(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test that fetch requires feed_id or --all."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "fetch"],
+        )
+        assert result.exit_code == 1
+        assert "Specify feed_id or --all" in result.output
+
+    def test_fetch_all_empty(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test fetch all when no feeds exist."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "fetch", "--all"],
+        )
+        assert result.exit_code == 0
+        assert "No feeds to fetch" in result.output
+
+
+class TestItemsCommand:
+    """Tests for items command."""
+
+    def test_items_empty(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+    ) -> None:
+        """Test listing items when none exist."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "items", sample_feed],
+        )
+        assert result.exit_code == 0
+        assert "No items found" in result.output
+
+    def test_items_with_data(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+        sample_items: list[FeedItem],
+    ) -> None:
+        """Test listing items with existing data."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "items", sample_feed],
+        )
+        assert result.exit_code == 0
+        assert "Test Article 1" in result.output
+        assert "Showing 2 items" in result.output
+
+    def test_items_json_output(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+        sample_items: list[FeedItem],
+    ) -> None:
+        """Test items command with JSON output."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "items", sample_feed, "--json"],
+        )
+        assert result.exit_code == 0
+        data = extract_json(result.output)
+        assert len(data) == 2
+        assert data[0]["title"] == "Test Article 1"
+
+    def test_items_with_limit(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+        sample_items: list[FeedItem],
+    ) -> None:
+        """Test items command with limit."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "items", sample_feed, "--limit", "1"],
+        )
+        assert result.exit_code == 0
+        assert "Showing 1 items" in result.output
+
+
+class TestSearchCommand:
+    """Tests for search command."""
+
+    def test_search_no_results(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+        sample_items: list[FeedItem],
+    ) -> None:
+        """Test search with no matching results."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "search", "-q", "nonexistent"],
+        )
+        assert result.exit_code == 0
+        assert "No items found" in result.output
+
+    def test_search_with_results(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+        sample_items: list[FeedItem],
+    ) -> None:
+        """Test search with matching results."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "search", "-q", "finance"],
+        )
+        assert result.exit_code == 0
+        assert "Test Article 1" in result.output
+        assert "Found 1 items" in result.output
+
+    def test_search_json_output(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+        sample_items: list[FeedItem],
+    ) -> None:
+        """Test search command with JSON output."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "search", "-q", "test", "--json"],
+        )
+        assert result.exit_code == 0
+        data = extract_json(result.output)
+        assert len(data) == 2
+
+    def test_search_filter_category(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+        sample_feed: str,
+        sample_items: list[FeedItem],
+    ) -> None:
+        """Test search with category filter."""
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--data-dir",
+                str(data_dir),
+                "search",
+                "-q",
+                "test",
+                "--category",
+                "nonexistent",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "No items found" in result.output
+
+
+class TestExitCodes:
+    """Tests for exit codes."""
+
+    def test_success_exit_code(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test that successful commands return exit code 0."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "list"],
+        )
+        assert result.exit_code == 0
+
+    def test_error_exit_code(
+        self,
+        cli_runner: CliRunner,
+        data_dir: Path,
+    ) -> None:
+        """Test that error commands return exit code 1."""
+        result = cli_runner.invoke(
+            cli,
+            ["--data-dir", str(data_dir), "remove", "nonexistent"],
+        )
+        assert result.exit_code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -638,6 +638,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cli = [
+    { name = "click" },
+]
 dev = [
     { name = "bandit" },
     { name = "hypothesis" },
@@ -680,6 +683,7 @@ dev = [
 requires-dist = [
     { name = "apscheduler", marker = "extra == 'scheduler'", specifier = ">=3.10.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
+    { name = "click", marker = "extra == 'cli'", specifier = ">=8.1.0" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "feedparser", specifier = ">=6.0.12" },
     { name = "filelock", specifier = ">=3.20.3" },
@@ -713,7 +717,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "yfinance", specifier = ">=0.2.0" },
 ]
-provides-extras = ["dev", "docs", "scheduler", "mcp"]
+provides-extras = ["dev", "docs", "scheduler", "mcp", "cli"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## 概要
RSSフィード管理用のコマンドラインインターフェース（rss-cli）を実装しました。

## 実装内容
- clickライブラリをオプショナル依存として追加
- `rss-cli` エントリーポイントを設定
- 7つのサブコマンドを実装:
  - `add`: フィード登録
  - `list`: フィード一覧表示
  - `update`: フィード情報更新
  - `remove`: フィード削除
  - `fetch`: フィード取得実行
  - `items`: アイテム一覧表示
  - `search`: アイテム検索

## 機能
- `--help` オプションで使用方法を表示
- `--json` オプションでJSON形式出力
- テーブル形式の見やすい出力（rich使用）
- 構造化ロギング（INFO: コマンド実行、ERROR: エラー）
- 終了コード（0=成功、1=エラー）

## 使用例
```bash
# フィード登録
rss-cli add --url https://example.com/feed.xml --title "Example" --category finance

# フィード一覧
rss-cli list
rss-cli list --json

# フィード取得
rss-cli fetch --all

# アイテム検索
rss-cli search -q "金利" --category finance
```

## テストプラン
- [x] make check-all が成功することを確認
- [x] 28テストが追加され、すべてパス
- [x] カバレッジ: CLI 70%、RSS全体 80%

Closes #66

🤖 Generated with [Claude Code](https://claude.ai/code)