### PR TITLE
feat: Chart API の実装 (#29)

### DIFF
--- a/src/market_analysis/__init__.py
+++ b/src/market_analysis/__init__.py
@@ -8,16 +8,22 @@ MarketData
     市場データ取得の統合インターフェース
 Analysis
     テクニカル分析（メソッドチェーン対応）
+Chart
+    チャート生成（価格チャート、ヒートマップ）
 __version__
     パッケージバージョン
 
 Examples
 --------
->>> from market_analysis import MarketData, Analysis
+>>> from market_analysis import MarketData, Analysis, Chart
 >>> data = MarketData()
 >>> stock_df = data.fetch_stock("AAPL", start="2024-01-01")
 >>> analysis = Analysis(stock_df)
 >>> result = analysis.add_sma(20).add_returns().result()
+>>>
+>>> chart = Chart(stock_df, title="AAPL Price Chart")
+>>> chart.price_chart(overlays=["SMA_20", "EMA_50"])
+>>> chart.save("chart.png")
 """
 
 # =============================================================================
@@ -25,7 +31,7 @@ Examples
 # Analysis Classes - 内部分析クラス（上級ユーザー向け）
 # =============================================================================
 from .analysis import Analyzer, CorrelationAnalyzer, IndicatorCalculator
-from .api import Analysis, MarketData
+from .api import Analysis, Chart, MarketData
 
 # =============================================================================
 # Errors - 例外クラス
@@ -93,6 +99,7 @@ __all__ = [
     "AssetType",
     "CacheConfig",
     "CacheError",
+    "Chart",
     "ChartOptions",
     "CorrelationAnalyzer",
     "CorrelationResult",

--- a/src/market_analysis/api/__init__.py
+++ b/src/market_analysis/api/__init__.py
@@ -1,9 +1,11 @@
 """Public API interfaces for market_analysis package."""
 
 from .analysis import Analysis
+from .chart import Chart
 from .market_data import MarketData
 
 __all__ = [
     "Analysis",
+    "Chart",
     "MarketData",
 ]

--- a/src/market_analysis/api/chart.py
+++ b/src/market_analysis/api/chart.py
@@ -1,0 +1,446 @@
+"""Chart API for market data visualization.
+
+This module provides a simplified interface for creating financial charts,
+wrapping the lower-level visualization components.
+
+Examples
+--------
+>>> from market_analysis import Chart
+>>> chart = Chart(stock_df, title="AAPL Price Chart")
+>>> fig = chart.price_chart(overlays=["SMA_20", "EMA_50"])
+>>> chart.save("chart.png")
+
+>>> corr_matrix = Analysis.correlation([stock1_df, stock2_df])
+>>> fig = Chart.correlation_heatmap(corr_matrix, title="Correlation Matrix")
+"""
+
+from logging import Logger
+from pathlib import Path
+from typing import Literal
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from ..utils.logger_factory import create_logger
+from ..visualization.charts import ChartConfig, ChartTheme
+from ..visualization.heatmap import HeatmapChart
+from ..visualization.price_charts import LineChart, PriceChartData
+
+logger: Logger = create_logger(__name__, module="api")
+
+
+class Chart:
+    """Chart generation class for market data visualization.
+
+    This class provides a simplified interface for creating financial charts
+    including price charts with indicator overlays and correlation heatmaps.
+    Uses plotly for interactive charts with marimo notebook support.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Market data DataFrame with OHLCV columns (Open, High, Low, Close, Volume).
+        Index should be DatetimeIndex.
+    title : str | None, default=None
+        Chart title to display
+
+    Attributes
+    ----------
+    data : pd.DataFrame
+        The market data used for charting
+    title : str | None
+        The chart title
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from market_analysis import Chart
+    >>>
+    >>> # Create price chart
+    >>> chart = Chart(stock_df, title="AAPL Price Chart")
+    >>> fig = chart.price_chart(overlays=["SMA_20", "EMA_50"])
+    >>> chart.save("chart.png")
+    >>>
+    >>> # Create correlation heatmap (static method)
+    >>> corr_matrix = stock_df[["AAPL", "GOOGL", "MSFT"]].corr()
+    >>> fig = Chart.correlation_heatmap(corr_matrix)
+    """
+
+    def __init__(
+        self,
+        data: pd.DataFrame,
+        title: str | None = None,
+    ) -> None:
+        """Initialize Chart with data and optional title.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            Market data DataFrame with OHLCV columns.
+            Required columns: Open, High, Low, Close
+            Optional columns: Volume
+            Index should be DatetimeIndex.
+        title : str | None, default=None
+            Chart title to display
+
+        Raises
+        ------
+        ValueError
+            If required columns (Open, High, Low, Close) are missing
+        """
+        self._data = data
+        self._title = title
+        self._figure: go.Figure | None = None
+
+        # Validate required columns for price charts
+        required_cols = {"Open", "High", "Low", "Close"}
+        missing = required_cols - set(data.columns)
+        if missing:
+            logger.warning(
+                "Missing OHLC columns for full price chart support",
+                missing_columns=list(missing),
+            )
+
+        logger.debug(
+            "Chart initialized",
+            title=title,
+            data_points=len(data),
+            columns=list(data.columns),
+        )
+
+    @property
+    def data(self) -> pd.DataFrame:
+        """Get the chart data.
+
+        Returns
+        -------
+        pd.DataFrame
+            The market data DataFrame
+        """
+        return self._data
+
+    @property
+    def title(self) -> str | None:
+        """Get the chart title.
+
+        Returns
+        -------
+        str | None
+            The chart title
+        """
+        return self._title
+
+    def price_chart(
+        self,
+        column: str = "Close",
+        overlays: list[str] | None = None,
+        width: int = 1200,
+        height: int = 600,
+    ) -> go.Figure:
+        """Generate a price chart with optional indicator overlays.
+
+        Creates a line chart of the specified price column with optional
+        technical indicator overlays (e.g., moving averages).
+
+        Parameters
+        ----------
+        column : str, default="Close"
+            Column to use for the price line
+        overlays : list[str] | None, default=None
+            List of indicator columns to overlay on the chart.
+            Supports patterns like "SMA_20", "EMA_50" which will be
+            calculated if not present in the data.
+        width : int, default=1200
+            Chart width in pixels
+        height : int, default=600
+            Chart height in pixels
+
+        Returns
+        -------
+        go.Figure
+            Plotly Figure object for interactive display
+
+        Raises
+        ------
+        ValueError
+            If the specified column does not exist in the data
+
+        Examples
+        --------
+        >>> chart = Chart(stock_df, title="AAPL")
+        >>> fig = chart.price_chart()  # Simple close price chart
+        >>> fig = chart.price_chart(overlays=["SMA_20", "EMA_50"])  # With overlays
+        >>> chart.save("chart.png")
+        """
+        if column not in self._data.columns:
+            raise ValueError(
+                f"Column '{column}' not found in data. "
+                f"Available columns: {list(self._data.columns)}"
+            )
+
+        logger.info(
+            "Creating price chart",
+            column=column,
+            overlays=overlays,
+            width=width,
+            height=height,
+        )
+
+        # Create config
+        config = ChartConfig(
+            width=width,
+            height=height,
+            title=self._title,
+            theme=ChartTheme.LIGHT,
+        )
+
+        # Create price chart data
+        price_data = PriceChartData(
+            df=self._data,
+            symbol=self._title or "",
+        )
+
+        # Build chart
+        chart_builder = LineChart(
+            data=price_data,
+            config=config,
+            show_volume="Volume" in self._data.columns,
+            price_column=column,
+        )
+
+        # Add overlay indicators
+        if overlays:
+            for overlay in overlays:
+                self._add_overlay(chart_builder, overlay)
+
+        chart_builder.build()
+        self._figure = chart_builder.figure
+
+        logger.info(
+            "Price chart created",
+            title=self._title,
+            data_points=len(self._data),
+        )
+
+        return self._figure  # type: ignore[return-value]
+
+    def _add_overlay(self, chart_builder: LineChart, overlay: str) -> None:
+        """Add an indicator overlay to the chart builder.
+
+        Parameters
+        ----------
+        chart_builder : LineChart
+            The chart builder to add the overlay to
+        overlay : str
+            Overlay specification (e.g., "SMA_20", "EMA_50")
+        """
+        parts = overlay.upper().split("_")
+        if len(parts) != 2:
+            logger.warning(
+                "Invalid overlay format, expected 'INDICATOR_PERIOD'",
+                overlay=overlay,
+            )
+            return
+
+        indicator_type = parts[0]
+        try:
+            period = int(parts[1])
+        except ValueError:
+            logger.warning(
+                "Invalid period in overlay specification",
+                overlay=overlay,
+            )
+            return
+
+        if indicator_type == "SMA":
+            chart_builder.add_sma(window=period, name=overlay)
+        elif indicator_type == "EMA":
+            chart_builder.add_ema(window=period, name=overlay)
+        elif indicator_type == "BB":
+            chart_builder.add_bollinger_bands(window=period, name=overlay)
+        else:
+            logger.warning(
+                "Unsupported indicator type",
+                indicator_type=indicator_type,
+                overlay=overlay,
+            )
+
+    @staticmethod
+    def correlation_heatmap(
+        correlation_matrix: pd.DataFrame,
+        title: str = "Correlation Matrix",
+        width: int = 800,
+        height: int = 800,
+    ) -> go.Figure:
+        """Generate a correlation heatmap.
+
+        Creates a heatmap visualization of a correlation matrix with
+        values annotated in each cell.
+
+        Parameters
+        ----------
+        correlation_matrix : pd.DataFrame
+            Correlation matrix (typically from pd.DataFrame.corr())
+        title : str, default="Correlation Matrix"
+            Chart title
+        width : int, default=800
+            Chart width in pixels
+        height : int, default=800
+            Chart height in pixels
+
+        Returns
+        -------
+        go.Figure
+            Plotly Figure object for interactive display
+
+        Raises
+        ------
+        ValueError
+            If the correlation matrix is empty
+
+        Examples
+        --------
+        >>> corr_matrix = prices_df.corr()
+        >>> fig = Chart.correlation_heatmap(corr_matrix, title="Asset Correlations")
+        >>> fig.write_html("heatmap.html")
+        """
+        if correlation_matrix.empty:
+            raise ValueError("Correlation matrix is empty")
+
+        logger.info(
+            "Creating correlation heatmap",
+            title=title,
+            symbols=list(correlation_matrix.columns),
+            width=width,
+            height=height,
+        )
+
+        # Create config
+        config = ChartConfig(
+            width=width,
+            height=height,
+            title=title,
+            theme=ChartTheme.LIGHT,
+        )
+
+        # Build heatmap
+        heatmap_builder = HeatmapChart(
+            correlation_matrix=correlation_matrix,
+            config=config,
+            show_values=True,
+        )
+        heatmap_builder.build()
+
+        logger.info(
+            "Correlation heatmap created",
+            title=title,
+            symbols_count=len(correlation_matrix.columns),
+        )
+
+        return heatmap_builder.figure  # type: ignore[return-value]
+
+    def save(
+        self,
+        path: str | Path,
+        format: Literal["png", "svg", "html"] | None = None,
+        scale: int = 2,
+    ) -> None:
+        """Save the chart to a file.
+
+        Parameters
+        ----------
+        path : str | Path
+            Output file path
+        format : {"png", "svg", "html"} | None, default=None
+            Export format. If None, inferred from file extension.
+        scale : int, default=2
+            Resolution scale for PNG format (higher = better quality)
+
+        Raises
+        ------
+        RuntimeError
+            If no chart has been generated yet (call price_chart first)
+        ValueError
+            If the format is not supported
+
+        Examples
+        --------
+        >>> chart = Chart(stock_df, title="AAPL")
+        >>> chart.price_chart()
+        >>> chart.save("chart.png")  # PNG format
+        >>> chart.save("chart.svg", format="svg")  # SVG format
+        >>> chart.save("chart.html")  # Interactive HTML
+        """
+        if self._figure is None:
+            raise RuntimeError(
+                "No chart to save. Call price_chart() first to generate a chart."
+            )
+
+        path = Path(path)
+
+        # Infer format from extension if not specified
+        if format is None:
+            ext = path.suffix.lower().lstrip(".")
+            if ext not in ("png", "svg", "html"):
+                raise ValueError(
+                    f"Cannot infer format from extension '{ext}'. "
+                    f"Supported formats: png, svg, html"
+                )
+            # ext is guaranteed to be one of the valid formats at this point
+            format = ext if ext in ("png", "svg", "html") else "png"
+
+        # Ensure parent directory exists
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        logger.info(
+            "Saving chart",
+            path=str(path),
+            format=format,
+            scale=scale if format == "png" else None,
+        )
+
+        if format == "html":
+            self._figure.write_html(str(path), include_plotlyjs=True)
+        elif format == "png":
+            import plotly.io as pio
+
+            pio.write_image(self._figure, str(path), format="png", scale=scale)
+        elif format == "svg":
+            import plotly.io as pio
+
+            pio.write_image(self._figure, str(path), format="svg")
+        else:
+            raise ValueError(f"Unsupported format: {format}")
+
+        logger.info("Chart saved successfully", path=str(path))
+
+    def show(self) -> None:
+        """Display the chart in an interactive viewer.
+
+        Shows the chart in a browser window or Jupyter/marimo notebook.
+        This method is designed to work seamlessly with marimo notebooks
+        for interactive data exploration.
+
+        Raises
+        ------
+        RuntimeError
+            If no chart has been generated yet (call price_chart first)
+
+        Examples
+        --------
+        >>> chart = Chart(stock_df, title="AAPL")
+        >>> chart.price_chart(overlays=["SMA_20"])
+        >>> chart.show()  # Opens in browser or notebook
+        """
+        if self._figure is None:
+            raise RuntimeError(
+                "No chart to show. Call price_chart() first to generate a chart."
+            )
+
+        logger.info("Displaying chart")
+        self._figure.show()
+
+
+__all__ = [
+    "Chart",
+]

--- a/tests/market_analysis/unit/api/test_chart.py
+++ b/tests/market_analysis/unit/api/test_chart.py
@@ -1,0 +1,395 @@
+"""Unit tests for Chart API module."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+
+from market_analysis.api.chart import Chart
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_ohlcv_df() -> pd.DataFrame:
+    """Create sample OHLCV DataFrame for testing."""
+    dates = pd.date_range(start="2024-01-01", periods=50, freq="D")
+    np.random.seed(42)
+    base_price = 100
+    prices = base_price + np.cumsum(np.random.randn(50))
+
+    return pd.DataFrame(
+        {
+            "Open": prices + np.random.rand(50),
+            "High": prices + np.random.rand(50) + 1,
+            "Low": prices - np.random.rand(50) - 1,
+            "Close": prices,
+            "Volume": np.random.randint(1000, 10000, 50),
+        },
+        index=dates,
+    )
+
+
+@pytest.fixture
+def sample_close_only_df() -> pd.DataFrame:
+    """Create sample DataFrame with only Close column."""
+    dates = pd.date_range(start="2024-01-01", periods=30, freq="D")
+    np.random.seed(42)
+    return pd.DataFrame(
+        {"Close": np.random.rand(30) * 100 + 100},
+        index=dates,
+    )
+
+
+@pytest.fixture
+def sample_correlation_matrix() -> pd.DataFrame:
+    """Create sample correlation matrix for testing."""
+    np.random.seed(42)
+    symbols = pd.Index(["AAPL", "GOOGL", "MSFT"])
+    data = np.random.rand(3, 3)
+    # Make it symmetric
+    data = (data + data.T) / 2
+    # Set diagonal to 1
+    np.fill_diagonal(data, 1)
+    return pd.DataFrame(data, index=symbols, columns=symbols)
+
+
+@pytest.fixture
+def chart(sample_ohlcv_df: pd.DataFrame) -> Chart:
+    """Create a Chart instance with sample data."""
+    return Chart(sample_ohlcv_df, title="Test Chart")
+
+
+@pytest.fixture
+def chart_with_figure(sample_ohlcv_df: pd.DataFrame) -> Chart:
+    """Create a Chart instance with a generated figure."""
+    chart = Chart(sample_ohlcv_df, title="Test Chart")
+    chart.price_chart()
+    return chart
+
+
+# =============================================================================
+# Chart Initialization Tests
+# =============================================================================
+
+
+class TestChartInit:
+    """Tests for Chart.__init__ method."""
+
+    def test_正常系_デフォルト初期化(self, sample_ohlcv_df: pd.DataFrame) -> None:
+        """Chartがデフォルト値で初期化されることを確認。"""
+        chart = Chart(sample_ohlcv_df)
+        assert chart.title is None
+        assert chart.data is sample_ohlcv_df
+
+    def test_正常系_タイトル付きで初期化(self, sample_ohlcv_df: pd.DataFrame) -> None:
+        """タイトル付きでChartを初期化できることを確認。"""
+        chart = Chart(sample_ohlcv_df, title="AAPL Price Chart")
+        assert chart.title == "AAPL Price Chart"
+
+    def test_正常系_OHLCカラムなしでも警告のみ(
+        self, sample_close_only_df: pd.DataFrame
+    ) -> None:
+        """OHLCカラムがなくても初期化でき、警告のみ出ることを確認。"""
+        # Should not raise, just log warning
+        chart = Chart(sample_close_only_df, title="Test")
+        assert chart.data is sample_close_only_df
+
+
+class TestChartProperties:
+    """Tests for Chart properties."""
+
+    def test_正常系_dataプロパティ(
+        self, chart: Chart, sample_ohlcv_df: pd.DataFrame
+    ) -> None:
+        """dataプロパティがデータを返すことを確認。"""
+        assert chart.data is sample_ohlcv_df
+
+    def test_正常系_titleプロパティ(self, chart: Chart) -> None:
+        """titleプロパティがタイトルを返すことを確認。"""
+        assert chart.title == "Test Chart"
+
+
+# =============================================================================
+# Price Chart Tests
+# =============================================================================
+
+
+class TestPriceChart:
+    """Tests for Chart.price_chart method."""
+
+    def test_正常系_基本的なプライスチャート作成(self, chart: Chart) -> None:
+        """基本的なプライスチャートを作成できることを確認。"""
+        fig = chart.price_chart()
+        assert isinstance(fig, go.Figure)
+
+    def test_正常系_カスタムカラム指定(self, chart: Chart) -> None:
+        """カスタムカラムでプライスチャートを作成できることを確認。"""
+        fig = chart.price_chart(column="Open")
+        assert isinstance(fig, go.Figure)
+
+    def test_正常系_サイズ指定(self, chart: Chart) -> None:
+        """カスタムサイズでプライスチャートを作成できることを確認。"""
+        fig = chart.price_chart(width=800, height=400)
+        assert isinstance(fig, go.Figure)
+        assert fig.layout.width == 800
+        assert fig.layout.height == 400
+
+    def test_正常系_SMAオーバーレイ付き(self, chart: Chart) -> None:
+        """SMAオーバーレイ付きでプライスチャートを作成できることを確認。"""
+        fig = chart.price_chart(overlays=["SMA_20"])
+        assert isinstance(fig, go.Figure)
+        # Should have price trace + SMA trace (+ optional volume)
+        trace_count = len(list(fig.data))
+        assert trace_count >= 2
+
+    def test_正常系_複数オーバーレイ付き(self, chart: Chart) -> None:
+        """複数のオーバーレイ付きでプライスチャートを作成できることを確認。"""
+        fig = chart.price_chart(overlays=["SMA_20", "EMA_50"])
+        assert isinstance(fig, go.Figure)
+        # Should have price trace + 2 indicator traces (+ optional volume)
+        trace_count = len(list(fig.data))
+        assert trace_count >= 3
+
+    def test_正常系_ボリンジャーバンドオーバーレイ(self, chart: Chart) -> None:
+        """ボリンジャーバンドオーバーレイ付きでプライスチャートを作成できることを確認。"""
+        fig = chart.price_chart(overlays=["BB_20"])
+        assert isinstance(fig, go.Figure)
+        # BB adds 3 traces (upper, middle, lower)
+        trace_count = len(list(fig.data))
+        assert trace_count >= 4
+
+    def test_異常系_存在しないカラム指定(self, chart: Chart) -> None:
+        """存在しないカラムを指定するとValueErrorが発生することを確認。"""
+        with pytest.raises(ValueError, match="Column 'NonExistent' not found"):
+            chart.price_chart(column="NonExistent")
+
+    def test_正常系_無効なオーバーレイは無視される(self, chart: Chart) -> None:
+        """無効なオーバーレイフォーマットは無視されることを確認。"""
+        # Should not raise, just log warning
+        fig = chart.price_chart(overlays=["INVALID_OVERLAY", "SMA"])
+        assert isinstance(fig, go.Figure)
+
+    def test_正常系_未対応の指標タイプは無視される(self, chart: Chart) -> None:
+        """未対応の指標タイプは無視されることを確認。"""
+        # Should not raise, just log warning
+        fig = chart.price_chart(overlays=["RSI_14"])
+        assert isinstance(fig, go.Figure)
+
+
+# =============================================================================
+# Correlation Heatmap Tests
+# =============================================================================
+
+
+class TestCorrelationHeatmap:
+    """Tests for Chart.correlation_heatmap static method."""
+
+    def test_正常系_基本的なヒートマップ作成(
+        self, sample_correlation_matrix: pd.DataFrame
+    ) -> None:
+        """基本的な相関ヒートマップを作成できることを確認。"""
+        fig = Chart.correlation_heatmap(sample_correlation_matrix)
+        assert isinstance(fig, go.Figure)
+
+    def test_正常系_カスタムタイトル(
+        self, sample_correlation_matrix: pd.DataFrame
+    ) -> None:
+        """カスタムタイトルでヒートマップを作成できることを確認。"""
+        fig = Chart.correlation_heatmap(
+            sample_correlation_matrix, title="Asset Correlations"
+        )
+        assert isinstance(fig, go.Figure)
+        assert fig.layout.title.text == "Asset Correlations"
+
+    def test_正常系_カスタムサイズ(
+        self, sample_correlation_matrix: pd.DataFrame
+    ) -> None:
+        """カスタムサイズでヒートマップを作成できることを確認。"""
+        fig = Chart.correlation_heatmap(
+            sample_correlation_matrix, width=600, height=600
+        )
+        assert isinstance(fig, go.Figure)
+        assert fig.layout.width == 600
+        assert fig.layout.height == 600
+
+    def test_異常系_空の相関行列でValueError(self) -> None:
+        """空の相関行列でValueErrorが発生することを確認。"""
+        empty_matrix = pd.DataFrame()
+        with pytest.raises(ValueError, match="Correlation matrix is empty"):
+            Chart.correlation_heatmap(empty_matrix)
+
+    def test_正常系_静的メソッドとして呼び出し(
+        self, sample_correlation_matrix: pd.DataFrame
+    ) -> None:
+        """静的メソッドとして呼び出せることを確認。"""
+        # Can be called without Chart instance
+        fig = Chart.correlation_heatmap(sample_correlation_matrix)
+        assert isinstance(fig, go.Figure)
+
+
+# =============================================================================
+# Save Tests
+# =============================================================================
+
+
+class TestSave:
+    """Tests for Chart.save method."""
+
+    def test_正常系_PNG保存(self, chart_with_figure: Chart, tmp_path: Path) -> None:
+        """PNG形式で保存できることを確認。"""
+        output_path = tmp_path / "test_chart.png"
+
+        with patch("plotly.io.write_image") as mock_write:
+            chart_with_figure.save(output_path)
+            mock_write.assert_called_once()
+            call_args = mock_write.call_args
+            assert call_args.kwargs["format"] == "png"
+
+    def test_正常系_SVG保存(self, chart_with_figure: Chart, tmp_path: Path) -> None:
+        """SVG形式で保存できることを確認。"""
+        output_path = tmp_path / "test_chart.svg"
+
+        with patch("plotly.io.write_image") as mock_write:
+            chart_with_figure.save(output_path)
+            mock_write.assert_called_once()
+            call_args = mock_write.call_args
+            assert call_args.kwargs["format"] == "svg"
+
+    def test_正常系_HTML保存(self, chart_with_figure: Chart, tmp_path: Path) -> None:
+        """HTML形式で保存できることを確認。"""
+        output_path = tmp_path / "test_chart.html"
+
+        # _figureにwrite_htmlメソッドをモック
+        chart_with_figure._figure = MagicMock()
+        chart_with_figure.save(output_path)
+        chart_with_figure._figure.write_html.assert_called_once()
+
+    def test_正常系_フォーマット明示指定(
+        self, chart_with_figure: Chart, tmp_path: Path
+    ) -> None:
+        """フォーマットを明示的に指定できることを確認。"""
+        output_path = tmp_path / "test_chart.xyz"
+
+        with patch("plotly.io.write_image") as mock_write:
+            chart_with_figure.save(output_path, format="png")
+            mock_write.assert_called_once()
+
+    def test_正常系_スケール指定(
+        self, chart_with_figure: Chart, tmp_path: Path
+    ) -> None:
+        """スケールを指定できることを確認。"""
+        output_path = tmp_path / "test_chart.png"
+
+        with patch("plotly.io.write_image") as mock_write:
+            chart_with_figure.save(output_path, scale=3)
+            mock_write.assert_called_once()
+            call_args = mock_write.call_args
+            assert call_args.kwargs["scale"] == 3
+
+    def test_異常系_チャート未生成でRuntimeError(
+        self, chart: Chart, tmp_path: Path
+    ) -> None:
+        """チャート未生成でsave()を呼ぶとRuntimeErrorが発生することを確認。"""
+        with pytest.raises(RuntimeError, match="No chart to save"):
+            chart.save(tmp_path / "test.png")
+
+    def test_異常系_未知の拡張子でValueError(
+        self, chart_with_figure: Chart, tmp_path: Path
+    ) -> None:
+        """未知の拡張子でValueErrorが発生することを確認。"""
+        with pytest.raises(ValueError, match="Cannot infer format"):
+            chart_with_figure.save(tmp_path / "test.unknown")
+
+    def test_異常系_未対応フォーマットでValueError(
+        self, chart_with_figure: Chart, tmp_path: Path
+    ) -> None:
+        """未対応フォーマット指定でValueErrorが発生することを確認。"""
+        with pytest.raises(ValueError, match="Unsupported format"):
+            chart_with_figure.save(tmp_path / "test.xyz", format="xyz")  # type: ignore[arg-type]
+
+    def test_正常系_親ディレクトリ自動作成(
+        self, chart_with_figure: Chart, tmp_path: Path
+    ) -> None:
+        """親ディレクトリが自動作成されることを確認。"""
+        output_path = tmp_path / "nested" / "dir" / "test_chart.html"
+
+        chart_with_figure._figure = MagicMock()
+        chart_with_figure.save(output_path)
+
+        assert output_path.parent.exists()
+
+
+# =============================================================================
+# Show Tests
+# =============================================================================
+
+
+class TestShow:
+    """Tests for Chart.show method."""
+
+    def test_正常系_showが呼び出せる(self, chart_with_figure: Chart) -> None:
+        """show()が呼び出せることを確認。"""
+        chart_with_figure._figure = MagicMock()
+        chart_with_figure.show()
+        chart_with_figure._figure.show.assert_called_once()
+
+    def test_異常系_チャート未生成でRuntimeError(self, chart: Chart) -> None:
+        """チャート未生成でshow()を呼ぶとRuntimeErrorが発生することを確認。"""
+        with pytest.raises(RuntimeError, match="No chart to show"):
+            chart.show()
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestChartIntegration:
+    """Integration tests for Chart class."""
+
+    def test_正常系_チャート作成からファイル保存までのフロー(
+        self, sample_ohlcv_df: pd.DataFrame, tmp_path: Path
+    ) -> None:
+        """チャート作成からファイル保存までの一連のフローを確認。"""
+        chart = Chart(sample_ohlcv_df, title="AAPL")
+        fig = chart.price_chart(overlays=["SMA_20", "EMA_50"])
+
+        assert isinstance(fig, go.Figure)
+
+        output_path = tmp_path / "output.html"
+        chart.save(output_path)
+        # Note: HTML write is mocked in individual tests,
+        # but here we verify the method doesn't crash
+        # (actual file write depends on plotly availability)
+
+    def test_正常系_相関ヒートマップのスタンドアロン使用(
+        self, sample_correlation_matrix: pd.DataFrame
+    ) -> None:
+        """相関ヒートマップをスタンドアロンで使用できることを確認。"""
+        # No need for Chart instance with data
+        fig = Chart.correlation_heatmap(
+            sample_correlation_matrix, title="Correlation Matrix", width=800, height=800
+        )
+        assert isinstance(fig, go.Figure)
+
+
+class TestChartImport:
+    """Tests for Chart class import."""
+
+    def test_正常系_パッケージからインポート可能(self) -> None:
+        """パッケージからChartクラスをインポートできることを確認。"""
+        from market_analysis import Chart as ImportedChart
+
+        assert ImportedChart is Chart
+
+    def test_正常系_apiモジュールからインポート可能(self) -> None:
+        """apiモジュールからChartクラスをインポートできることを確認。"""
+        from market_analysis.api import Chart as ApiChart
+
+        assert ApiChart is Chart


### PR DESCRIPTION
## 概要

Issue #29 (TASK-020) の実装: LRD で定義された Chart API インターフェースを実装

### 新規追加
- `src/market_analysis/api/chart.py` - Chart API クラス
- `tests/market_analysis/unit/api/test_chart.py` - ユニットテスト（34件）

### 変更
- `src/market_analysis/api/__init__.py` - Chart クラスをエクスポート
- `src/market_analysis/__init__.py` - Chart クラスをパッケージレベルでエクスポート

## 主な機能

```python
from market_analysis import Chart

# 価格チャート作成
chart = Chart(stock_df, title="AAPL Price Chart")
fig = chart.price_chart(overlays=["SMA_20", "EMA_50"])
chart.save("chart.png")
chart.show()  # marimo ノートブック対応

# 相関ヒートマップ（静的メソッド）
fig = Chart.correlation_heatmap(corr_matrix, title="Correlation Matrix")
```

## テストプラン

- [x] make check-all が成功することを確認（pyright の既存エラーは rss パッケージ関連で今回のスコープ外）
- [x] 新規テスト 34 件が全て PASS
- [x] market_analysis 全テスト 475 件が PASS
- [x] NumPy 形式の docstring が記載されていることを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.ai/code)