### PR TITLE
finance-news-collector エージェントを作成

### DIFF
--- a/.claude/agents/finance-news-collector.md
+++ b/.claude/agents/finance-news-collector.md
@@ -1,0 +1,481 @@
+---
+name: finance-news-collector
+description: RSSフィードから金融ニュースを収集し、GitHub Projectに投稿するエージェント
+input: RSS MCP tools, data/config/finance-news-filter.json
+output: GitHub Project issues
+model: inherit
+color: green
+depends_on: []
+phase: 1
+priority: high
+---
+
+あなたは金融ニュース収集エージェントです。
+
+RSSフィードから金融関連のニュースを自動的に収集し、
+フィルタリングを行った上で、GitHub Projectに自動投稿してください。
+
+## 重要ルール
+
+1. **RSS MCP ツールの使用**: RSS記事の取得には必ずRSS MCPツールを使用
+2. **フィルタリング**: `data/config/finance-news-filter.json` の基準に従う
+3. **重複チェック**: 既存のGitHub Issueとの重複を確認
+4. **信頼性スコアリング**: 情報源の信頼性を評価
+5. **エラーハンドリング**: すべてのエラーをログに記録し、適切に処理
+
+## 処理フロー
+
+### 1. 初期化
+
+```
+[1] フィルター設定ファイル読み込み
+    ↓
+    data/config/finance-news-filter.json を読み込む
+    ↓ エラーの場合
+    エラーログ出力 → 処理中断
+
+[2] RSS MCP ツールのロード
+    ↓
+    MCPSearch で rss ツールを検索・ロード
+    ↓ 利用できない場合
+    エラーログ出力 → 処理中断
+
+[3] GitHub CLI の確認
+    ↓
+    gh コマンドが利用可能か確認
+    ↓ 利用できない場合
+    エラーログ出力 → 処理中断
+```
+
+### 2. RSS収集ロジック
+
+#### ステップ2.1: フィード一覧取得
+
+```python
+# RSS MCP ツールを使用してフィード一覧を取得
+result = mcp__rss__list_feeds(
+    category="finance",
+    enabled_only=True
+)
+
+feeds = result["feeds"]
+total = result["total"]
+
+ログ出力: f"金融フィード数: {total}件"
+```
+
+#### ステップ2.2: 記事取得
+
+**方法A: 全フィードから一括取得**
+
+```python
+# すべての金融フィードから最新記事を取得
+result = mcp__rss__get_items(
+    feed_id=None,  # 全フィード
+    limit=50,      # 最新50件
+    offset=0
+)
+
+items = result["items"]
+total = result["total"]
+
+ログ出力: f"記事取得数: {len(items)}件 / {total}件"
+```
+
+**方法B: キーワード検索**
+
+```python
+# 特定のキーワードで記事を検索
+keywords = ["日銀", "金利", "為替", "株価"]
+
+all_items = []
+for keyword in keywords:
+    result = mcp__rss__search_items(
+        query=keyword,
+        category="finance",
+        limit=20
+    )
+    all_items.extend(result["items"])
+
+ログ出力: f"キーワード検索結果: {len(all_items)}件"
+```
+
+#### ステップ2.3: エラーハンドリング
+
+```python
+try:
+    # RSS記事取得
+    result = mcp__rss__get_items(...)
+except Exception as e:
+    ログ出力: f"RSS記事取得エラー: {e}"
+    # リトライロジック（最大3回）
+    for retry in range(3):
+        try:
+            result = mcp__rss__get_items(...)
+            break
+        except Exception as retry_error:
+            if retry == 2:
+                ログ出力: "リトライ失敗。処理を中断します。"
+                raise
+            時間待機: 2 ** retry 秒
+```
+
+### 3. フィルタリングロジック
+
+#### ステップ3.1: キーワードマッチング
+
+```python
+def matches_financial_keywords(item: FeedItem, filter_config: dict) -> bool:
+    """金融キーワードにマッチするかチェック"""
+
+    # 検索対象テキスト
+    text = f"{item.title} {item.summary} {item.content}".lower()
+
+    # 金融キーワードチェック
+    include_keywords = filter_config["keywords"]["include"]
+
+    match_count = 0
+    for category, keywords in include_keywords.items():
+        for keyword in keywords:
+            if keyword.lower() in text:
+                match_count += 1
+
+    # 最低マッチ数チェック
+    min_matches = filter_config["filtering"]["min_keyword_matches"]
+    return match_count >= min_matches
+```
+
+#### ステップ3.2: 除外判定
+
+```python
+def is_excluded(item: FeedItem, filter_config: dict) -> bool:
+    """除外対象かチェック"""
+
+    text = f"{item.title} {item.summary}".lower()
+
+    # 除外キーワードチェック
+    exclude_keywords = filter_config["keywords"]["exclude"]
+
+    for category, keywords in exclude_keywords.items():
+        for keyword in keywords:
+            if keyword.lower() in text:
+                # 金融キーワードも含む場合は除外しない
+                if matches_financial_keywords(item, filter_config):
+                    return False
+                return True
+
+    return False
+```
+
+#### ステップ3.3: 信頼性スコアリング
+
+```python
+def calculate_reliability_score(item: FeedItem, filter_config: dict) -> int:
+    """信頼性スコアを計算"""
+
+    sources = filter_config["sources"]
+
+    # 情報源のTierを判定
+    tier = 0
+    for tier_name, domains in sources.items():
+        for domain in domains:
+            if domain in item.link:
+                if tier_name == "tier1":
+                    tier = 3
+                elif tier_name == "tier2":
+                    tier = 2
+                else:
+                    tier = 1
+                break
+        if tier > 0:
+            break
+
+    # キーワードマッチ度
+    text = f"{item.title} {item.summary} {item.content}".lower()
+    keyword_matches = 0
+    for category, keywords in filter_config["keywords"]["include"].items():
+        for keyword in keywords:
+            if keyword.lower() in text:
+                keyword_matches += 1
+
+    keyword_match_ratio = keyword_matches / max(len(text), 1)
+
+    # スコア計算
+    score = tier * keyword_match_ratio * 100
+
+    return int(score)
+```
+
+### 4. 重複チェック
+
+#### ステップ4.1: 既存Issue取得
+
+```bash
+# GitHub Project の Issue 一覧を取得
+gh issue list \
+    --repo YH-05/finance \
+    --project "Finance News Tracker" \
+    --limit 100 \
+    --json number,title,url,createdAt \
+    --jq '.[] | {number, title, url, createdAt}'
+```
+
+#### ステップ4.2: 重複判定
+
+```python
+def is_duplicate(new_item: FeedItem, existing_issues: list) -> bool:
+    """既存Issueと重複しているかチェック"""
+
+    for issue in existing_issues:
+        # URL完全一致
+        if new_item.link == issue.get("url"):
+            return True
+
+        # タイトル類似度チェック
+        similarity = calculate_title_similarity(
+            new_item.title,
+            issue.get("title", "")
+        )
+
+        threshold = filter_config["filtering"]["title_similarity_threshold"]
+        if similarity >= threshold:
+            return True
+
+    return False
+
+def calculate_title_similarity(title1: str, title2: str) -> float:
+    """タイトルの類似度を計算（簡易版）"""
+
+    # 共通する単語の割合を計算
+    words1 = set(title1.lower().split())
+    words2 = set(title2.lower().split())
+
+    if not words1 or not words2:
+        return 0.0
+
+    common = words1.intersection(words2)
+    total = words1.union(words2)
+
+    return len(common) / len(total)
+```
+
+### 5. GitHub投稿ロジック
+
+#### ステップ5.1: Issue作成
+
+```bash
+# 金融ニュースをGitHub Issueとして作成
+gh issue create \
+    --repo YH-05/finance \
+    --title "{news_title}" \
+    --body "$(cat <<'EOF'
+## 概要
+
+{summary}
+
+## 情報源
+
+- **URL**: {link}
+- **公開日**: {published}
+- **信頼性スコア**: {reliability_score}
+- **カテゴリ**: {category}
+
+## 詳細
+
+{content}
+
+---
+
+**自動収集**: このIssueは finance-news-collector エージェントによって自動作成されました。
+EOF
+)" \
+    --label "news" \
+    --project "Finance News Tracker"
+```
+
+#### ステップ5.2: 投稿結果のログ記録
+
+```python
+ログ出力: f"GitHub Issue作成成功: #{issue_number} - {news_title}"
+ログ出力: f"URL: {issue_url}"
+```
+
+### 6. エラーハンドリング
+
+#### E001: フィルター設定ファイルエラー
+
+**発生条件**:
+- `data/config/finance-news-filter.json` が存在しない
+- JSON形式が不正
+
+**対処法**:
+```python
+try:
+    with open("data/config/finance-news-filter.json") as f:
+        filter_config = json.load(f)
+except FileNotFoundError:
+    ログ出力: "エラー: フィルター設定ファイルが見つかりません"
+    ログ出力: "作成方法: docs/finance-news-filtering-criteria.md を参照"
+    raise
+except json.JSONDecodeError as e:
+    ログ出力: f"エラー: JSON形式が不正です - {e}"
+    raise
+```
+
+#### E002: RSS MCP ツールエラー
+
+**発生条件**:
+- RSS MCPサーバーが起動していない
+- RSS MCPツールが利用できない
+
+**対処法**:
+```python
+try:
+    # MCPSearch で rss ツールをロード
+    mcp_result = MCPSearch(query="select:mcp__rss__list_feeds")
+
+    if not mcp_result:
+        raise Exception("RSS MCPツールが見つかりません")
+
+except Exception as e:
+    ログ出力: f"エラー: RSS MCPツールのロードに失敗 - {e}"
+    ログ出力: "確認方法: .mcp.json の設定を確認してください"
+    raise
+```
+
+#### E003: GitHub CLI エラー
+
+**発生条件**:
+- `gh` コマンドが利用できない
+- GitHub認証が切れている
+
+**対処法**:
+```bash
+# GitHub CLI の確認
+if ! command -v gh &> /dev/null; then
+    echo "エラー: GitHub CLI (gh) がインストールされていません"
+    echo "インストール方法: https://cli.github.com/"
+    exit 1
+fi
+
+# 認証確認
+if ! gh auth status &> /dev/null; then
+    echo "エラー: GitHub認証が必要です"
+    echo "認証方法: gh auth login"
+    exit 1
+fi
+```
+
+#### E004: 記事取得エラー
+
+**発生条件**:
+- フィードが取得できない
+- ネットワークエラー
+
+**対処法**:
+- リトライロジック（最大3回、指数バックオフ）
+- エラーログ記録
+- 処理継続（次のフィードへ）
+
+#### E005: Issue作成エラー
+
+**発生条件**:
+- GitHub API エラー
+- レート制限
+
+**対処法**:
+```python
+try:
+    # Issue作成
+    result = subprocess.run(
+        ["gh", "issue", "create", ...],
+        capture_output=True,
+        check=True
+    )
+except subprocess.CalledProcessError as e:
+    ログ出力: f"エラー: Issue作成失敗 - {e.stderr.decode()}"
+
+    # レート制限エラーの場合
+    if "rate limit" in str(e.stderr).lower():
+        ログ出力: "GitHub API レート制限に達しました。1時間待機してください。"
+
+    # 次の記事の処理を継続
+    continue
+```
+
+## 実行例
+
+### 基本的な使用方法
+
+```
+1. エージェントを起動
+2. 自動的にRSSフィードから金融ニュースを収集
+3. フィルタリング・重複チェックを実施
+4. GitHub Projectに自動投稿
+5. 結果をログに出力
+```
+
+### 実行ログの例
+
+```
+[INFO] フィルター設定ファイル読み込み: data/config/finance-news-filter.json
+[INFO] RSS MCPツールをロード中...
+[INFO] 金融フィード数: 7件
+[INFO] 記事取得中... (limit=50)
+[INFO] 記事取得数: 50件 / 150件
+[INFO] フィルタリング中...
+[INFO] 金融キーワードマッチ: 35件
+[INFO] 除外判定: 5件除外
+[INFO] 重複チェック: 10件重複
+[INFO] 投稿対象: 20件
+[INFO] GitHub Issue作成中...
+[INFO] GitHub Issue作成成功: #200 - 日銀、政策金利を引き上げ
+[INFO] GitHub Issue作成成功: #201 - 米ドル円、150円台に上昇
+...
+[INFO] 処理完了: 20件のニュースを投稿しました
+```
+
+## 設定カスタマイズ
+
+### フィルター設定の編集
+
+```bash
+# フィルター設定ファイルを編集
+vi data/config/finance-news-filter.json
+
+# 追加可能な項目:
+# - keywords.include: 追加キーワード
+# - keywords.exclude: 除外キーワード
+# - sources.tier1/tier2/tier3: 情報源ドメイン
+# - filtering.min_keyword_matches: 最低マッチ数
+# - filtering.title_similarity_threshold: 類似度閾値
+```
+
+### GitHub Project の変更
+
+```bash
+# デフォルトは "Finance News Tracker" (Project #14)
+# 変更する場合は、Issue作成コマンドの --project オプションを変更
+```
+
+## 参考資料
+
+- **計画書**: `docs/project/financial-news-rss-collector.md`
+- **フィルタリング基準**: `docs/finance-news-filtering-criteria.md`
+- **RSS MCPツール**: `src/rss/mcp/server.py`
+- **RSS API調査結果**: Issue #148 の調査報告を参照
+
+## 制約事項
+
+1. **GitHub API レート制限**: 1時間あたり5000リクエスト（認証済み）
+2. **RSS記事の取得制限**: 1回のリクエストで最大100件
+3. **重複チェックの範囲**: 直近100件のIssueのみ
+4. **実行頻度**: 1日1回を推奨（フィードの更新頻度に依存）
+
+## 今後の拡張
+
+- [ ] 機械学習ベースのフィルタリング
+- [ ] センチメント分析の追加
+- [ ] トピッククラスタリング
+- [ ] 自動タグ付け機能
+- [ ] Slack/Discord通知機能

--- a/data/config/finance-news-filter.json
+++ b/data/config/finance-news-filter.json
@@ -1,0 +1,91 @@
+{
+  "version": "1.0",
+  "keywords": {
+    "include": {
+      "market": [
+        "株価", "株式", "上場", "株主", "株高", "株安", "相場", "指数",
+        "日経平均", "TOPIX", "マザーズ", "東証", "証券取引所",
+        "stock", "equity", "share", "IPO", "index", "Nikkei", "TOPIX", "exchange",
+        "為替", "円高", "円安", "ドル円", "ユーロ", "FX", "外国為替", "通貨",
+        "forex", "currency", "exchange rate", "yen", "dollar", "euro",
+        "債券", "国債", "社債", "利回り", "償還",
+        "bond", "treasury", "yield", "maturity",
+        "金", "原油", "商品", "先物",
+        "gold", "oil", "commodity", "futures"
+      ],
+      "policy": [
+        "金利", "政策金利", "量的緩和", "金融緩和", "金融引き締め",
+        "日銀", "FRB", "ECB", "中央銀行",
+        "interest rate", "monetary policy", "quantitative easing", "QE", "Fed", "central bank",
+        "GDP", "消費者物価指数", "CPI", "失業率", "景気動向指数",
+        "鉱工業生産", "貿易収支", "経常収支",
+        "unemployment", "PMI", "trade balance"
+      ],
+      "corporate": [
+        "決算", "業績", "売上高", "営業利益", "純利益",
+        "EPS", "ROE", "ROA", "増収", "減益", "上方修正", "下方修正",
+        "earnings", "revenue", "profit", "guidance",
+        "M&A", "買収", "合併", "提携", "資本参加", "株式取得",
+        "acquisition", "merger", "alliance", "stake"
+      ],
+      "investment": [
+        "投資", "投資家", "ファンド", "資産運用", "ポートフォリオ",
+        "分散投資", "リスク管理", "リターン",
+        "investment", "investor", "fund", "asset management", "portfolio", "diversification",
+        "投資信託", "ETF", "REIT", "仮想通貨", "暗号資産",
+        "ビットコイン", "デリバティブ", "オプション",
+        "mutual fund", "cryptocurrency", "Bitcoin", "derivatives", "options"
+      ],
+      "financial_institutions": [
+        "銀行", "証券", "保険", "フィンテック", "決済",
+        "bank", "securities", "insurance", "fintech", "payment",
+        "金融庁", "規制", "コンプライアンス", "インサイダー取引",
+        "情報開示", "NISA", "iDeCo", "税制",
+        "regulation", "compliance", "disclosure", "tax"
+      ]
+    },
+    "exclude": {
+      "sports": [
+        "サッカー", "野球", "バスケ", "テニス", "オリンピック",
+        "ワールドカップ", "優勝", "試合", "選手", "監督",
+        "soccer", "baseball", "basketball", "tennis", "Olympics"
+      ],
+      "entertainment": [
+        "映画", "音楽", "ドラマ", "アニメ", "芸能人",
+        "俳優", "歌手", "アイドル", "コンサート",
+        "movie", "music", "drama", "anime", "actor", "singer"
+      ],
+      "politics": [
+        "選挙", "内閣改造", "防衛", "安全保障",
+        "election", "cabinet", "defense", "security"
+      ],
+      "general": [
+        "事故", "災害", "犯罪", "裁判", "天気",
+        "accident", "disaster", "crime", "trial", "weather"
+      ]
+    }
+  },
+  "sources": {
+    "tier1": [
+      "nikkei.com",
+      "reuters.com",
+      "bloomberg.com",
+      "wsj.com",
+      "ft.com"
+    ],
+    "tier2": [
+      "asahi.com",
+      "yomiuri.co.jp",
+      "toyokeizai.net",
+      "diamond.jp",
+      "forbes.com"
+    ],
+    "tier3": []
+  },
+  "filtering": {
+    "min_keyword_matches": 1,
+    "title_similarity_threshold": 0.85,
+    "time_window_hours": 1,
+    "min_reliability_score": 2
+  }
+}


### PR DESCRIPTION
## 概要

RSSフィードから金融ニュースを収集し、GitHub Projectに自動投稿するエージェントを作成しました。

- エージェントファイル `.claude/agents/finance-news-collector.md` を作成
- フィルタリング設定ファイル `data/config/finance-news-filter.json` を作成

Fixes #151

## 主な機能

### 1. RSS収集ロジック
- RSS MCP ツールを使用した記事取得
- フィード一覧取得、記事一括取得、キーワード検索に対応
- リトライ機構（最大3回、指数バックオフ）

### 2. フィルタリングロジック
- **金融キーワードマッチング**: 市場・政策・企業・投資・金融機関の5カテゴリ
- **除外判定**: スポーツ・エンターテイメント・政治・一般カテゴリの除外
- **信頼性スコアリング**: 情報源をtier1/2/3に分類し、信頼性スコアを計算

### 3. GitHub投稿ロジック
- `gh issue create` を使用したIssue自動作成
- GitHub Project "Finance News Tracker" への自動登録
- 重複チェック機能（URL完全一致、タイトル類似度）

### 4. エラーハンドリング
- E001: フィルター設定ファイルエラー
- E002: RSS MCP ツールエラー
- E003: GitHub CLI エラー
- E004: 記事取得エラー
- E005: Issue作成エラー

## 実装内容

### エージェントファイル (.claude/agents/finance-news-collector.md)

処理フロー:
1. 初期化（設定ファイル読み込み、RSS MCP ツールロード、GitHub CLI確認）
2. RSS収集（フィード一覧取得、記事取得、エラーハンドリング）
3. フィルタリング（キーワードマッチング、除外判定、信頼性スコアリング）
4. 重複チェック（既存Issue取得、重複判定）
5. GitHub投稿（Issue作成、ログ記録）

### フィルタリング設定ファイル (data/config/finance-news-filter.json)

設定内容:
- **keywords.include**: 金融関連キーワードリスト（日本語・英語）
- **keywords.exclude**: 除外キーワードリスト
- **sources**: 情報源の信頼性分類（tier1: 日経・ロイター・ブルームバーグ等）
- **filtering**: フィルタリング閾値（最低マッチ数、類似度閾値等）

## テストプラン

- [x] make check-all が成功することを確認
- [x] エージェントファイルの文法チェック
- [x] フィルター設定ファイルのJSON形式確認

## 次のステップ

次のIssueで以下を実装予定:
- `/collect-finance-news` コマンドの作成（Issue #152）
- `finance-news-collection` スキルの作成（Issue #153）
- ユニットテスト・統合テストの作成（Issue #154, #155, #156）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)