### PR TITLE
[Project-16] Wave 6: ROIC・品質ファクター実装

### DIFF
--- a/src/factor/factors/__init__.py
+++ b/src/factor/factors/__init__.py
@@ -1,0 +1,8 @@
+"""Factor subpackage for specific factor implementations."""
+
+from .quality import ROICFactor, ROICTransitionLabeler
+
+__all__ = [
+    "ROICFactor",
+    "ROICTransitionLabeler",
+]

--- a/src/factor/factors/quality/__init__.py
+++ b/src/factor/factors/quality/__init__.py
@@ -1,0 +1,13 @@
+"""Quality factor implementations.
+
+This module provides ROIC (Return on Invested Capital) factor calculations
+and transition labeling for factor analysis.
+"""
+
+from .roic import ROICFactor
+from .roic_label import ROICTransitionLabeler
+
+__all__ = [
+    "ROICFactor",
+    "ROICTransitionLabeler",
+]

--- a/src/factor/factors/quality/roic.py
+++ b/src/factor/factors/quality/roic.py
@@ -1,0 +1,276 @@
+"""ROIC (Return on Invested Capital) factor calculations.
+
+This module provides ROIC factor calculations including:
+- Quintile ranking of ROIC values
+- Past/future ROIC value shifting for time-series analysis
+
+Reference: src_sample/ROIC_make_data_files_ver2.py:1113-1151
+"""
+
+import numpy as np
+import pandas as pd
+
+from factor.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Default rank labels (rank1 = highest ROIC, rank5 = lowest ROIC)
+_DEFAULT_RANK_LABELS = ["rank5", "rank4", "rank3", "rank2", "rank1"]
+
+
+class ROICFactor:
+    """ROIC factor calculator for cross-sectional analysis.
+
+    Provides methods to calculate quintile ranks of ROIC values
+    and create shifted (past/future) ROIC columns for time-series analysis.
+
+    Parameters
+    ----------
+    min_samples : int, default=5
+        Minimum number of valid samples required for rank calculation.
+        If fewer samples exist, NaN is returned.
+
+    Attributes
+    ----------
+    min_samples : int
+        Minimum samples required for calculations
+
+    Examples
+    --------
+    >>> factor = ROICFactor(min_samples=10)
+    >>> df = pd.DataFrame({
+    ...     "date": ["2024-01-01"] * 10,
+    ...     "ticker": [f"STOCK{i}" for i in range(10)],
+    ...     "ROIC": [0.05, 0.08, 0.10, 0.12, 0.15, 0.18, 0.20, 0.22, 0.25, 0.30],
+    ... })
+    >>> result = factor.calculate_ranks(df)
+    >>> "ROIC_Rank" in result.columns
+    True
+    """
+
+    def __init__(self, min_samples: int = 5) -> None:
+        """Initialize ROICFactor.
+
+        Parameters
+        ----------
+        min_samples : int, default=5
+            Minimum number of valid samples required for calculations
+
+        Raises
+        ------
+        ValueError
+            If min_samples is not positive
+        """
+        if min_samples <= 0:
+            raise ValueError(f"min_samples must be positive, got {min_samples}")
+
+        self.min_samples = min_samples
+        logger.debug("ROICFactor initialized", min_samples=min_samples)
+
+    def calculate_ranks(
+        self,
+        df: pd.DataFrame,
+        roic_column: str = "ROIC",
+        date_column: str = "date",
+    ) -> pd.DataFrame:
+        """Calculate quintile ranks of ROIC values by date.
+
+        Transforms ROIC values to 5 quintile ranks for each date independently.
+        Rank1 represents the highest ROIC values, rank5 the lowest.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Input DataFrame containing ROIC and date columns
+        roic_column : str, default="ROIC"
+            Name of the column containing ROIC values
+        date_column : str, default="date"
+            Name of the column containing date values
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with additional rank column named "{roic_column}_Rank"
+
+        Notes
+        -----
+        The rank transformation uses pd.qcut with 5 bins. If fewer than
+        min_samples valid values exist for a date, NaN is assigned.
+        If all values are identical (no variance), NaN is assigned.
+
+        Reference: src_sample/ROIC_make_data_files_ver2.py:1113-1151
+
+        Examples
+        --------
+        >>> factor = ROICFactor()
+        >>> df = pd.DataFrame({
+        ...     "date": ["2024-01-01"] * 10,
+        ...     "ticker": [f"STOCK{i}" for i in range(10)],
+        ...     "ROIC": [0.05, 0.08, 0.10, 0.12, 0.15, 0.18, 0.20, 0.22, 0.25, 0.30],
+        ... })
+        >>> result = factor.calculate_ranks(df)
+        >>> result.loc[result["ROIC"] == 0.30, "ROIC_Rank"].iloc[0]
+        'rank1'
+        """
+        logger.debug(
+            "Calculating ROIC ranks",
+            roic_column=roic_column,
+            date_column=date_column,
+            rows=len(df),
+        )
+
+        result = df.copy()
+        rank_column = f"{roic_column}_Rank"
+
+        def _calculate_quintile(group: pd.Series) -> pd.Series:
+            """Calculate quintile rank for a group."""
+            valid_count = group.notna().sum()
+
+            if valid_count < self.min_samples:
+                logger.warning(
+                    "Insufficient data for quintile rank",
+                    valid_count=valid_count,
+                    min_samples=self.min_samples,
+                )
+                return pd.Series(np.nan, index=group.index)
+
+            try:
+                # pd.qcut assigns 0-4 (5 bins), we add 1 to get 1-5
+                qcut_result = pd.qcut(group, q=5, labels=False, duplicates="drop")
+                quintile_numeric = pd.Series(qcut_result, index=group.index) + 1
+
+                # Map numeric values to rank labels
+                # Note: qcut assigns lower numbers to lower values
+                # So quintile 1 (lowest values) -> rank5
+                # And quintile 5 (highest values) -> rank1
+                label_map = {
+                    1.0: "rank5",
+                    2.0: "rank4",
+                    3.0: "rank3",
+                    4.0: "rank2",
+                    5.0: "rank1",
+                }
+                return quintile_numeric.map(label_map)
+
+            except ValueError as e:
+                # Handle case where there are too few unique values
+                logger.warning(
+                    "Could not create 5 quintiles",
+                    error=str(e),
+                    unique_values=group.nunique(),
+                )
+                return pd.Series(np.nan, index=group.index)
+
+        result[rank_column] = df.groupby(date_column)[roic_column].transform(
+            _calculate_quintile
+        )
+
+        logger.info(
+            "ROIC ranks calculated",
+            output_column=rank_column,
+            unique_ranks=result[rank_column].nunique(),
+        )
+
+        return result
+
+    def add_shifted_values(
+        self,
+        df: pd.DataFrame,
+        roic_column: str = "ROIC",
+        ticker_column: str = "ticker",
+        date_column: str = "date",
+        past_periods: list[int] | None = None,
+        future_periods: list[int] | None = None,
+        freq_suffix: str = "Q",
+    ) -> pd.DataFrame:
+        """Add past and future ROIC value columns.
+
+        Creates new columns with shifted ROIC values for each ticker.
+        For past values, shift forward (current row gets past value).
+        For future values, shift backward (current row gets future value).
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Input DataFrame containing ROIC, ticker, and date columns
+        roic_column : str, default="ROIC"
+            Name of the column containing ROIC values
+        ticker_column : str, default="ticker"
+            Name of the column containing ticker/symbol values
+        date_column : str, default="date"
+            Name of the column containing date values
+        past_periods : list[int] | None, default=None
+            List of periods to shift for past values.
+            E.g., [1, 2, 4] creates columns for 1, 2, and 4 periods ago.
+        future_periods : list[int] | None, default=None
+            List of periods to shift for future values.
+            E.g., [1, 2, 4] creates columns for 1, 2, and 4 periods forward.
+        freq_suffix : str, default="Q"
+            Suffix for column names indicating frequency.
+            "Q" for quarterly, "M" for monthly.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with additional shifted value columns
+
+        Notes
+        -----
+        Column naming convention:
+        - Past: "{roic_column}_{n}{freq_suffix}Ago" (e.g., "ROIC_1QAgo")
+        - Future: "{roic_column}_{n}{freq_suffix}Forward" (e.g., "ROIC_1QForward")
+
+        Examples
+        --------
+        >>> factor = ROICFactor()
+        >>> result = factor.add_shifted_values(
+        ...     df,
+        ...     past_periods=[1, 2],
+        ...     future_periods=[1, 2],
+        ...     freq_suffix="Q",
+        ... )
+        >>> "ROIC_1QAgo" in result.columns
+        True
+        """
+        past_periods = past_periods or []
+        future_periods = future_periods or []
+
+        logger.debug(
+            "Adding shifted ROIC values",
+            roic_column=roic_column,
+            ticker_column=ticker_column,
+            past_periods=past_periods,
+            future_periods=future_periods,
+            freq_suffix=freq_suffix,
+        )
+
+        result = df.copy()
+
+        # Ensure data is sorted by ticker and date for proper shifting
+        result = result.sort_values([ticker_column, date_column])
+
+        # Add past value columns
+        for period in past_periods:
+            col_name = f"{roic_column}_{period}{freq_suffix}Ago"
+            result[col_name] = result.groupby(ticker_column)[roic_column].shift(period)
+            logger.debug("Added past column", column=col_name, shift=period)
+
+        # Add future value columns
+        for period in future_periods:
+            col_name = f"{roic_column}_{period}{freq_suffix}Forward"
+            result[col_name] = result.groupby(ticker_column)[roic_column].shift(-period)
+            logger.debug("Added future column", column=col_name, shift=-period)
+
+        # Restore original order
+        result = result.loc[df.index]
+
+        logger.info(
+            "Shifted ROIC values added",
+            past_columns=len(past_periods),
+            future_columns=len(future_periods),
+        )
+
+        return result
+
+
+__all__ = ["ROICFactor"]

--- a/src/factor/factors/quality/roic_label.py
+++ b/src/factor/factors/quality/roic_label.py
@@ -1,0 +1,203 @@
+"""ROIC transition labeling for factor analysis.
+
+This module provides functionality to label ROIC rank transitions
+over time periods, categorizing stocks based on their ROIC trajectory.
+
+Reference: src_sample/ROIC_make_data_files_ver2.py:1246-1386
+"""
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from factor.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class ROICTransitionLabeler:
+    """ROIC transition labeler for categorizing rank trajectories.
+
+    Labels stock ROIC trajectories based on rank transitions over time.
+    Categories include: remain high, remain low, move to high, drop to low, others.
+
+    Parameters
+    ----------
+    high_ranks : list[str] | None, default=None
+        Ranks considered as "high" ROIC. Defaults to ["rank1", "rank2"].
+    low_ranks : list[str] | None, default=None
+        Ranks considered as "low" ROIC. Defaults to ["rank4", "rank5"].
+
+    Attributes
+    ----------
+    high_ranks : list[str]
+        Ranks considered high
+    low_ranks : list[str]
+        Ranks considered low
+
+    Examples
+    --------
+    >>> labeler = ROICTransitionLabeler()
+    >>> ranks = ["rank1", "rank1", "rank2", "rank1", "rank2"]
+    >>> labeler.label_transition(ranks)
+    'remain high'
+    """
+
+    def __init__(
+        self,
+        high_ranks: list[str] | None = None,
+        low_ranks: list[str] | None = None,
+    ) -> None:
+        """Initialize ROICTransitionLabeler.
+
+        Parameters
+        ----------
+        high_ranks : list[str] | None, default=None
+            Ranks considered as "high" ROIC. Defaults to ["rank1", "rank2"].
+        low_ranks : list[str] | None, default=None
+            Ranks considered as "low" ROIC. Defaults to ["rank4", "rank5"].
+        """
+        self.high_ranks = high_ranks or ["rank1", "rank2"]
+        self.low_ranks = low_ranks or ["rank4", "rank5"]
+
+        logger.debug(
+            "ROICTransitionLabeler initialized",
+            high_ranks=self.high_ranks,
+            low_ranks=self.low_ranks,
+        )
+
+    def label_transition(self, ranks: Sequence[Any]) -> str | float:
+        """Generate transition label from a list of ranks.
+
+        Analyzes the trajectory of ROIC ranks over time and assigns
+        a descriptive label based on the observed pattern.
+
+        Parameters
+        ----------
+        ranks : Sequence[Any]
+            Sequence of rank values (e.g., ["rank1", "rank2", "rank3"]).
+            Can contain np.nan for missing values.
+
+        Returns
+        -------
+        str | float
+            One of:
+            - "remain high": All ranks are in high_ranks
+            - "remain low": All ranks are in low_ranks
+            - "move to high": Starts low/mid, ends high
+            - "drop to low": Starts high/mid, ends low
+            - "others": Other patterns
+            - np.nan: Missing data
+
+        Notes
+        -----
+        The logic follows src_sample/ROIC_make_data_files_ver2.py:1246-1386
+
+        Examples
+        --------
+        >>> labeler = ROICTransitionLabeler()
+        >>> labeler.label_transition(["rank5", "rank3", "rank2", "rank1"])
+        'move to high'
+        """
+        # Handle empty list
+        if not ranks:
+            return np.nan
+
+        # Check for any NaN values
+        if any(pd.isna(r) for r in ranks):
+            return np.nan
+
+        first_rank = ranks[0]
+        last_rank = ranks[-1]
+
+        # Check "remain high" - all ranks in high_ranks
+        if all(r in self.high_ranks for r in ranks):
+            return "remain high"
+
+        # Check "remain low" - all ranks in low_ranks
+        if all(r in self.low_ranks for r in ranks):
+            return "remain low"
+
+        # Check "move to high" - starts low/mid, ends high
+        # Low/mid: not in high_ranks (includes rank3, rank4, rank5)
+        # High: in high_ranks (rank1, rank2)
+        starts_not_high = first_rank not in self.high_ranks
+        ends_high = last_rank in self.high_ranks
+        if starts_not_high and ends_high:
+            return "move to high"
+
+        # Check "drop to low" - starts high/mid, ends low
+        # High/mid: not in low_ranks (includes rank1, rank2, rank3)
+        # Low: in low_ranks (rank4, rank5)
+        starts_not_low = first_rank not in self.low_ranks
+        ends_low = last_rank in self.low_ranks
+        if starts_not_low and ends_low:
+            return "drop to low"
+
+        # All other patterns
+        return "others"
+
+    def label_dataframe(
+        self,
+        df: pd.DataFrame,
+        rank_columns: list[str],
+        label_column: str = "ROIC_Label",
+    ) -> pd.DataFrame:
+        """Add transition labels to a DataFrame.
+
+        Applies label_transition to each row using the specified rank columns.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Input DataFrame containing rank columns
+        rank_columns : list[str]
+            List of column names containing ranks in chronological order
+        label_column : str, default="ROIC_Label"
+            Name of the output label column
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with additional label column
+
+        Examples
+        --------
+        >>> labeler = ROICTransitionLabeler()
+        >>> df = pd.DataFrame({
+        ...     "ticker": ["A", "B"],
+        ...     "ROIC_Rank": ["rank1", "rank5"],
+        ...     "ROIC_Rank_1QForward": ["rank1", "rank1"],
+        ... })
+        >>> result = labeler.label_dataframe(df, ["ROIC_Rank", "ROIC_Rank_1QForward"])
+        >>> result["ROIC_Label"].tolist()
+        ['remain high', 'move to high']
+        """
+        logger.debug(
+            "Labeling DataFrame",
+            rank_columns=rank_columns,
+            label_column=label_column,
+            rows=len(df),
+        )
+
+        result = df.copy()
+
+        def _apply_label(row: pd.Series) -> str | float:
+            """Extract ranks and apply labeling."""
+            ranks: list[Any] = [row[col] for col in rank_columns]
+            return self.label_transition(ranks)
+
+        result[label_column] = df.apply(_apply_label, axis=1)
+
+        logger.info(
+            "DataFrame labeled",
+            label_column=label_column,
+            unique_labels=result[label_column].nunique(),
+        )
+
+        return result
+
+
+__all__ = ["ROICTransitionLabeler"]

--- a/tests/factor/unit/factors/__init__.py
+++ b/tests/factor/unit/factors/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for factor algorithms."""

--- a/tests/factor/unit/factors/quality/__init__.py
+++ b/tests/factor/unit/factors/quality/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for quality factor algorithms."""

--- a/tests/factor/unit/factors/quality/test_roic.py
+++ b/tests/factor/unit/factors/quality/test_roic.py
@@ -1,0 +1,388 @@
+"""Unit tests for ROICFactor class.
+
+ROICFactorはROIC（投下資本利益率）の5分位ランク計算と
+過去/将来値のシフト機能を提供する。
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# AIDEV-NOTE: 実装が存在しないため、インポートは失敗する（Red状態）
+# pytest.importorskipを使用して、実装後に自動的にテストが有効になる
+ROICFactor = pytest.importorskip("factor.factors.quality.roic").ROICFactor
+
+
+class TestROICFactorInit:
+    """ROICFactor初期化のテスト。"""
+
+    def test_正常系_デフォルト値で初期化される(self) -> None:
+        """デフォルトのmin_samplesで初期化されることを確認。"""
+        factor = ROICFactor()
+        assert factor.min_samples == 5
+
+    def test_正常系_カスタム値で初期化される(self) -> None:
+        """カスタムのmin_samplesで初期化されることを確認。"""
+        factor = ROICFactor(min_samples=10)
+        assert factor.min_samples == 10
+
+    def test_異常系_min_samplesがゼロ以下でエラー(self) -> None:
+        """min_samplesが0以下の場合、エラーが発生することを確認。"""
+        with pytest.raises(ValueError):
+            ROICFactor(min_samples=0)
+
+        with pytest.raises(ValueError):
+            ROICFactor(min_samples=-1)
+
+
+class TestROICFactorCalculateRanks:
+    """ROICFactor.calculate_ranks()のテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = ROICFactor(min_samples=5)
+
+    def test_正常系_十分なデータで5分位ランクが計算される(self) -> None:
+        """十分なデータがある場合、5分位ランクが正しく計算されることを確認。"""
+        # Arrange: 10銘柄のデータを作成
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 10,
+                "ticker": [f"STOCK{i}" for i in range(10)],
+                "ROIC": [0.05, 0.08, 0.10, 0.12, 0.15, 0.18, 0.20, 0.22, 0.25, 0.30],
+            }
+        )
+
+        # Act
+        result = self.factor.calculate_ranks(df, roic_column="ROIC", date_column="date")
+
+        # Assert: ROIC_Rankカラムが追加される
+        assert "ROIC_Rank" in result.columns
+
+        # ランク値は rank1～rank5 のいずれか
+        unique_ranks = result["ROIC_Rank"].dropna().unique()
+        assert set(unique_ranks).issubset({"rank1", "rank2", "rank3", "rank4", "rank5"})
+
+    def test_正常系_最高ROIC銘柄がrank1になる(self) -> None:
+        """ROIC値が最も高い銘柄がrank1（最高ランク）になることを確認。"""
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 10,
+                "ticker": [f"STOCK{i}" for i in range(10)],
+                "ROIC": [0.05, 0.08, 0.10, 0.12, 0.15, 0.18, 0.20, 0.22, 0.25, 0.30],
+            }
+        )
+
+        result = self.factor.calculate_ranks(df, roic_column="ROIC", date_column="date")
+
+        # ROIC=0.30（最高値）の銘柄がrank1
+        max_roic_rank = result.loc[result["ROIC"] == 0.30, "ROIC_Rank"].iloc[0]
+        assert max_roic_rank == "rank1"
+
+    def test_正常系_最低ROIC銘柄がrank5になる(self) -> None:
+        """ROIC値が最も低い銘柄がrank5（最低ランク）になることを確認。"""
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 10,
+                "ticker": [f"STOCK{i}" for i in range(10)],
+                "ROIC": [0.05, 0.08, 0.10, 0.12, 0.15, 0.18, 0.20, 0.22, 0.25, 0.30],
+            }
+        )
+
+        result = self.factor.calculate_ranks(df, roic_column="ROIC", date_column="date")
+
+        # ROIC=0.05（最低値）の銘柄がrank5
+        min_roic_rank = result.loc[result["ROIC"] == 0.05, "ROIC_Rank"].iloc[0]
+        assert min_roic_rank == "rank5"
+
+    def test_正常系_複数日付でそれぞれ独立にランク付けされる(self) -> None:
+        """各日付ごとに独立してランク付けされることを確認。"""
+        # Arrange: 2日間、各5銘柄のデータ
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 5 + ["2024-01-02"] * 5,
+                "ticker": [f"STOCK{i}" for i in range(5)] * 2,
+                # 1日目と2日目で順位が逆転
+                "ROIC": [0.10, 0.20, 0.30, 0.40, 0.50, 0.50, 0.40, 0.30, 0.20, 0.10],
+            }
+        )
+
+        result = self.factor.calculate_ranks(df, roic_column="ROIC", date_column="date")
+
+        # 1日目: STOCK4 (ROIC=0.50) がrank1
+        day1 = result[result["date"] == "2024-01-01"]
+        assert day1.loc[day1["ticker"] == "STOCK4", "ROIC_Rank"].iloc[0] == "rank1"
+
+        # 2日目: STOCK0 (ROIC=0.50) がrank1
+        day2 = result[result["date"] == "2024-01-02"]
+        assert day2.loc[day2["ticker"] == "STOCK0", "ROIC_Rank"].iloc[0] == "rank1"
+
+    def test_異常系_データが5件未満でNaN(self) -> None:
+        """データが5件未満の場合、NaNが返されることを確認。"""
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 4,
+                "ticker": ["STOCK0", "STOCK1", "STOCK2", "STOCK3"],
+                "ROIC": [0.10, 0.20, 0.30, 0.40],
+            }
+        )
+
+        result = self.factor.calculate_ranks(df, roic_column="ROIC", date_column="date")
+
+        # 全てNaN
+        assert result["ROIC_Rank"].isna().all()
+
+    def test_異常系_全て同じ値の場合の処理(self) -> None:
+        """全ての値が同じ場合、NaNが返されることを確認。"""
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 10,
+                "ticker": [f"STOCK{i}" for i in range(10)],
+                "ROIC": [0.15] * 10,  # 全て同じ値
+            }
+        )
+
+        result = self.factor.calculate_ranks(df, roic_column="ROIC", date_column="date")
+
+        # 5分位に分割できないためNaN
+        assert result["ROIC_Rank"].isna().all()
+
+    def test_正常系_NaN値を含むデータの処理(self) -> None:
+        """NaN値を含むデータでも正しく処理されることを確認。"""
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 12,
+                "ticker": [f"STOCK{i}" for i in range(12)],
+                "ROIC": [
+                    0.05,
+                    0.08,
+                    np.nan,
+                    0.12,
+                    0.15,
+                    np.nan,
+                    0.20,
+                    0.22,
+                    0.25,
+                    0.30,
+                    0.32,
+                    0.35,
+                ],
+            }
+        )
+
+        result = self.factor.calculate_ranks(df, roic_column="ROIC", date_column="date")
+
+        # NaN以外の値にはランクが付く
+        valid_ranks = result[result["ROIC"].notna()]["ROIC_Rank"]
+        assert not valid_ranks.isna().all()
+
+        # 元々NaNだった行はNaNのまま
+        nan_rows = result[result["ROIC"].isna()]
+        assert nan_rows["ROIC_Rank"].isna().all()
+
+    def test_正常系_カスタムROICカラム名を使用できる(self) -> None:
+        """ROICカラム名をカスタマイズできることを確認。"""
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01"] * 10,
+                "ticker": [f"STOCK{i}" for i in range(10)],
+                "custom_roic": [
+                    0.05,
+                    0.08,
+                    0.10,
+                    0.12,
+                    0.15,
+                    0.18,
+                    0.20,
+                    0.22,
+                    0.25,
+                    0.30,
+                ],
+            }
+        )
+
+        result = self.factor.calculate_ranks(
+            df, roic_column="custom_roic", date_column="date"
+        )
+
+        assert "custom_roic_Rank" in result.columns
+
+
+class TestROICFactorAddShiftedValues:
+    """ROICFactor.add_shifted_values()のテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = ROICFactor(min_samples=5)
+
+    def _create_time_series_data(self) -> pd.DataFrame:
+        """時系列データを作成するヘルパーメソッド。"""
+        dates = pd.date_range("2020-01-01", periods=20, freq="QE")
+        tickers = ["STOCK0", "STOCK1"]
+
+        data = []
+        for ticker in tickers:
+            for i, date in enumerate(dates):
+                data.append(
+                    {
+                        "date": date,
+                        "ticker": ticker,
+                        "ROIC": 0.10 + 0.01 * i
+                        if ticker == "STOCK0"
+                        else 0.20 - 0.01 * i,
+                    }
+                )
+
+        return pd.DataFrame(data)
+
+    def test_正常系_過去値カラムが追加される(self) -> None:
+        """ROIC_1QAgo, ROIC_2QAgoなどの過去値カラムが追加されることを確認。"""
+        df = self._create_time_series_data()
+
+        result = self.factor.add_shifted_values(
+            df,
+            roic_column="ROIC",
+            ticker_column="ticker",
+            date_column="date",
+            past_periods=[1, 2, 4],
+            future_periods=[],
+        )
+
+        assert "ROIC_1QAgo" in result.columns
+        assert "ROIC_2QAgo" in result.columns
+        assert "ROIC_4QAgo" in result.columns
+
+    def test_正常系_将来値カラムが追加される(self) -> None:
+        """ROIC_1QForward, ROIC_2QForwardなどの将来値カラムが追加されることを確認。"""
+        df = self._create_time_series_data()
+
+        result = self.factor.add_shifted_values(
+            df,
+            roic_column="ROIC",
+            ticker_column="ticker",
+            date_column="date",
+            past_periods=[],
+            future_periods=[1, 2, 4],
+        )
+
+        assert "ROIC_1QForward" in result.columns
+        assert "ROIC_2QForward" in result.columns
+        assert "ROIC_4QForward" in result.columns
+
+    def test_正常系_過去値が正しくシフトされる(self) -> None:
+        """過去値が正しい期間だけシフトされることを確認。"""
+        df = self._create_time_series_data()
+
+        result = self.factor.add_shifted_values(
+            df,
+            roic_column="ROIC",
+            ticker_column="ticker",
+            date_column="date",
+            past_periods=[1],
+            future_periods=[],
+        )
+
+        # STOCK0の2四半期目のROIC_1QAgoは1四半期目のROICと同じ
+        stock0_data = result[result["ticker"] == "STOCK0"].sort_values("date")
+        second_row = stock0_data.iloc[1]
+        first_row = stock0_data.iloc[0]
+
+        assert second_row["ROIC_1QAgo"] == first_row["ROIC"]
+
+    def test_正常系_将来値が正しくシフトされる(self) -> None:
+        """将来値が正しい期間だけシフトされることを確認。"""
+        df = self._create_time_series_data()
+
+        result = self.factor.add_shifted_values(
+            df,
+            roic_column="ROIC",
+            ticker_column="ticker",
+            date_column="date",
+            past_periods=[],
+            future_periods=[1],
+        )
+
+        # STOCK0の1四半期目のROIC_1QForwardは2四半期目のROICと同じ
+        stock0_data = result[result["ticker"] == "STOCK0"].sort_values("date")
+        first_row = stock0_data.iloc[0]
+        second_row = stock0_data.iloc[1]
+
+        assert first_row["ROIC_1QForward"] == second_row["ROIC"]
+
+    def test_正常系_銘柄ごとに独立してシフトされる(self) -> None:
+        """各銘柄ごとに独立してシフトされることを確認。"""
+        df = self._create_time_series_data()
+
+        result = self.factor.add_shifted_values(
+            df,
+            roic_column="ROIC",
+            ticker_column="ticker",
+            date_column="date",
+            past_periods=[1],
+            future_periods=[],
+        )
+
+        # 異なる銘柄間でシフトが混ざらない
+        stock0_data = result[result["ticker"] == "STOCK0"].sort_values("date")
+        stock1_data = result[result["ticker"] == "STOCK1"].sort_values("date")
+
+        # STOCK0の2四半期目のROIC_1QAgoはSTOCK0の1四半期目のROIC
+        assert stock0_data.iloc[1]["ROIC_1QAgo"] == stock0_data.iloc[0]["ROIC"]
+
+        # STOCK1の2四半期目のROIC_1QAgoはSTOCK1の1四半期目のROIC（STOCK0ではない）
+        assert stock1_data.iloc[1]["ROIC_1QAgo"] == stock1_data.iloc[0]["ROIC"]
+
+    def test_境界条件_シフト期間がデータ範囲を超える場合NaN(self) -> None:
+        """シフト期間がデータ範囲を超える場合、NaNになることを確認。"""
+        df = self._create_time_series_data()
+
+        result = self.factor.add_shifted_values(
+            df,
+            roic_column="ROIC",
+            ticker_column="ticker",
+            date_column="date",
+            past_periods=[1, 2],
+            future_periods=[1, 2],
+        )
+
+        stock0_data = result[result["ticker"] == "STOCK0"].sort_values("date")
+
+        # 最初の行は1期前のデータがない
+        assert pd.isna(stock0_data.iloc[0]["ROIC_1QAgo"])
+
+        # 最初の2行は2期前のデータがない
+        assert pd.isna(stock0_data.iloc[0]["ROIC_2QAgo"])
+        assert pd.isna(stock0_data.iloc[1]["ROIC_2QAgo"])
+
+        # 最後の行は1期先のデータがない
+        assert pd.isna(stock0_data.iloc[-1]["ROIC_1QForward"])
+
+        # 最後の2行は2期先のデータがない
+        assert pd.isna(stock0_data.iloc[-1]["ROIC_2QForward"])
+        assert pd.isna(stock0_data.iloc[-2]["ROIC_2QForward"])
+
+    def test_正常系_月次サフィックスを使用できる(self) -> None:
+        """月次データ用のサフィックス(M)を使用できることを確認。"""
+        dates = pd.date_range("2020-01-01", periods=24, freq="ME")
+        df = pd.DataFrame(
+            {
+                "date": dates,
+                "ticker": ["STOCK0"] * 24,
+                "ROIC": [0.10 + 0.001 * i for i in range(24)],
+            }
+        )
+
+        result = self.factor.add_shifted_values(
+            df,
+            roic_column="ROIC",
+            ticker_column="ticker",
+            date_column="date",
+            past_periods=[1, 12],
+            future_periods=[1, 12],
+            freq_suffix="M",  # 月次
+        )
+
+        assert "ROIC_1MAgo" in result.columns
+        assert "ROIC_12MAgo" in result.columns
+        assert "ROIC_1MForward" in result.columns
+        assert "ROIC_12MForward" in result.columns

--- a/tests/factor/unit/factors/quality/test_roic_label.py
+++ b/tests/factor/unit/factors/quality/test_roic_label.py
@@ -1,0 +1,368 @@
+"""Unit tests for ROICTransitionLabeler class.
+
+ROICTransitionLabelerはROIC5分位ランクの推移に基づいて
+遷移ラベル（remain high, remain low, move to high, drop to low, others）を生成する。
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# AIDEV-NOTE: 実装が存在しないため、インポートは失敗する（Red状態）
+# pytest.importorskipを使用して、実装後に自動的にテストが有効になる
+ROICTransitionLabeler = pytest.importorskip(
+    "factor.factors.quality.roic_label"
+).ROICTransitionLabeler
+
+
+class TestROICTransitionLabelerInit:
+    """ROICTransitionLabeler初期化のテスト。"""
+
+    def test_正常系_デフォルト値で初期化される(self) -> None:
+        """デフォルト値で初期化されることを確認。"""
+        labeler = ROICTransitionLabeler()
+        assert labeler is not None
+
+    def test_正常系_カスタムパラメータで初期化される(self) -> None:
+        """カスタムパラメータで初期化できることを確認。"""
+        labeler = ROICTransitionLabeler(
+            high_ranks=["rank1", "rank2"],
+            low_ranks=["rank4", "rank5"],
+        )
+        assert labeler.high_ranks == ["rank1", "rank2"]
+        assert labeler.low_ranks == ["rank4", "rank5"]
+
+
+class TestROICTransitionLabelerLabelTransition:
+    """ROICTransitionLabeler.label_transition()のテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.labeler = ROICTransitionLabeler()
+
+    def test_正常系_remain_high_全期間rank1(self) -> None:
+        """期間中の全ランクがrank1の場合、'remain high'を返すことを確認。"""
+        # Arrange: 5期間分のランクデータ（全てrank1）
+        ranks = ["rank1", "rank1", "rank1", "rank1", "rank1"]
+
+        # Act
+        result = self.labeler.label_transition(ranks)
+
+        # Assert
+        assert result == "remain high"
+
+    def test_正常系_remain_high_全期間rank2(self) -> None:
+        """期間中の全ランクがrank2の場合、'remain high'を返すことを確認。"""
+        ranks = ["rank2", "rank2", "rank2", "rank2", "rank2"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "remain high"
+
+    def test_正常系_remain_high_rank1とrank2の混合(self) -> None:
+        """期間中の全ランクがrank1またはrank2の場合、'remain high'を返すことを確認。"""
+        ranks = ["rank1", "rank2", "rank1", "rank2", "rank1"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "remain high"
+
+    def test_正常系_remain_low_全期間rank5(self) -> None:
+        """期間中の全ランクがrank5の場合、'remain low'を返すことを確認。"""
+        ranks = ["rank5", "rank5", "rank5", "rank5", "rank5"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "remain low"
+
+    def test_正常系_remain_low_全期間rank4(self) -> None:
+        """期間中の全ランクがrank4の場合、'remain low'を返すことを確認。"""
+        ranks = ["rank4", "rank4", "rank4", "rank4", "rank4"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "remain low"
+
+    def test_正常系_remain_low_rank4とrank5の混合(self) -> None:
+        """期間中の全ランクがrank4またはrank5の場合、'remain low'を返すことを確認。"""
+        ranks = ["rank4", "rank5", "rank4", "rank5", "rank4"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "remain low"
+
+    def test_正常系_move_to_high_rank5からrank1へ(self) -> None:
+        """低ランク(rank5)から高ランク(rank1)への遷移で'move to high'を返すことを確認。"""
+        ranks = ["rank5", "rank4", "rank3", "rank2", "rank1"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "move to high"
+
+    def test_正常系_move_to_high_rank3からrank2へ(self) -> None:
+        """低ランク(rank3)から高ランク(rank2)への遷移で'move to high'を返すことを確認。"""
+        ranks = ["rank3", "rank3", "rank3", "rank2", "rank2"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "move to high"
+
+    def test_正常系_drop_to_low_rank1からrank5へ(self) -> None:
+        """高ランク(rank1)から低ランク(rank5)への遷移で'drop to low'を返すことを確認。"""
+        ranks = ["rank1", "rank2", "rank3", "rank4", "rank5"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "drop to low"
+
+    def test_正常系_drop_to_low_rank3からrank4へ(self) -> None:
+        """高ランク(rank3)から低ランク(rank4)への遷移で'drop to low'を返すことを確認。"""
+        ranks = ["rank3", "rank3", "rank3", "rank4", "rank4"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "drop to low"
+
+    def test_正常系_others_中間ランクで推移(self) -> None:
+        """中間ランクのみで推移する場合、'others'を返すことを確認。"""
+        ranks = ["rank3", "rank3", "rank3", "rank3", "rank3"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "others"
+
+    def test_正常系_others_高から低へ戻る(self) -> None:
+        """高ランクから低ランクに下がり、また高ランクに戻る場合、'others'を返すことを確認。"""
+        # remain highでもdrop to lowでもないパターン
+        ranks = ["rank1", "rank3", "rank5", "rank3", "rank1"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "others"
+
+    def test_正常系_others_低から高へ戻る(self) -> None:
+        """低ランクから高ランクに上がり、また低ランクに戻る場合、'others'を返すことを確認。"""
+        ranks = ["rank5", "rank3", "rank1", "rank3", "rank5"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert result == "others"
+
+    def test_異常系_NaNを含む場合NaNを返す(self) -> None:
+        """期間中にNaNが1つでも含まれる場合、NaNを返すことを確認。"""
+        ranks = ["rank1", "rank1", np.nan, "rank1", "rank1"]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert pd.isna(result)
+
+    def test_異常系_全てNaNの場合NaNを返す(self) -> None:
+        """期間中の全てがNaNの場合、NaNを返すことを確認。"""
+        ranks = [np.nan, np.nan, np.nan, np.nan, np.nan]
+
+        result = self.labeler.label_transition(ranks)
+
+        assert pd.isna(result)
+
+    def test_異常系_空リストの場合NaNを返す(self) -> None:
+        """空のリストが渡された場合、NaNを返すことを確認。"""
+        ranks: list[str] = []
+
+        result = self.labeler.label_transition(ranks)
+
+        assert pd.isna(result)
+
+
+class TestROICTransitionLabelerLabelDataFrame:
+    """ROICTransitionLabeler.label_dataframe()のテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.labeler = ROICTransitionLabeler()
+
+    def _create_sample_dataframe(self) -> pd.DataFrame:
+        """サンプルDataFrameを作成するヘルパーメソッド。"""
+        # 5期間分のランクカラムを持つDataFrame
+        return pd.DataFrame(
+            {
+                "ticker": ["STOCK0", "STOCK1", "STOCK2", "STOCK3", "STOCK4"],
+                "ROIC_Rank": ["rank1", "rank5", "rank3", "rank1", "rank4"],
+                "ROIC_Rank_1QForward": ["rank1", "rank4", "rank3", "rank2", "rank4"],
+                "ROIC_Rank_2QForward": ["rank1", "rank3", "rank3", "rank3", "rank5"],
+                "ROIC_Rank_3QForward": ["rank2", "rank2", "rank3", "rank4", "rank5"],
+                "ROIC_Rank_4QForward": ["rank2", "rank1", "rank3", "rank5", "rank5"],
+            }
+        )
+
+    def test_正常系_DataFrameにラベルカラムが追加される(self) -> None:
+        """DataFrameにROIC_Labelカラムが追加されることを確認。"""
+        df = self._create_sample_dataframe()
+        rank_columns = [
+            "ROIC_Rank",
+            "ROIC_Rank_1QForward",
+            "ROIC_Rank_2QForward",
+            "ROIC_Rank_3QForward",
+            "ROIC_Rank_4QForward",
+        ]
+
+        result = self.labeler.label_dataframe(df, rank_columns=rank_columns)
+
+        assert "ROIC_Label" in result.columns
+
+    def test_正常系_各行に正しいラベルが付与される(self) -> None:
+        """各行に正しいラベルが付与されることを確認。"""
+        df = self._create_sample_dataframe()
+        rank_columns = [
+            "ROIC_Rank",
+            "ROIC_Rank_1QForward",
+            "ROIC_Rank_2QForward",
+            "ROIC_Rank_3QForward",
+            "ROIC_Rank_4QForward",
+        ]
+
+        result = self.labeler.label_dataframe(df, rank_columns=rank_columns)
+
+        # STOCK0: rank1 → rank1 → rank1 → rank2 → rank2 = remain high
+        assert (
+            result.loc[result["ticker"] == "STOCK0", "ROIC_Label"].iloc[0]
+            == "remain high"
+        )
+
+        # STOCK1: rank5 → rank4 → rank3 → rank2 → rank1 = move to high
+        assert (
+            result.loc[result["ticker"] == "STOCK1", "ROIC_Label"].iloc[0]
+            == "move to high"
+        )
+
+        # STOCK2: rank3 → rank3 → rank3 → rank3 → rank3 = others
+        assert (
+            result.loc[result["ticker"] == "STOCK2", "ROIC_Label"].iloc[0] == "others"
+        )
+
+        # STOCK3: rank1 → rank2 → rank3 → rank4 → rank5 = drop to low
+        assert (
+            result.loc[result["ticker"] == "STOCK3", "ROIC_Label"].iloc[0]
+            == "drop to low"
+        )
+
+        # STOCK4: rank4 → rank4 → rank5 → rank5 → rank5 = remain low
+        assert (
+            result.loc[result["ticker"] == "STOCK4", "ROIC_Label"].iloc[0]
+            == "remain low"
+        )
+
+    def test_正常系_カスタムラベルカラム名を使用できる(self) -> None:
+        """カスタムラベルカラム名を使用できることを確認。"""
+        df = self._create_sample_dataframe()
+        rank_columns = [
+            "ROIC_Rank",
+            "ROIC_Rank_1QForward",
+            "ROIC_Rank_2QForward",
+            "ROIC_Rank_3QForward",
+            "ROIC_Rank_4QForward",
+        ]
+
+        result = self.labeler.label_dataframe(
+            df, rank_columns=rank_columns, label_column="CustomLabel"
+        )
+
+        assert "CustomLabel" in result.columns
+        assert "ROIC_Label" not in result.columns
+
+    def test_正常系_欠損カラムがある場合NaNが付与される(self) -> None:
+        """ランクカラムに欠損値がある行にはNaNが付与されることを確認。"""
+        df = pd.DataFrame(
+            {
+                "ticker": ["STOCK0", "STOCK1"],
+                "ROIC_Rank": ["rank1", np.nan],
+                "ROIC_Rank_1QForward": ["rank1", "rank2"],
+                "ROIC_Rank_2QForward": ["rank1", "rank3"],
+                "ROIC_Rank_3QForward": ["rank2", "rank4"],
+                "ROIC_Rank_4QForward": ["rank2", "rank5"],
+            }
+        )
+        rank_columns = [
+            "ROIC_Rank",
+            "ROIC_Rank_1QForward",
+            "ROIC_Rank_2QForward",
+            "ROIC_Rank_3QForward",
+            "ROIC_Rank_4QForward",
+        ]
+
+        result = self.labeler.label_dataframe(df, rank_columns=rank_columns)
+
+        # STOCK0は正常にラベル付け
+        assert (
+            result.loc[result["ticker"] == "STOCK0", "ROIC_Label"].iloc[0]
+            == "remain high"
+        )
+
+        # STOCK1はNaNを含むのでNaN
+        assert pd.isna(result.loc[result["ticker"] == "STOCK1", "ROIC_Label"].iloc[0])
+
+
+class TestROICTransitionLabelerEdgeCases:
+    """ROICTransitionLabelerのエッジケーステスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.labeler = ROICTransitionLabeler()
+
+    def test_正常系_2期間のみのデータでもラベル付け可能(self) -> None:
+        """2期間のみのデータでも正しくラベル付けされることを確認。"""
+        # remain high: rank1 → rank2
+        ranks = ["rank1", "rank2"]
+        result = self.labeler.label_transition(ranks)
+        assert result == "remain high"
+
+        # move to high: rank5 → rank1
+        ranks = ["rank5", "rank1"]
+        result = self.labeler.label_transition(ranks)
+        assert result == "move to high"
+
+    def test_正常系_1期間のみのデータでもラベル付け可能(self) -> None:
+        """1期間のみのデータでも正しくラベル付けされることを確認。"""
+        # 1期間のみの場合、そのランクに基づいてラベル付け
+        # rank1のみ → remain high
+        result = self.labeler.label_transition(["rank1"])
+        assert result == "remain high"
+
+        # rank5のみ → remain low
+        result = self.labeler.label_transition(["rank5"])
+        assert result == "remain low"
+
+        # rank3のみ → others
+        result = self.labeler.label_transition(["rank3"])
+        assert result == "others"
+
+    def test_正常系_境界条件_move_to_high判定の始点(self) -> None:
+        """move to high判定で始点がrank3（低ランク境界）の場合を確認。"""
+        # rank3は低ランクに含まれる（rank3, rank4, rank5）
+        ranks = ["rank3", "rank2"]
+        result = self.labeler.label_transition(ranks)
+        assert result == "move to high"
+
+    def test_正常系_境界条件_drop_to_low判定の始点(self) -> None:
+        """drop to low判定で始点がrank3（高ランク境界）の場合を確認。"""
+        # rank3は高ランクに含まれる（rank1, rank2, rank3）
+        ranks = ["rank3", "rank4"]
+        result = self.labeler.label_transition(ranks)
+        assert result == "drop to low"
+
+    def test_正常系_カスタムランク定義を使用できる(self) -> None:
+        """カスタムの高/低ランク定義を使用できることを確認。"""
+        # カスタム定義: rank1のみが高ランク、rank5のみが低ランク
+        labeler = ROICTransitionLabeler(
+            high_ranks=["rank1"],
+            low_ranks=["rank5"],
+        )
+
+        # rank2は高ランクではないのでremain highにならない
+        ranks = ["rank2", "rank2", "rank2"]
+        result = labeler.label_transition(ranks)
+        assert result != "remain high"
+
+        # rank1のみならremain high
+        ranks = ["rank1", "rank1", "rank1"]
+        result = labeler.label_transition(ranks)
+        assert result == "remain high"


### PR DESCRIPTION
## 概要
Issue #259 の実装

## 変更内容
- `ROICFactor` クラス追加（5分位ランク計算、過去/将来値シフト）
  - `calculate_ranks()`: 各日付で ROIC 値を 5 分位（rank1=最高 〜 rank5=最低）に分類
  - `add_shifted_values()`: 過去/将来の ROIC 値カラムを追加
- `ROICTransitionLabeler` クラス追加（ROIC 遷移ラベル生成）
  - `label_transition()`: ランク推移から遷移ラベルを生成
    - "remain high", "remain low", "move to high", "drop to low", "others"
  - `label_dataframe()`: DataFrame 全体へのラベル付与
- 45 件の単体テストを追加

Fixes #259

## テストプラン
- [x] make check-all が成功することを確認
- [x] 45 件の単体テストが全てパス
- [x] 型チェック・リントエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)