### PR TITLE
feat(strategy): MarketAnalysisProvider を実装

### DIFF
--- a/src/strategy/providers/__init__.py
+++ b/src/strategy/providers/__init__.py
@@ -4,8 +4,10 @@ This module provides abstract interfaces and concrete implementations
 for data providers used in portfolio strategy analysis.
 """
 
+from .market_analysis import MarketAnalysisProvider
 from .protocol import DataProvider
 
 __all__ = [
     "DataProvider",
+    "MarketAnalysisProvider",
 ]

--- a/src/strategy/providers/market_analysis.py
+++ b/src/strategy/providers/market_analysis.py
@@ -1,0 +1,326 @@
+"""MarketAnalysisProvider implementation.
+
+market_analysis パッケージを使用した DataProvider の実装。
+YFinanceFetcher を使用して株価データを取得し、TickerInfo を提供する。
+"""
+
+from typing import Any
+
+import pandas as pd
+import yfinance as yf
+
+from market_analysis.core.yfinance_fetcher import YFinanceFetcher
+from market_analysis.errors import DataFetchError
+from market_analysis.types import FetchOptions
+from strategy.errors import DataProviderError
+from strategy.types import TickerInfo
+from strategy.utils.logging_config import get_logger
+
+logger = get_logger(__name__, module="market_analysis_provider")
+
+
+class MarketAnalysisProvider:
+    """DataProvider implementation using market_analysis package.
+
+    市場データの取得に market_analysis パッケージの YFinanceFetcher を使用する
+    DataProvider の実装。
+
+    Parameters
+    ----------
+    use_cache : bool, default=True
+        キャッシュを使用するかどうか
+
+    Examples
+    --------
+    >>> provider = MarketAnalysisProvider()
+    >>> df = provider.get_prices(["AAPL"], "2024-01-01", "2024-12-31")
+    >>> df.columns.names
+    ['ticker', 'price_type']
+    """
+
+    def __init__(self, use_cache: bool = True) -> None:
+        """Initialize MarketAnalysisProvider.
+
+        Parameters
+        ----------
+        use_cache : bool, default=True
+            キャッシュを使用するかどうか
+        """
+        logger.debug(
+            "Initializing MarketAnalysisProvider",
+            use_cache=use_cache,
+        )
+        self._use_cache = use_cache
+        self._fetcher = YFinanceFetcher()
+        logger.info(
+            "MarketAnalysisProvider initialized",
+            use_cache=use_cache,
+        )
+
+    def get_prices(
+        self,
+        tickers: list[str],
+        start: str,
+        end: str,
+    ) -> pd.DataFrame:
+        """指定期間の価格データ（OHLCV）を取得.
+
+        Parameters
+        ----------
+        tickers : list[str]
+            取得するティッカーシンボルのリスト（例: ["AAPL", "GOOGL", "MSFT"]）
+        start : str
+            開始日（YYYY-MM-DD形式、例: "2024-01-01"）
+        end : str
+            終了日（YYYY-MM-DD形式、例: "2024-12-31"）
+
+        Returns
+        -------
+        pd.DataFrame
+            MultiIndex DataFrame で以下の構造を持つ:
+
+            - **index**: DatetimeIndex（date）
+            - **columns**: MultiIndex with levels:
+                - level 0 (ticker): ティッカーシンボル
+                - level 1 (price_type): open, high, low, close, volume
+
+        Raises
+        ------
+        DataProviderError
+            データ取得に失敗した場合
+
+        Examples
+        --------
+        >>> provider = MarketAnalysisProvider()
+        >>> df = provider.get_prices(["AAPL", "GOOGL"], "2024-01-01", "2024-12-31")
+        >>> df.columns.names
+        ['ticker', 'price_type']
+        """
+        logger.debug(
+            "Fetching prices",
+            tickers=tickers,
+            start=start,
+            end=end,
+        )
+
+        try:
+            options = FetchOptions(
+                symbols=tickers,
+                start_date=start,
+                end_date=end,
+                use_cache=self._use_cache,
+            )
+
+            results = self._fetcher.fetch(options)
+
+            # Convert results to MultiIndex DataFrame
+            df = self._convert_to_multiindex_dataframe(results)
+
+            logger.info(
+                "Prices fetched successfully",
+                tickers=tickers,
+                rows=len(df),
+            )
+
+            return df
+
+        except DataFetchError as e:
+            logger.error(
+                "Failed to fetch prices",
+                tickers=tickers,
+                error=str(e),
+            )
+            raise DataProviderError(
+                f"Failed to fetch prices for {tickers}: {e}",
+                code="PROVIDER_FETCH_ERROR",
+                cause=e,
+            ) from e
+        except Exception as e:
+            logger.error(
+                "Unexpected error fetching prices",
+                tickers=tickers,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            raise DataProviderError(
+                f"Unexpected error fetching prices for {tickers}: {e}",
+                code="PROVIDER_UNEXPECTED_ERROR",
+                cause=e,
+            ) from e
+
+    def _convert_to_multiindex_dataframe(
+        self,
+        results: list[Any],
+    ) -> pd.DataFrame:
+        """Convert MarketDataResult list to MultiIndex DataFrame.
+
+        Parameters
+        ----------
+        results : list[MarketDataResult]
+            YFinanceFetcher.fetch() の結果
+
+        Returns
+        -------
+        pd.DataFrame
+            MultiIndex DataFrame with (ticker, price_type) columns
+        """
+        if not results:
+            # Return empty DataFrame with correct structure
+            columns = pd.MultiIndex.from_tuples(
+                [],
+                names=["ticker", "price_type"],
+            )
+            return pd.DataFrame(columns=columns)
+
+        dfs: dict[str, pd.DataFrame] = {}
+
+        for result in results:
+            symbol = result.symbol
+            data = result.data
+
+            if data.empty:
+                continue
+
+            # Ensure column names are lowercase
+            data.columns = pd.Index([col.lower() for col in data.columns])
+
+            # Select only OHLCV columns
+            ohlcv_cols = ["open", "high", "low", "close", "volume"]
+            available_cols = [col for col in ohlcv_cols if col in data.columns]
+
+            if available_cols:
+                dfs[symbol] = data[available_cols]
+
+        if not dfs:
+            # Return empty DataFrame with correct structure
+            columns = pd.MultiIndex.from_tuples(
+                [],
+                names=["ticker", "price_type"],
+            )
+            return pd.DataFrame(columns=columns)
+
+        # Concatenate all DataFrames with MultiIndex columns
+        combined = pd.concat(
+            dfs,
+            axis=1,
+            keys=dfs.keys(),
+            names=["ticker", "price_type"],
+        )
+
+        # Ensure index is named 'date'
+        combined.index.name = "date"
+
+        return combined
+
+    def get_ticker_info(self, ticker: str) -> TickerInfo:
+        """ティッカーの情報（セクター、資産クラス等）を取得.
+
+        Parameters
+        ----------
+        ticker : str
+            ティッカーシンボル（例: "AAPL"）
+
+        Returns
+        -------
+        TickerInfo
+            ティッカーの詳細情報を含むデータクラス。
+
+        Raises
+        ------
+        DataProviderError
+            銘柄情報取得に失敗した場合
+
+        Examples
+        --------
+        >>> provider = MarketAnalysisProvider()
+        >>> info = provider.get_ticker_info("AAPL")
+        >>> info.ticker
+        'AAPL'
+        """
+        logger.debug("Fetching ticker info", ticker=ticker)
+
+        try:
+            yf_ticker = yf.Ticker(ticker)
+            info: dict[str, Any] = yf_ticker.info
+
+            name = info.get("shortName") or info.get("longName") or ticker
+            sector = info.get("sector")
+            industry = info.get("industry")
+
+            ticker_info = TickerInfo(
+                ticker=ticker,
+                name=str(name),
+                sector=str(sector) if sector else None,
+                industry=str(industry) if industry else None,
+                asset_class="equity",
+            )
+
+            logger.debug(
+                "Ticker info fetched",
+                ticker=ticker,
+                name=ticker_info.name,
+                sector=ticker_info.sector,
+            )
+
+            return ticker_info
+
+        except Exception as e:
+            logger.error(
+                "Failed to fetch ticker info",
+                ticker=ticker,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            raise DataProviderError(
+                f"Failed to fetch ticker info for {ticker}: {e}",
+                code="PROVIDER_TICKER_INFO_ERROR",
+                cause=e,
+            ) from e
+
+    def get_ticker_infos(self, tickers: list[str]) -> dict[str, TickerInfo]:
+        """複数ティッカーの情報を一括取得.
+
+        Parameters
+        ----------
+        tickers : list[str]
+            ティッカーシンボルのリスト（例: ["AAPL", "GOOGL", "MSFT"]）
+
+        Returns
+        -------
+        dict[str, TickerInfo]
+            ティッカーシンボルをキー、TickerInfo を値とする辞書。
+
+        Examples
+        --------
+        >>> provider = MarketAnalysisProvider()
+        >>> infos = provider.get_ticker_infos(["AAPL", "GOOGL"])
+        >>> infos["AAPL"].name
+        'Apple Inc.'
+        """
+        logger.debug("Fetching ticker infos", tickers=tickers)
+
+        result: dict[str, TickerInfo] = {}
+
+        for ticker in tickers:
+            try:
+                result[ticker] = self.get_ticker_info(ticker)
+            except DataProviderError:
+                # Re-raise to preserve the error
+                raise
+            except Exception as e:
+                raise DataProviderError(
+                    f"Failed to fetch ticker info for {ticker}: {e}",
+                    code="PROVIDER_TICKER_INFO_ERROR",
+                    cause=e,
+                ) from e
+
+        logger.info(
+            "Ticker infos fetched",
+            tickers=tickers,
+            count=len(result),
+        )
+
+        return result
+
+
+__all__ = ["MarketAnalysisProvider"]

--- a/tests/strategy/integration/providers/__init__.py
+++ b/tests/strategy/integration/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for strategy providers."""

--- a/tests/strategy/integration/providers/test_market_analysis.py
+++ b/tests/strategy/integration/providers/test_market_analysis.py
@@ -1,0 +1,89 @@
+"""Integration tests for MarketAnalysisProvider.
+
+このテストファイルは、MarketAnalysisProvider が実際の yfinance API を
+使用してデータを取得できることを確認します。
+
+Note:
+    これらのテストは実際の API 呼び出しを行うため、ネットワーク接続が必要です。
+    CI 環境では skip される可能性があります。
+"""
+
+import pandas as pd
+import pytest
+
+from strategy.providers.market_analysis import MarketAnalysisProvider
+from strategy.providers.protocol import DataProvider
+from strategy.types import TickerInfo
+
+
+@pytest.mark.integration
+class TestMarketAnalysisProviderIntegration:
+    """MarketAnalysisProvider の統合テスト."""
+
+    def test_正常系_実データでDataProviderプロトコルを満たす(self) -> None:
+        """実際の API を使用して DataProvider プロトコルを満たすことを確認."""
+        provider = MarketAnalysisProvider(use_cache=False)
+        assert isinstance(provider, DataProvider)
+
+    def test_正常系_実データで価格データを取得(self) -> None:
+        """実際の yfinance API から価格データを取得できることを確認."""
+        provider = MarketAnalysisProvider(use_cache=False)
+
+        # 短い期間で少量のデータを取得
+        df = provider.get_prices(
+            tickers=["AAPL"],
+            start="2024-01-01",
+            end="2024-01-31",
+        )
+
+        # 基本的な検証
+        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df.columns, pd.MultiIndex)
+        assert "ticker" in df.columns.names
+        assert "price_type" in df.columns.names
+
+        # ティッカーが含まれていること
+        tickers = df.columns.get_level_values("ticker").unique()
+        assert "AAPL" in tickers
+
+        # OHLCV カラムが存在すること
+        price_types = df.columns.get_level_values("price_type").unique()
+        assert "close" in price_types
+
+    def test_正常系_実データで複数銘柄の価格データを取得(self) -> None:
+        """複数銘柄の価格データを取得できることを確認."""
+        provider = MarketAnalysisProvider(use_cache=False)
+
+        df = provider.get_prices(
+            tickers=["AAPL", "GOOGL"],
+            start="2024-01-01",
+            end="2024-01-31",
+        )
+
+        # 両方のティッカーが含まれていること
+        tickers = df.columns.get_level_values("ticker").unique()
+        assert "AAPL" in tickers
+        assert "GOOGL" in tickers
+
+    def test_正常系_実データで銘柄情報を取得(self) -> None:
+        """実際の yfinance API から銘柄情報を取得できることを確認."""
+        provider = MarketAnalysisProvider()
+
+        info = provider.get_ticker_info("AAPL")
+
+        assert isinstance(info, TickerInfo)
+        assert info.ticker == "AAPL"
+        assert info.name is not None
+        assert len(info.name) > 0
+
+    def test_正常系_実データで複数銘柄情報を一括取得(self) -> None:
+        """複数銘柄の情報を一括取得できることを確認."""
+        provider = MarketAnalysisProvider()
+
+        infos = provider.get_ticker_infos(["AAPL", "MSFT"])
+
+        assert isinstance(infos, dict)
+        assert "AAPL" in infos
+        assert "MSFT" in infos
+        assert isinstance(infos["AAPL"], TickerInfo)
+        assert isinstance(infos["MSFT"], TickerInfo)

--- a/tests/strategy/unit/providers/test_market_analysis.py
+++ b/tests/strategy/unit/providers/test_market_analysis.py
@@ -1,0 +1,553 @@
+"""Unit tests for MarketAnalysisProvider.
+
+このテストファイルは、strategy パッケージの MarketAnalysisProvider の実装を検証します。
+
+テストTODO:
+- [x] MarketAnalysisProvider クラスが実装されている
+- [x] DataProvider Protocol を満たしている
+- [x] get_prices() で market_analysis の YFinanceFetcher を使用
+- [x] get_ticker_info() で銘柄情報を取得
+- [x] get_ticker_infos() で複数銘柄情報を一括取得
+- [x] market_analysis のエラーを DataProviderError に変換
+- [x] キャッシュ設定を使用
+
+Note: 統合テストは tests/strategy/integration/providers/test_market_analysis.py に配置
+"""
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from market_analysis.errors import DataFetchError, ErrorCode
+from market_analysis.types import DataSource, FetchOptions, MarketDataResult
+from strategy.errors import DataProviderError
+from strategy.providers.market_analysis import MarketAnalysisProvider
+from strategy.providers.protocol import DataProvider
+from strategy.types import TickerInfo
+
+
+class TestMarketAnalysisProviderProtocol:
+    """MarketAnalysisProvider が DataProvider Protocol を満たすことを確認するテスト。"""
+
+    def test_正常系_DataProviderプロトコルを満たす(self) -> None:
+        """MarketAnalysisProvider が DataProvider のインスタンスとして認識されることを確認。"""
+        provider = MarketAnalysisProvider()
+
+        assert isinstance(provider, DataProvider)
+
+    def test_正常系_get_pricesメソッドが存在する(self) -> None:
+        """MarketAnalysisProvider に get_prices メソッドが存在することを確認。"""
+        provider = MarketAnalysisProvider()
+
+        assert hasattr(provider, "get_prices")
+        assert callable(getattr(provider, "get_prices", None))
+
+    def test_正常系_get_ticker_infoメソッドが存在する(self) -> None:
+        """MarketAnalysisProvider に get_ticker_info メソッドが存在することを確認。"""
+        provider = MarketAnalysisProvider()
+
+        assert hasattr(provider, "get_ticker_info")
+        assert callable(getattr(provider, "get_ticker_info", None))
+
+    def test_正常系_get_ticker_infosメソッドが存在する(self) -> None:
+        """MarketAnalysisProvider に get_ticker_infos メソッドが存在することを確認。"""
+        provider = MarketAnalysisProvider()
+
+        assert hasattr(provider, "get_ticker_infos")
+        assert callable(getattr(provider, "get_ticker_infos", None))
+
+
+class TestGetPrices:
+    """get_prices メソッドのテスト。"""
+
+    def setup_method(self) -> None:
+        """テストのセットアップ。"""
+        self.provider = MarketAnalysisProvider()
+        self.tickers = ["AAPL", "GOOGL"]
+        self.start = "2024-01-01"
+        self.end = "2024-12-31"
+
+    def _create_mock_result(
+        self,
+        symbol: str,
+        data: pd.DataFrame | None = None,
+    ) -> MarketDataResult:
+        """テスト用のモック MarketDataResult を作成。"""
+        if data is None:
+            dates = pd.date_range("2024-01-01", periods=5, freq="D")
+            data = pd.DataFrame(
+                {
+                    "open": [100.0] * 5,
+                    "high": [105.0] * 5,
+                    "low": [95.0] * 5,
+                    "close": [102.0] * 5,
+                    "volume": [1000000] * 5,
+                },
+                index=dates,
+            )
+        return MarketDataResult(
+            symbol=symbol,
+            data=data,
+            source=DataSource.YFINANCE,
+            fetched_at=datetime.now(),
+            from_cache=False,
+        )
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_正常系_get_pricesで価格データを取得(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """get_prices で YFinanceFetcher を使用して価格データを取得することを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+        mock_fetcher.fetch.return_value = [
+            self._create_mock_result("AAPL"),
+            self._create_mock_result("GOOGL"),
+        ]
+
+        provider = MarketAnalysisProvider()
+
+        # Act
+        result = provider.get_prices(self.tickers, self.start, self.end)
+
+        # Assert
+        assert isinstance(result, pd.DataFrame)
+        mock_fetcher.fetch.assert_called_once()
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_正常系_戻り値がMultiIndexDataFrameである(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """get_prices の戻り値が MultiIndex DataFrame であることを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+        mock_fetcher.fetch.return_value = [
+            self._create_mock_result("AAPL"),
+            self._create_mock_result("GOOGL"),
+        ]
+
+        provider = MarketAnalysisProvider()
+
+        # Act
+        result = provider.get_prices(self.tickers, self.start, self.end)
+
+        # Assert
+        assert isinstance(result.columns, pd.MultiIndex)
+        assert "ticker" in result.columns.names
+        assert "price_type" in result.columns.names
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_正常系_OHLCVカラムが含まれる(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """get_prices の戻り値に OHLCV カラムが含まれることを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+        mock_fetcher.fetch.return_value = [
+            self._create_mock_result("AAPL"),
+            self._create_mock_result("GOOGL"),
+        ]
+
+        provider = MarketAnalysisProvider()
+
+        # Act
+        result = provider.get_prices(self.tickers, self.start, self.end)
+
+        # Assert
+        price_types = result.columns.get_level_values("price_type").unique()
+        expected_types = {"open", "high", "low", "close", "volume"}
+        assert set(price_types) == expected_types
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_正常系_指定したティッカーが含まれる(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """get_prices の戻り値に指定したティッカーが含まれることを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+        mock_fetcher.fetch.return_value = [
+            self._create_mock_result("AAPL"),
+            self._create_mock_result("GOOGL"),
+        ]
+
+        provider = MarketAnalysisProvider()
+
+        # Act
+        result = provider.get_prices(self.tickers, self.start, self.end)
+
+        # Assert
+        tickers_in_result = result.columns.get_level_values("ticker").unique()
+        assert set(tickers_in_result) == set(self.tickers)
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_正常系_FetchOptionsに正しいパラメータが渡される(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """get_prices が FetchOptions に正しいパラメータを渡すことを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+        mock_fetcher.fetch.return_value = [
+            self._create_mock_result("AAPL"),
+        ]
+
+        provider = MarketAnalysisProvider()
+
+        # Act
+        provider.get_prices(["AAPL"], "2024-01-01", "2024-06-30")
+
+        # Assert
+        call_args = mock_fetcher.fetch.call_args
+        options: FetchOptions = call_args[0][0]
+        assert options.symbols == ["AAPL"]
+        assert "2024-01-01" in str(options.start_date)
+        assert "2024-06-30" in str(options.end_date)
+
+
+class TestGetTickerInfo:
+    """get_ticker_info メソッドのテスト。"""
+
+    def setup_method(self) -> None:
+        """テストのセットアップ。"""
+        self.provider = MarketAnalysisProvider()
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    def test_正常系_get_ticker_infoで銘柄情報を取得(
+        self,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """get_ticker_info で yfinance から銘柄情報を取得することを確認。"""
+        # Arrange
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        mock_ticker.info = {
+            "symbol": "AAPL",
+            "shortName": "Apple Inc.",
+            "sector": "Technology",
+            "industry": "Consumer Electronics",
+        }
+
+        # Act
+        result = self.provider.get_ticker_info("AAPL")
+
+        # Assert
+        assert isinstance(result, TickerInfo)
+        assert result.ticker == "AAPL"
+        assert result.name == "Apple Inc."
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    def test_正常系_sectorとindustryが設定される(
+        self,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """get_ticker_info で sector と industry が設定されることを確認。"""
+        # Arrange
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        mock_ticker.info = {
+            "symbol": "AAPL",
+            "shortName": "Apple Inc.",
+            "sector": "Technology",
+            "industry": "Consumer Electronics",
+        }
+
+        # Act
+        result = self.provider.get_ticker_info("AAPL")
+
+        # Assert
+        assert result.sector == "Technology"
+        assert result.industry == "Consumer Electronics"
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    def test_正常系_asset_classがequityに設定される(
+        self,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """get_ticker_info で asset_class がデフォルトで equity に設定されることを確認。"""
+        # Arrange
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        mock_ticker.info = {
+            "symbol": "AAPL",
+            "shortName": "Apple Inc.",
+        }
+
+        # Act
+        result = self.provider.get_ticker_info("AAPL")
+
+        # Assert
+        assert result.asset_class == "equity"
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    def test_正常系_infoがNoneの場合でも動作する(
+        self,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """yfinance の info が空でも TickerInfo を返すことを確認。"""
+        # Arrange
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        mock_ticker.info = {}
+
+        # Act
+        result = self.provider.get_ticker_info("AAPL")
+
+        # Assert
+        assert isinstance(result, TickerInfo)
+        assert result.ticker == "AAPL"
+
+
+class TestGetTickerInfos:
+    """get_ticker_infos メソッドのテスト。"""
+
+    def setup_method(self) -> None:
+        """テストのセットアップ。"""
+        self.provider = MarketAnalysisProvider()
+        self.tickers = ["AAPL", "GOOGL", "MSFT"]
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    def test_正常系_get_ticker_infosで複数銘柄情報を一括取得(
+        self,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """get_ticker_infos で複数銘柄の情報を一括取得することを確認。"""
+
+        # Arrange
+        def create_mock_info(symbol: str) -> dict[str, Any]:
+            return {
+                "symbol": symbol,
+                "shortName": f"{symbol} Inc.",
+                "sector": "Technology",
+                "industry": "Software",
+            }
+
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        # 各呼び出しで異なる info を返す
+        mock_ticker.info = create_mock_info("AAPL")
+
+        # Act
+        result = self.provider.get_ticker_infos(self.tickers)
+
+        # Assert
+        assert isinstance(result, dict)
+        assert len(result) == len(self.tickers)
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    def test_正常系_全てのティッカーが辞書のキーに含まれる(
+        self,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """get_ticker_infos の戻り値に全てのティッカーがキーとして含まれることを確認。"""
+        # Arrange
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        mock_ticker.info = {
+            "symbol": "AAPL",
+            "shortName": "Apple Inc.",
+        }
+
+        # Act
+        result = self.provider.get_ticker_infos(self.tickers)
+
+        # Assert
+        assert set(result.keys()) == set(self.tickers)
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    def test_正常系_各値がTickerInfoである(
+        self,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """get_ticker_infos の各値が TickerInfo であることを確認。"""
+        # Arrange
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        mock_ticker.info = {
+            "symbol": "AAPL",
+            "shortName": "Apple Inc.",
+        }
+
+        # Act
+        result = self.provider.get_ticker_infos(self.tickers)
+
+        # Assert
+        for ticker, info in result.items():
+            assert isinstance(info, TickerInfo)
+
+
+class TestErrorHandling:
+    """エラーハンドリングのテスト。"""
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_異常系_DataFetchErrorをDataProviderErrorに変換(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """market_analysis の DataFetchError を DataProviderError に変換することを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+        mock_fetcher.fetch.side_effect = DataFetchError(
+            "Failed to fetch data",
+            symbol="AAPL",
+            source="yfinance",
+            code=ErrorCode.API_ERROR,
+        )
+
+        # Provider を patch 適用後に作成
+        provider = MarketAnalysisProvider()
+
+        # Act & Assert
+        with pytest.raises(DataProviderError) as exc_info:
+            provider.get_prices(["AAPL"], "2024-01-01", "2024-12-31")
+
+        assert exc_info.value.cause is not None
+        assert isinstance(exc_info.value.cause, DataFetchError)
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_異常系_エラーメッセージが適切に設定される(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """DataProviderError のエラーメッセージが適切に設定されることを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+        original_error = DataFetchError(
+            "Network connection failed",
+            symbol="AAPL",
+            source="yfinance",
+            code=ErrorCode.NETWORK_ERROR,
+        )
+        mock_fetcher.fetch.side_effect = original_error
+
+        # Provider を patch 適用後に作成
+        provider = MarketAnalysisProvider()
+
+        # Act & Assert
+        with pytest.raises(DataProviderError) as exc_info:
+            provider.get_prices(["AAPL"], "2024-01-01", "2024-12-31")
+
+        # エラーメッセージに元のエラー情報が含まれていることを確認
+        assert "AAPL" in str(exc_info.value.message) or exc_info.value.cause is not None
+
+    @patch("strategy.providers.market_analysis.yf.Ticker")
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_異常系_get_ticker_infoでExceptionをDataProviderErrorに変換(
+        self,
+        mock_fetcher_class: MagicMock,
+        mock_ticker_class: MagicMock,
+    ) -> None:
+        """get_ticker_info で発生した Exception を DataProviderError に変換することを確認。"""
+        # Arrange
+        mock_ticker = MagicMock()
+        mock_ticker_class.return_value = mock_ticker
+        # info プロパティへのアクセスで例外を発生させる
+        type(mock_ticker).info = property(
+            fget=MagicMock(side_effect=Exception("API error"))
+        )
+
+        # Provider を patch 適用後に作成
+        provider = MarketAnalysisProvider()
+
+        # Act & Assert
+        with pytest.raises(DataProviderError):
+            provider.get_ticker_info("INVALID")
+
+
+class TestCacheConfiguration:
+    """キャッシュ設定のテスト。"""
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_正常系_キャッシュ有効でFetchOptionsのuse_cacheがTrue(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """キャッシュ有効時に FetchOptions.use_cache が True であることを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+
+        dates = pd.date_range("2024-01-01", periods=5, freq="D")
+        mock_data = pd.DataFrame(
+            {
+                "open": [100.0] * 5,
+                "high": [105.0] * 5,
+                "low": [95.0] * 5,
+                "close": [102.0] * 5,
+                "volume": [1000000] * 5,
+            },
+            index=dates,
+        )
+        mock_fetcher.fetch.return_value = [
+            MarketDataResult(
+                symbol="AAPL",
+                data=mock_data,
+                source=DataSource.YFINANCE,
+                fetched_at=datetime.now(),
+                from_cache=False,
+            )
+        ]
+
+        provider = MarketAnalysisProvider(use_cache=True)
+
+        # Act
+        provider.get_prices(["AAPL"], "2024-01-01", "2024-12-31")
+
+        # Assert
+        call_args = mock_fetcher.fetch.call_args
+        options: FetchOptions = call_args[0][0]
+        assert options.use_cache is True
+
+    @patch("strategy.providers.market_analysis.YFinanceFetcher")
+    def test_正常系_キャッシュ無効でFetchOptionsのuse_cacheがFalse(
+        self,
+        mock_fetcher_class: MagicMock,
+    ) -> None:
+        """キャッシュ無効時に FetchOptions.use_cache が False であることを確認。"""
+        # Arrange
+        mock_fetcher = MagicMock()
+        mock_fetcher_class.return_value = mock_fetcher
+
+        dates = pd.date_range("2024-01-01", periods=5, freq="D")
+        mock_data = pd.DataFrame(
+            {
+                "open": [100.0] * 5,
+                "high": [105.0] * 5,
+                "low": [95.0] * 5,
+                "close": [102.0] * 5,
+                "volume": [1000000] * 5,
+            },
+            index=dates,
+        )
+        mock_fetcher.fetch.return_value = [
+            MarketDataResult(
+                symbol="AAPL",
+                data=mock_data,
+                source=DataSource.YFINANCE,
+                fetched_at=datetime.now(),
+                from_cache=False,
+            )
+        ]
+
+        provider = MarketAnalysisProvider(use_cache=False)
+
+        # Act
+        provider.get_prices(["AAPL"], "2024-01-01", "2024-12-31")
+
+        # Assert
+        call_args = mock_fetcher.fetch.call_args
+        options: FetchOptions = call_args[0][0]
+        assert options.use_cache is False


### PR DESCRIPTION
## 概要
- `MarketAnalysisProvider` クラスを実装
- market_analysis パッケージの `YFinanceFetcher` をラップ
- `DataProvider` Protocol を満たす

## 変更内容
- `src/strategy/providers/market_analysis.py`: MarketAnalysisProvider 実装
- `tests/strategy/unit/providers/test_market_analysis.py`: ユニットテスト (21件)
- `tests/strategy/integration/providers/test_market_analysis.py`: 統合テスト (5件)

## テストプラン
- [x] make check-all が成功することを確認
- [x] ユニットテスト 21件が全てパス
- [x] 統合テスト 5件が全てパス
- [x] pyright strict でエラーなし

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)