### PR TITLE
[factor] T12: ValueFactor (factors/value/value.py)

### DIFF
--- a/src/factor/factors/__init__.py
+++ b/src/factor/factors/__init__.py
@@ -3,11 +3,14 @@
 This package contains factor implementations organized by category:
 - macro: Macroeconomic factors (interest rates, inflation, etc.)
 - quality: Quality factors (ROIC, etc.)
+- value: Value factors (PER, PBR, dividend yield, EV/EBITDA)
 """
 
 from .quality import ROICFactor, ROICTransitionLabeler
+from .value import ValueFactor
 
 __all__ = [
     "ROICFactor",
     "ROICTransitionLabeler",
+    "ValueFactor",
 ]

--- a/src/factor/factors/value/__init__.py
+++ b/src/factor/factors/value/__init__.py
@@ -1,0 +1,19 @@
+"""Value factors package.
+
+This package provides value-based factor implementations including:
+- ValueFactor: Computes valuation metrics (PER, PBR, dividend yield, EV/EBITDA)
+
+Examples
+--------
+>>> from factor.factors.value import ValueFactor
+>>>
+>>> # Create a PER-based value factor
+>>> per_factor = ValueFactor(metric="per", invert=True)
+>>>
+>>> # Create a dividend yield factor
+>>> div_factor = ValueFactor(metric="dividend_yield", invert=False)
+"""
+
+from .value import ValueFactor
+
+__all__ = ["ValueFactor"]

--- a/src/factor/factors/value/value.py
+++ b/src/factor/factors/value/value.py
@@ -1,0 +1,302 @@
+"""ValueFactor module for computing value-based factor values.
+
+This module provides ValueFactor class that computes various value metrics
+including PER, PBR, dividend yield, and EV/EBITDA.
+
+Classes
+-------
+ValueFactor
+    Factor implementation for value-based metrics.
+
+Examples
+--------
+>>> from factor.factors.value import ValueFactor
+>>> from factor.providers import YFinanceProvider
+>>>
+>>> provider = YFinanceProvider()
+>>> factor = ValueFactor(metric="per", invert=True)
+>>> result = factor.compute(
+...     provider=provider,
+...     universe=["AAPL", "GOOGL", "MSFT"],
+...     start_date="2024-01-01",
+...     end_date="2024-12-31",
+... )
+>>> result.columns.tolist()
+['AAPL', 'GOOGL', 'MSFT']
+"""
+
+from datetime import datetime
+from typing import Literal
+
+import pandas as pd
+
+from factor.core.base import Factor
+from factor.enums import FactorCategory
+from factor.errors import ValidationError
+from factor.providers.base import DataProvider
+from factor.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Valid metrics for ValueFactor
+ValueMetric = Literal["per", "pbr", "dividend_yield", "ev_ebitda"]
+
+
+class ValueFactor(Factor):
+    """Value factor for computing valuation metrics.
+
+    Computes value-based factor values such as PER, PBR, dividend yield,
+    and EV/EBITDA. Lower values typically indicate undervaluation (except
+    for dividend yield where higher is better).
+
+    Parameters
+    ----------
+    metric : str, default="per"
+        The valuation metric to compute. Must be one of:
+        - "per": Price-to-Earnings Ratio
+        - "pbr": Price-to-Book Ratio
+        - "dividend_yield": Dividend Yield
+        - "ev_ebitda": Enterprise Value to EBITDA
+    invert : bool, default=True
+        Whether to invert the factor values. When True, lower raw values
+        result in higher factor scores (e.g., low PER = high value score).
+        Set to False for metrics where higher is better (like dividend yield).
+
+    Attributes
+    ----------
+    name : str
+        Factor name, always "value".
+    description : str
+        Human-readable description of the factor.
+    category : FactorCategory
+        Factor category, always FactorCategory.VALUE.
+    metric : str
+        The valuation metric being computed.
+    invert : bool
+        Whether factor values are inverted.
+    VALID_METRICS : tuple[str, ...]
+        Class attribute containing valid metric names.
+
+    Raises
+    ------
+    ValidationError
+        If metric is not one of VALID_METRICS.
+
+    Examples
+    --------
+    >>> factor = ValueFactor(metric="per", invert=True)
+    >>> factor.metric
+    'per'
+    >>> factor.invert
+    True
+
+    >>> # For dividend yield, higher is better
+    >>> div_factor = ValueFactor(metric="dividend_yield", invert=False)
+
+    Notes
+    -----
+    The invert parameter controls the direction of factor scores:
+    - For PER/PBR/EV-EBITDA: invert=True (low values = good)
+    - For dividend yield: invert=False (high values = good)
+
+    References
+    ----------
+    Fama, E. F., & French, K. R. (1993). Common risk factors in the returns
+    on stocks and bonds. Journal of Financial Economics, 33(1), 3-56.
+    """
+
+    # Class attributes required by Factor base class
+    name: str = "value"
+    description: str = "Value factor computing valuation metrics (PER, PBR, etc.)"
+    category: FactorCategory = FactorCategory.VALUE
+
+    # Class constant for valid metrics
+    VALID_METRICS: tuple[str, ...] = ("per", "pbr", "dividend_yield", "ev_ebitda")
+
+    # Optional class attributes for metadata customization
+    _required_data: list[str] = ["fundamentals"]
+    _frequency: str = "daily"
+    _lookback_period: int | None = None
+    _higher_is_better: bool = True  # After inversion, higher is better
+    _default_parameters: dict[str, int | float] = {}
+
+    def __init__(
+        self,
+        metric: str = "per",
+        invert: bool = True,
+    ) -> None:
+        """Initialize ValueFactor with the specified metric.
+
+        Parameters
+        ----------
+        metric : str, default="per"
+            The valuation metric to compute.
+        invert : bool, default=True
+            Whether to invert factor values.
+
+        Raises
+        ------
+        ValidationError
+            If metric is not a valid metric name.
+        """
+        logger.debug(
+            "Initializing ValueFactor",
+            metric=metric,
+            invert=invert,
+        )
+
+        if metric not in self.VALID_METRICS:
+            logger.error(
+                "Invalid metric specified",
+                metric=metric,
+                valid_metrics=self.VALID_METRICS,
+            )
+            raise ValidationError(
+                f"metric must be one of {self.VALID_METRICS}, got '{metric}'",
+                field="metric",
+                value=metric,
+            )
+
+        self.metric = metric
+        self.invert = invert
+
+        logger.info(
+            "ValueFactor initialized",
+            metric=metric,
+            invert=invert,
+        )
+
+    def compute(
+        self,
+        provider: DataProvider,
+        universe: list[str],
+        start_date: datetime | str,
+        end_date: datetime | str,
+    ) -> pd.DataFrame:
+        """Compute value factor values for the specified universe and date range.
+
+        Fetches fundamental data from the provider and computes factor values
+        based on the configured metric. If invert is True, the values are
+        negated so that lower raw values result in higher factor scores.
+
+        Parameters
+        ----------
+        provider : DataProvider
+            Data provider implementing the DataProvider protocol.
+        universe : list[str]
+            List of ticker symbols to compute factors for.
+        start_date : datetime | str
+            Start date for the computation period.
+            Accepts datetime object or ISO format string (e.g., "2024-01-01").
+        end_date : datetime | str
+            End date for the computation period.
+            Accepts datetime object or ISO format string (e.g., "2024-12-31").
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with factor values:
+            - Index: DatetimeIndex named "Date"
+            - Columns: symbol names from universe
+            - Values: float64 factor values
+
+        Raises
+        ------
+        ValidationError
+            If universe is empty or date range is invalid.
+
+        Examples
+        --------
+        >>> provider = SomeDataProvider()
+        >>> factor = ValueFactor(metric="per", invert=True)
+        >>> result = factor.compute(
+        ...     provider=provider,
+        ...     universe=["AAPL", "GOOGL"],
+        ...     start_date="2024-01-01",
+        ...     end_date="2024-12-31",
+        ... )
+        >>> result.index.name
+        'Date'
+        >>> list(result.columns)
+        ['AAPL', 'GOOGL']
+        """
+        logger.debug(
+            "Computing ValueFactor",
+            metric=self.metric,
+            invert=self.invert,
+            universe_size=len(universe),
+            start_date=str(start_date),
+            end_date=str(end_date),
+        )
+
+        # Validate inputs using base class method
+        self.validate_inputs(universe, start_date, end_date)
+
+        # Fetch fundamental data from provider
+        logger.debug(
+            "Fetching fundamentals data",
+            symbols=universe,
+            metrics=[self.metric],
+        )
+        fundamentals = provider.get_fundamentals(
+            symbols=universe,
+            metrics=[self.metric],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        # Extract the metric values for each symbol
+        # fundamentals has MultiIndex columns: (symbol, metric)
+        result_data: dict[str, pd.Series] = {}
+
+        for symbol in universe:
+            try:
+                # Access the specific symbol and metric from MultiIndex
+                # Cast to Series since we're accessing a single column
+                symbol_data = fundamentals[(symbol, self.metric)]
+                if isinstance(symbol_data, pd.Series):
+                    result_data[symbol] = symbol_data
+                else:
+                    # Handle edge case where it might be DataFrame
+                    result_data[symbol] = pd.Series(
+                        index=fundamentals.index,
+                        dtype=float,
+                    )
+            except KeyError:
+                logger.warning(
+                    "Symbol data not found in fundamentals",
+                    symbol=symbol,
+                    metric=self.metric,
+                )
+                # Create a series of NaN values
+                result_data[symbol] = pd.Series(
+                    index=fundamentals.index,
+                    dtype=float,
+                )
+
+        # Create result DataFrame
+        result = pd.DataFrame(result_data)
+
+        # Ensure index is named "Date"
+        result.index.name = "Date"
+
+        # Apply inversion if configured
+        if self.invert:
+            logger.debug("Applying factor inversion")
+            result = -result
+
+        # Ensure column order matches universe and return as DataFrame
+        # Use .loc for proper DataFrame return type
+        ordered_result = result.loc[:, universe]
+
+        logger.info(
+            "ValueFactor computation completed",
+            metric=self.metric,
+            rows=len(ordered_result),
+            columns=len(ordered_result.columns),
+        )
+
+        return ordered_result
+
+
+__all__ = ["ValueFactor"]

--- a/tests/factor/unit/factors/value/__init__.py
+++ b/tests/factor/unit/factors/value/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for value factor module."""

--- a/tests/factor/unit/factors/value/test_value.py
+++ b/tests/factor/unit/factors/value/test_value.py
@@ -1,0 +1,740 @@
+"""Unit tests for ValueFactor class.
+
+ValueFactorはPER、PBR、配当利回り、EV/EBITDAなどの
+バリュー指標を計算するファクタークラスである。
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# AIDEV-NOTE: 実装が存在しないため、インポートは失敗する（Red状態）
+# pytest.importorskipを使用して、実装後に自動的にテストが有効になる
+value_module = pytest.importorskip("factor.factors.value.value")
+ValueFactor = value_module.ValueFactor
+
+
+class TestValueFactorInheritance:
+    """ValueFactorがFactor基底クラスを正しく継承していることのテスト。"""
+
+    def test_正常系_Factor基底クラスを継承している(self) -> None:
+        """ValueFactorがFactor基底クラスを継承していることを確認。"""
+        from factor.core.base import Factor
+
+        factor = ValueFactor()
+        assert isinstance(factor, Factor)
+
+    def test_正常系_name属性が定義されている(self) -> None:
+        """ValueFactorにname属性が定義されていることを確認。"""
+        factor = ValueFactor()
+        assert hasattr(factor, "name")
+        assert factor.name == "value"
+
+    def test_正常系_description属性が定義されている(self) -> None:
+        """ValueFactorにdescription属性が定義されていることを確認。"""
+        factor = ValueFactor()
+        assert hasattr(factor, "description")
+        assert len(factor.description) > 0
+
+    def test_正常系_category属性がVALUEである(self) -> None:
+        """ValueFactorのcategoryがFactorCategory.VALUEであることを確認。"""
+        from factor.enums import FactorCategory
+
+        factor = ValueFactor()
+        assert factor.category == FactorCategory.VALUE
+
+    def test_正常系_computeメソッドが実装されている(self) -> None:
+        """ValueFactorにcomputeメソッドが実装されていることを確認。"""
+        factor = ValueFactor()
+        assert hasattr(factor, "compute")
+        assert callable(factor.compute)
+
+    def test_正常系_validate_inputsメソッドが使用可能(self) -> None:
+        """ValueFactorでvalidate_inputsメソッドが使用可能であることを確認。"""
+        factor = ValueFactor()
+        assert hasattr(factor, "validate_inputs")
+        assert callable(factor.validate_inputs)
+
+
+class TestValueFactorInit:
+    """ValueFactor初期化のテスト。"""
+
+    def test_正常系_デフォルト値で初期化される(self) -> None:
+        """デフォルトのmetric(per)とinvert(True)で初期化されることを確認。"""
+        factor = ValueFactor()
+        assert factor.metric == "per"
+        assert factor.invert is True
+
+    def test_正常系_metricにperを指定できる(self) -> None:
+        """metric='per'で初期化できることを確認。"""
+        factor = ValueFactor(metric="per")
+        assert factor.metric == "per"
+
+    def test_正常系_metricにpbrを指定できる(self) -> None:
+        """metric='pbr'で初期化できることを確認。"""
+        factor = ValueFactor(metric="pbr")
+        assert factor.metric == "pbr"
+
+    def test_正常系_metricにdividend_yieldを指定できる(self) -> None:
+        """metric='dividend_yield'で初期化できることを確認。"""
+        factor = ValueFactor(metric="dividend_yield")
+        assert factor.metric == "dividend_yield"
+
+    def test_正常系_metricにev_ebitdaを指定できる(self) -> None:
+        """metric='ev_ebitda'で初期化できることを確認。"""
+        factor = ValueFactor(metric="ev_ebitda")
+        assert factor.metric == "ev_ebitda"
+
+    def test_正常系_invertにFalseを指定できる(self) -> None:
+        """invert=Falseで初期化できることを確認。"""
+        factor = ValueFactor(invert=False)
+        assert factor.invert is False
+
+    def test_正常系_metricとinvertを同時に指定できる(self) -> None:
+        """metricとinvertを同時に指定できることを確認。"""
+        factor = ValueFactor(metric="pbr", invert=False)
+        assert factor.metric == "pbr"
+        assert factor.invert is False
+
+    def test_異常系_無効なmetricでValidationError(self) -> None:
+        """無効なmetricを指定するとValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            ValueFactor(metric="invalid_metric")
+
+    def test_異常系_空文字metricでValidationError(self) -> None:
+        """空文字のmetricを指定するとValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            ValueFactor(metric="")
+
+    def test_正常系_VALID_METRICS定数が定義されている(self) -> None:
+        """VALID_METRICS定数が正しく定義されていることを確認。"""
+        assert hasattr(ValueFactor, "VALID_METRICS")
+        expected_metrics = ("per", "pbr", "dividend_yield", "ev_ebitda")
+        assert expected_metrics == ValueFactor.VALID_METRICS
+
+
+class TestValueFactorComputePER:
+    """ValueFactor.compute()のPER計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = ValueFactor(metric="per", invert=True)
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        # MultiIndex DataFrame構造を作成
+        # Index: Date, Columns: (symbol, metric)
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["per"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_PERファクター値が計算される(self) -> None:
+        """PERファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+        symbols = ["AAPL", "GOOGL", "MSFT"]
+        values = {
+            "AAPL": [15.0, 16.0, 17.0],
+            "GOOGL": [20.0, 21.0, 22.0],
+            "MSFT": [25.0, 26.0, 27.0],
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-03",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 3  # 3日分
+        assert list(result.columns) == symbols
+
+    def test_正常系_invertがTrueの場合符号が反転する(self) -> None:
+        """invert=Trueの場合、ファクター値の符号が反転することを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        values = {"AAPL": [15.0, 15.0], "GOOGL": [30.0, 30.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor_inverted = ValueFactor(metric="per", invert=True)
+        result = factor_inverted.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 低PER（AAPL=15）の方が高スコアになる
+        assert result.loc["2024-01-01", "AAPL"] > result.loc["2024-01-01", "GOOGL"]
+
+    def test_正常系_invertがFalseの場合符号が反転しない(self) -> None:
+        """invert=Falseの場合、元の値が維持されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        values = {"AAPL": [15.0, 15.0], "GOOGL": [30.0, 30.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor_not_inverted = ValueFactor(metric="per", invert=False)
+        result = factor_not_inverted.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 高PER（GOOGL=30）の方が高スコアになる
+        assert result.loc["2024-01-01", "GOOGL"] > result.loc["2024-01-01", "AAPL"]
+
+
+class TestValueFactorComputePBR:
+    """ValueFactor.compute()のPBR計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = ValueFactor(metric="pbr", invert=True)
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["pbr"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_PBRファクター値が計算される(self) -> None:
+        """PBRファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        values = {
+            "AAPL": [1.5, 1.6],
+            "GOOGL": [2.0, 2.1],
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+    def test_正常系_低PBR銘柄が高スコアになる(self) -> None:
+        """invert=Trueで低PBR銘柄が高スコアになることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["LOW_PBR", "HIGH_PBR"]
+        values = {"LOW_PBR": [0.8, 0.8], "HIGH_PBR": [3.0, 3.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 低PBRの方が高スコア
+        assert (
+            result.loc["2024-01-01", "LOW_PBR"] > result.loc["2024-01-01", "HIGH_PBR"]
+        )
+
+
+class TestValueFactorComputeDividendYield:
+    """ValueFactor.compute()の配当利回り計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        # 配当利回りは高い方が良いのでinvert=False
+        self.factor = ValueFactor(metric="dividend_yield", invert=False)
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["dividend_yield"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_配当利回りファクター値が計算される(self) -> None:
+        """配当利回りファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["HIGH_YIELD", "LOW_YIELD"]
+        values = {"HIGH_YIELD": [0.05, 0.05], "LOW_YIELD": [0.01, 0.01]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+    def test_正常系_高配当利回り銘柄が高スコアになる(self) -> None:
+        """高配当利回り銘柄が高スコアになることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["HIGH_YIELD", "LOW_YIELD"]
+        values = {"HIGH_YIELD": [0.05, 0.05], "LOW_YIELD": [0.01, 0.01]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 高配当利回りの方が高スコア
+        assert (
+            result.loc["2024-01-01", "HIGH_YIELD"]
+            > result.loc["2024-01-01", "LOW_YIELD"]
+        )
+
+
+class TestValueFactorComputeEVEBITDA:
+    """ValueFactor.compute()のEV/EBITDA計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = ValueFactor(metric="ev_ebitda", invert=True)
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["ev_ebitda"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_EV_EBITDAファクター値が計算される(self) -> None:
+        """EV/EBITDAファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["LOW_EV", "HIGH_EV"]
+        values = {"LOW_EV": [5.0, 5.0], "HIGH_EV": [15.0, 15.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+    def test_正常系_低EV_EBITDA銘柄が高スコアになる(self) -> None:
+        """低EV/EBITDA銘柄が高スコアになることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["LOW_EV", "HIGH_EV"]
+        values = {"LOW_EV": [5.0, 5.0], "HIGH_EV": [15.0, 15.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 低EV/EBITDAの方が高スコア
+        assert result.loc["2024-01-01", "LOW_EV"] > result.loc["2024-01-01", "HIGH_EV"]
+
+    def test_正常系_EV_EBITDAデータが欠損の場合NaN(self) -> None:
+        """EV/EBITDAデータが欠損の場合、NaNが返されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["VALID", "MISSING"]
+        values = {"VALID": [10.0, 10.0], "MISSING": [np.nan, np.nan]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert not pd.isna(result.loc["2024-01-01", "VALID"])
+        assert pd.isna(result.loc["2024-01-01", "MISSING"])
+
+
+class TestValueFactorDataFrameFormat:
+    """ValueFactor戻り値のDataFrameフォーマットテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = ValueFactor(metric="per")
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metric: str,
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, [metric]],
+            names=["symbol", "metric"],
+        )
+        np.random.seed(42)
+        data = np.random.rand(len(dates), len(symbols)) * 20 + 5
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_戻り値がDataFrameである(self) -> None:
+        """戻り値がpd.DataFrameであることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_インデックスがDatetimeIndexである(self) -> None:
+        """インデックスがDatetimeIndexであることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result.index, pd.DatetimeIndex)
+
+    def test_正常系_インデックス名がDateである(self) -> None:
+        """インデックス名が'Date'であることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert result.index.name == "Date"
+
+    def test_正常系_カラムがユニバースと一致する(self) -> None:
+        """カラムがユニバースのシンボルと一致することを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL", "MSFT"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert list(result.columns) == symbols
+
+    def test_正常系_値がfloat型である(self) -> None:
+        """ファクター値がfloat型であることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert result.dtypes["AAPL"] is np.float64 or np.issubdtype(
+            result.dtypes["AAPL"], np.floating
+        )
+
+
+class TestValueFactorValidation:
+    """ValueFactor入力バリデーションのテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = ValueFactor(metric="per")
+
+    def _create_mock_provider(self) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        return MagicMock()
+
+    def test_異常系_空のユニバースでValidationError(self) -> None:
+        """空のユニバースでValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+
+        with pytest.raises(ValidationError):
+            self.factor.compute(
+                provider=provider,
+                universe=[],
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+
+    def test_異常系_開始日が終了日より後でValidationError(self) -> None:
+        """開始日が終了日より後の場合、ValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+
+        with pytest.raises(ValidationError):
+            self.factor.compute(
+                provider=provider,
+                universe=["AAPL"],
+                start_date="2024-12-31",
+                end_date="2024-01-01",
+            )
+
+    def test_異常系_開始日と終了日が同じでValidationError(self) -> None:
+        """開始日と終了日が同じ場合、ValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+
+        with pytest.raises(ValidationError):
+            self.factor.compute(
+                provider=provider,
+                universe=["AAPL"],
+                start_date="2024-01-01",
+                end_date="2024-01-01",
+            )
+
+
+class TestValueFactorEdgeCases:
+    """ValueFactorのエッジケーステスト。"""
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metric: str,
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, [metric]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_NaN値を含むデータの処理(self) -> None:
+        """NaN値を含むデータでも正しく処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        values = {
+            "AAPL": [15.0, np.nan],
+            "GOOGL": [20.0, 25.0],
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = ValueFactor(metric="per")
+
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # NaN値を含む行も処理される
+        assert pd.isna(result.loc["2024-01-02", "AAPL"])
+        assert not pd.isna(result.loc["2024-01-02", "GOOGL"])
+
+    def test_正常系_ゼロ値を含むデータの処理(self) -> None:
+        """ゼロ値を含むデータでも正しく処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["ZERO", "POSITIVE"]
+        values = {"ZERO": [0.0, 0.0], "POSITIVE": [10.0, 10.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = ValueFactor(metric="per", invert=True)
+
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # ゼロ値も処理される（エラーにならない）
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_負のPER値を含むデータの処理(self) -> None:
+        """負のPER値（赤字企業）を含むデータでも処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["NEGATIVE", "POSITIVE"]
+        values = {"NEGATIVE": [-5.0, -5.0], "POSITIVE": [15.0, 15.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = ValueFactor(metric="per", invert=True)
+
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_日付文字列とdatetimeの両方を受け付ける(self) -> None:
+        """日付がstr形式とdatetime形式の両方で受け付けられることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        values = {"AAPL": [15.0, 16.0]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "per", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = ValueFactor(metric="per")
+
+        # 文字列形式
+        result_str = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # datetime形式
+        result_dt = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 2),
+        )
+
+        assert isinstance(result_str, pd.DataFrame)
+        assert isinstance(result_dt, pd.DataFrame)
+
+
+class TestValueFactorMetadata:
+    """ValueFactorメタデータのテスト。"""
+
+    def test_正常系_metadataプロパティが存在する(self) -> None:
+        """metadataプロパティが存在することを確認。"""
+        factor = ValueFactor()
+        assert hasattr(factor, "metadata")
+
+    def test_正常系_metadata_nameがvalueである(self) -> None:
+        """metadata.nameが'value'であることを確認。"""
+        factor = ValueFactor()
+        assert factor.metadata.name == "value"
+
+    def test_正常系_metadata_categoryがvalueである(self) -> None:
+        """metadata.categoryが'value'であることを確認。"""
+        factor = ValueFactor()
+        assert factor.metadata.category == "value"
+
+    def test_正常系_metadataがFactorMetadata型である(self) -> None:
+        """metadataがFactorMetadata型であることを確認。"""
+        from factor.core.base import FactorMetadata
+
+        factor = ValueFactor()
+        assert isinstance(factor.metadata, FactorMetadata)


### PR DESCRIPTION
## 概要
- バリューファクター（PER, PBR, 配当利回り, EV/EBITDA）を実装
- Factor 基底クラスを継承し、4つの指標をサポート
- invert パラメータで符号反転（低PER = 高スコア）に対応

Fixes #126

## 変更内容
- `src/factor/factors/value/value.py` - ValueFactor クラス
- `src/factor/factors/value/__init__.py` - パッケージエクスポート
- `src/factor/factors/__init__.py` - ValueFactor をパッケージレベルでエクスポート
- `tests/factor/unit/factors/value/test_value.py` - 42件のユニットテスト

## テストプラン
- [x] make format が成功することを確認
- [x] make lint がエラーなしを確認
- [x] make typecheck がエラーなしを確認
- [x] make test が全テスト（1780件）パスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)