### PR TITLE
[factor] QualityFactor (ROE/ROA/利益安定性/負債比率) を実装

### DIFF
--- a/src/factor/factors/__init__.py
+++ b/src/factor/factors/__init__.py
@@ -3,16 +3,17 @@
 This package contains factor implementations organized by category:
 - macro: Macroeconomic factors (interest rates, inflation, etc.)
 - price: Price-based factors (momentum, etc.)
-- quality: Quality factors (ROIC, etc.)
+- quality: Quality factors (ROE, ROA, ROIC, etc.)
 - value: Value factors (PER, PBR, dividend yield, EV/EBITDA)
 """
 
 from .price import MomentumFactor
-from .quality import ROICFactor, ROICTransitionLabeler
+from .quality import QualityFactor, ROICFactor, ROICTransitionLabeler
 from .value import ValueFactor
 
 __all__ = [
     "MomentumFactor",
+    "QualityFactor",
     "ROICFactor",
     "ROICTransitionLabeler",
     "ValueFactor",

--- a/src/factor/factors/quality/__init__.py
+++ b/src/factor/factors/quality/__init__.py
@@ -1,13 +1,17 @@
 """Quality factor implementations.
 
-This module provides ROIC (Return on Invested Capital) factor calculations
-and transition labeling for factor analysis.
+This module provides quality factor implementations including:
+- QualityFactor: ROE, ROA, earnings stability, debt ratio
+- ROIC (Return on Invested Capital) factor calculations
+- Transition labeling for factor analysis.
 """
 
+from .quality import QualityFactor
 from .roic import ROICFactor
 from .roic_label import ROICTransitionLabeler
 
 __all__ = [
+    "QualityFactor",
     "ROICFactor",
     "ROICTransitionLabeler",
 ]

--- a/src/factor/factors/quality/quality.py
+++ b/src/factor/factors/quality/quality.py
@@ -1,0 +1,288 @@
+"""QualityFactor module for computing quality-based factor values.
+
+This module provides QualityFactor class that computes various quality metrics
+including ROE, ROA, earnings stability, and debt ratio.
+
+Classes
+-------
+QualityFactor
+    Factor implementation for quality-based metrics.
+
+Examples
+--------
+>>> from factor.factors.quality import QualityFactor
+>>> from factor.providers import YFinanceProvider
+>>>
+>>> provider = YFinanceProvider()
+>>> factor = QualityFactor(metric="roe")
+>>> result = factor.compute(
+...     provider=provider,
+...     universe=["AAPL", "GOOGL", "MSFT"],
+...     start_date="2024-01-01",
+...     end_date="2024-12-31",
+... )
+>>> result.columns.tolist()
+['AAPL', 'GOOGL', 'MSFT']
+"""
+
+from datetime import datetime
+from typing import Literal
+
+import pandas as pd
+
+from factor.core.base import Factor
+from factor.enums import FactorCategory
+from factor.errors import ValidationError
+from factor.providers.base import DataProvider
+from factor.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Valid metrics for QualityFactor
+QualityMetric = Literal["roe", "roa", "earnings_stability", "debt_ratio"]
+
+
+class QualityFactor(Factor):
+    """Quality factor for computing quality metrics.
+
+    Computes quality-based factor values such as ROE (Return on Equity),
+    ROA (Return on Assets), earnings stability, and debt ratio.
+    Higher values typically indicate better quality (except for debt ratio
+    where lower is better).
+
+    Parameters
+    ----------
+    metric : str, default="roe"
+        The quality metric to compute. Must be one of:
+        - "roe": Return on Equity
+        - "roa": Return on Assets
+        - "earnings_stability": Earnings stability (inverse of volatility)
+        - "debt_ratio": Debt to assets ratio (inverted so lower debt = higher score)
+
+    Attributes
+    ----------
+    name : str
+        Factor name, always "quality".
+    description : str
+        Human-readable description of the factor.
+    category : FactorCategory
+        Factor category, always FactorCategory.QUALITY.
+    metric : str
+        The quality metric being computed.
+    VALID_METRICS : tuple[str, ...]
+        Class attribute containing valid metric names.
+
+    Raises
+    ------
+    ValidationError
+        If metric is not one of VALID_METRICS.
+
+    Examples
+    --------
+    >>> factor = QualityFactor(metric="roe")
+    >>> factor.metric
+    'roe'
+
+    >>> # For debt ratio, values are inverted (low debt = high score)
+    >>> debt_factor = QualityFactor(metric="debt_ratio")
+
+    Notes
+    -----
+    The factor values are computed as follows:
+    - For ROE/ROA/earnings_stability: higher values = higher scores (no inversion)
+    - For debt_ratio: values are inverted (lower debt = higher score)
+
+    References
+    ----------
+    Novy-Marx, R. (2013). The other side of value: The gross profitability
+    premium. Journal of Financial Economics, 108(1), 1-28.
+    """
+
+    # Class attributes required by Factor base class
+    name: str = "quality"
+    description: str = "Quality factor computing quality metrics (ROE, ROA, etc.)"
+    category: FactorCategory = FactorCategory.QUALITY
+
+    # Class constant for valid metrics
+    VALID_METRICS: tuple[str, ...] = ("roe", "roa", "earnings_stability", "debt_ratio")
+
+    # Optional class attributes for metadata customization
+    _required_data: list[str] = ["fundamentals"]
+    _frequency: str = "daily"
+    _lookback_period: int | None = None
+    _higher_is_better: bool = True
+    _default_parameters: dict[str, int | float] = {}
+
+    def __init__(
+        self,
+        metric: str = "roe",
+    ) -> None:
+        """Initialize QualityFactor with the specified metric.
+
+        Parameters
+        ----------
+        metric : str, default="roe"
+            The quality metric to compute.
+
+        Raises
+        ------
+        ValidationError
+            If metric is not a valid metric name.
+        """
+        logger.debug(
+            "Initializing QualityFactor",
+            metric=metric,
+        )
+
+        if metric not in self.VALID_METRICS:
+            logger.error(
+                "Invalid metric specified",
+                metric=metric,
+                valid_metrics=self.VALID_METRICS,
+            )
+            raise ValidationError(
+                f"metric must be one of {self.VALID_METRICS}, got '{metric}'",
+                field="metric",
+                value=metric,
+            )
+
+        self.metric = metric
+
+        logger.info(
+            "QualityFactor initialized",
+            metric=metric,
+        )
+
+    def compute(
+        self,
+        provider: DataProvider,
+        universe: list[str],
+        start_date: datetime | str,
+        end_date: datetime | str,
+    ) -> pd.DataFrame:
+        """Compute quality factor values for the specified universe and date range.
+
+        Fetches fundamental data from the provider and computes factor values
+        based on the configured metric. For debt_ratio, values are negated
+        so that lower debt results in higher factor scores.
+
+        Parameters
+        ----------
+        provider : DataProvider
+            Data provider implementing the DataProvider protocol.
+        universe : list[str]
+            List of ticker symbols to compute factors for.
+        start_date : datetime | str
+            Start date for the computation period.
+            Accepts datetime object or ISO format string (e.g., "2024-01-01").
+        end_date : datetime | str
+            End date for the computation period.
+            Accepts datetime object or ISO format string (e.g., "2024-12-31").
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with factor values:
+            - Index: DatetimeIndex named "Date"
+            - Columns: symbol names from universe
+            - Values: float64 factor values
+
+        Raises
+        ------
+        ValidationError
+            If universe is empty or date range is invalid.
+
+        Examples
+        --------
+        >>> provider = SomeDataProvider()
+        >>> factor = QualityFactor(metric="roe")
+        >>> result = factor.compute(
+        ...     provider=provider,
+        ...     universe=["AAPL", "GOOGL"],
+        ...     start_date="2024-01-01",
+        ...     end_date="2024-12-31",
+        ... )
+        >>> result.index.name
+        'Date'
+        >>> list(result.columns)
+        ['AAPL', 'GOOGL']
+        """
+        logger.debug(
+            "Computing QualityFactor",
+            metric=self.metric,
+            universe_size=len(universe),
+            start_date=str(start_date),
+            end_date=str(end_date),
+        )
+
+        # Validate inputs using base class method
+        self.validate_inputs(universe, start_date, end_date)
+
+        # Fetch fundamental data from provider
+        logger.debug(
+            "Fetching fundamentals data",
+            symbols=universe,
+            metrics=[self.metric],
+        )
+        fundamentals = provider.get_fundamentals(
+            symbols=universe,
+            metrics=[self.metric],
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        # Extract the metric values for each symbol
+        # fundamentals has MultiIndex columns: (symbol, metric)
+        result_data: dict[str, pd.Series] = {}
+
+        for symbol in universe:
+            try:
+                # Access the specific symbol and metric from MultiIndex
+                # Cast to Series since we're accessing a single column
+                symbol_data = fundamentals[(symbol, self.metric)]
+                if isinstance(symbol_data, pd.Series):
+                    result_data[symbol] = symbol_data
+                else:
+                    # Handle edge case where it might be DataFrame
+                    result_data[symbol] = pd.Series(
+                        index=fundamentals.index,
+                        dtype=float,
+                    )
+            except KeyError:
+                logger.warning(
+                    "Symbol data not found in fundamentals",
+                    symbol=symbol,
+                    metric=self.metric,
+                )
+                # Create a series of NaN values
+                result_data[symbol] = pd.Series(
+                    index=fundamentals.index,
+                    dtype=float,
+                )
+
+        # Create result DataFrame
+        result = pd.DataFrame(result_data)
+
+        # Ensure index is named "Date"
+        result.index.name = "Date"
+
+        # For debt_ratio, invert values (lower debt = higher score)
+        if self.metric == "debt_ratio":
+            logger.debug("Inverting debt_ratio values (lower debt = higher score)")
+            result = -result
+
+        # Ensure column order matches universe and return as DataFrame
+        # Use .loc for proper DataFrame return type
+        ordered_result = result.loc[:, universe]
+
+        logger.info(
+            "QualityFactor computation completed",
+            metric=self.metric,
+            rows=len(ordered_result),
+            columns=len(ordered_result.columns),
+        )
+
+        return ordered_result
+
+
+__all__ = ["QualityFactor"]

--- a/tests/factor/unit/factors/quality/test_quality.py
+++ b/tests/factor/unit/factors/quality/test_quality.py
@@ -1,0 +1,698 @@
+"""Unit tests for QualityFactor class.
+
+QualityFactorはROE、ROA、利益安定性、負債比率などの
+クオリティ指標を計算するファクタークラスである。
+
+AIDEV-NOTE: TDDのRed状態として、実装前にテストを作成している。
+テストはQualityFactorの仕様に基づいて作成されている。
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# AIDEV-NOTE: 実装が存在しないため、インポートは失敗する（Red状態）
+# pytest.importorskipを使用して、実装後に自動的にテストが有効になる
+quality_module = pytest.importorskip("factor.factors.quality.quality")
+QualityFactor = quality_module.QualityFactor
+
+
+class TestQualityFactorInheritance:
+    """QualityFactorがFactor基底クラスを正しく継承していることのテスト。"""
+
+    def test_正常系_Factor基底クラスを継承している(self) -> None:
+        """QualityFactorがFactor基底クラスを継承していることを確認。"""
+        from factor.core.base import Factor
+
+        factor = QualityFactor()
+        assert isinstance(factor, Factor)
+
+    def test_正常系_name属性が定義されている(self) -> None:
+        """QualityFactorにname属性が定義されていることを確認。"""
+        factor = QualityFactor()
+        assert hasattr(factor, "name")
+        assert factor.name == "quality"
+
+    def test_正常系_description属性が定義されている(self) -> None:
+        """QualityFactorにdescription属性が定義されていることを確認。"""
+        factor = QualityFactor()
+        assert hasattr(factor, "description")
+        assert len(factor.description) > 0
+
+    def test_正常系_category属性がQUALITYである(self) -> None:
+        """QualityFactorのcategoryがFactorCategory.QUALITYであることを確認。"""
+        from factor.enums import FactorCategory
+
+        factor = QualityFactor()
+        assert factor.category == FactorCategory.QUALITY
+
+    def test_正常系_computeメソッドが実装されている(self) -> None:
+        """QualityFactorにcomputeメソッドが実装されていることを確認。"""
+        factor = QualityFactor()
+        assert hasattr(factor, "compute")
+        assert callable(factor.compute)
+
+    def test_正常系_validate_inputsメソッドが使用可能(self) -> None:
+        """QualityFactorでvalidate_inputsメソッドが使用可能であることを確認。"""
+        factor = QualityFactor()
+        assert hasattr(factor, "validate_inputs")
+        assert callable(factor.validate_inputs)
+
+
+class TestQualityFactorInit:
+    """QualityFactor初期化のテスト。"""
+
+    def test_正常系_デフォルト値で初期化される(self) -> None:
+        """デフォルトのmetric(roe)で初期化されることを確認。"""
+        factor = QualityFactor()
+        assert factor.metric == "roe"
+
+    def test_正常系_metricにroeを指定できる(self) -> None:
+        """metric='roe'で初期化できることを確認。"""
+        factor = QualityFactor(metric="roe")
+        assert factor.metric == "roe"
+
+    def test_正常系_metricにroaを指定できる(self) -> None:
+        """metric='roa'で初期化できることを確認。"""
+        factor = QualityFactor(metric="roa")
+        assert factor.metric == "roa"
+
+    def test_正常系_metricにearnings_stabilityを指定できる(self) -> None:
+        """metric='earnings_stability'で初期化できることを確認。"""
+        factor = QualityFactor(metric="earnings_stability")
+        assert factor.metric == "earnings_stability"
+
+    def test_正常系_metricにdebt_ratioを指定できる(self) -> None:
+        """metric='debt_ratio'で初期化できることを確認。"""
+        factor = QualityFactor(metric="debt_ratio")
+        assert factor.metric == "debt_ratio"
+
+    def test_異常系_無効なmetricでValidationError(self) -> None:
+        """無効なmetricを指定するとValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            QualityFactor(metric="invalid_metric")
+
+    def test_異常系_空文字metricでValidationError(self) -> None:
+        """空文字のmetricを指定するとValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            QualityFactor(metric="")
+
+    def test_正常系_VALID_METRICS定数が定義されている(self) -> None:
+        """VALID_METRICS定数が正しく定義されていることを確認。"""
+        assert hasattr(QualityFactor, "VALID_METRICS")
+        expected_metrics = ("roe", "roa", "earnings_stability", "debt_ratio")
+        assert expected_metrics == QualityFactor.VALID_METRICS
+
+
+class TestQualityFactorComputeROE:
+    """QualityFactor.compute()のROE計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = QualityFactor(metric="roe")
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        # MultiIndex DataFrame構造を作成
+        # Index: Date, Columns: (symbol, metric)
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["roe"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_ROEファクター値が計算される(self) -> None:
+        """ROEファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+        symbols = ["AAPL", "GOOGL", "MSFT"]
+        values = {
+            "AAPL": [0.15, 0.16, 0.17],  # 15%, 16%, 17% ROE
+            "GOOGL": [0.20, 0.21, 0.22],  # 20%, 21%, 22% ROE
+            "MSFT": [0.25, 0.26, 0.27],  # 25%, 26%, 27% ROE
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-03",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 3  # 3日分
+        assert list(result.columns) == symbols
+
+    def test_正常系_高ROE銘柄が高スコアになる(self) -> None:
+        """高ROE銘柄が高スコアになることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["HIGH_ROE", "LOW_ROE"]
+        values = {"HIGH_ROE": [0.25, 0.25], "LOW_ROE": [0.05, 0.05]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 高ROEの方が高スコア
+        assert (
+            result.loc["2024-01-01", "HIGH_ROE"] > result.loc["2024-01-01", "LOW_ROE"]
+        )
+
+
+class TestQualityFactorComputeROA:
+    """QualityFactor.compute()のROA計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = QualityFactor(metric="roa")
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["roa"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_ROAファクター値が計算される(self) -> None:
+        """ROAファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        values = {
+            "AAPL": [0.10, 0.11],  # 10%, 11% ROA
+            "GOOGL": [0.08, 0.09],  # 8%, 9% ROA
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+    def test_正常系_高ROA銘柄が高スコアになる(self) -> None:
+        """高ROA銘柄が高スコアになることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["HIGH_ROA", "LOW_ROA"]
+        values = {"HIGH_ROA": [0.15, 0.15], "LOW_ROA": [0.02, 0.02]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 高ROAの方が高スコア
+        assert (
+            result.loc["2024-01-01", "HIGH_ROA"] > result.loc["2024-01-01", "LOW_ROA"]
+        )
+
+
+class TestQualityFactorComputeEarningsStability:
+    """QualityFactor.compute()の利益安定性計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = QualityFactor(metric="earnings_stability")
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["earnings_stability"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_利益安定性ファクター値が計算される(self) -> None:
+        """利益安定性ファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["STABLE", "VOLATILE"]
+        # 高い値は安定性が高いことを示す
+        values = {"STABLE": [0.95, 0.95], "VOLATILE": [0.50, 0.50]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+    def test_正常系_高安定性銘柄が高スコアになる(self) -> None:
+        """高い利益安定性の銘柄が高スコアになることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["STABLE", "VOLATILE"]
+        values = {"STABLE": [0.95, 0.95], "VOLATILE": [0.30, 0.30]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 高安定性の方が高スコア
+        assert result.loc["2024-01-01", "STABLE"] > result.loc["2024-01-01", "VOLATILE"]
+
+
+class TestQualityFactorComputeDebtRatio:
+    """QualityFactor.compute()の負債比率計算テスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = QualityFactor(metric="debt_ratio")
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, ["debt_ratio"]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_負債比率ファクター値が計算される(self) -> None:
+        """負債比率ファクター値が正しく計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["LOW_DEBT", "HIGH_DEBT"]
+        # 低い値は良い（負債が少ない）
+        values = {"LOW_DEBT": [0.20, 0.20], "HIGH_DEBT": [0.80, 0.80]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+    def test_正常系_低負債比率銘柄が高スコアになる(self) -> None:
+        """低負債比率の銘柄が高スコアになることを確認。
+
+        負債比率は低いほど良いため、ファクター値は符号反転されるべき。
+        """
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["LOW_DEBT", "HIGH_DEBT"]
+        values = {"LOW_DEBT": [0.20, 0.20], "HIGH_DEBT": [0.80, 0.80]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 低負債の方が高スコア（符号反転されている）
+        assert (
+            result.loc["2024-01-01", "LOW_DEBT"] > result.loc["2024-01-01", "HIGH_DEBT"]
+        )
+
+
+class TestQualityFactorDataFrameFormat:
+    """QualityFactor戻り値のDataFrameフォーマットテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = QualityFactor(metric="roe")
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metric: str,
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, [metric]],
+            names=["symbol", "metric"],
+        )
+        np.random.seed(42)
+        data = np.random.rand(len(dates), len(symbols)) * 0.3  # 0-30% ROE
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_戻り値がDataFrameである(self) -> None:
+        """戻り値がpd.DataFrameであることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_インデックスがDatetimeIndexである(self) -> None:
+        """インデックスがDatetimeIndexであることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result.index, pd.DatetimeIndex)
+
+    def test_正常系_インデックス名がDateである(self) -> None:
+        """インデックス名が'Date'であることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert result.index.name == "Date"
+
+    def test_正常系_カラムがユニバースと一致する(self) -> None:
+        """カラムがユニバースのシンボルと一致することを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL", "MSFT"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert list(result.columns) == symbols
+
+    def test_正常系_値がfloat型である(self) -> None:
+        """ファクター値がfloat型であることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe")
+        provider = self._create_mock_provider(fundamentals_df)
+
+        result = self.factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert result.dtypes["AAPL"] is np.float64 or np.issubdtype(
+            result.dtypes["AAPL"], np.floating
+        )
+
+
+class TestQualityFactorValidation:
+    """QualityFactor入力バリデーションのテスト。"""
+
+    def setup_method(self) -> None:
+        """テストフィクスチャのセットアップ。"""
+        self.factor = QualityFactor(metric="roe")
+
+    def _create_mock_provider(self) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        return MagicMock()
+
+    def test_異常系_空のユニバースでValidationError(self) -> None:
+        """空のユニバースでValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+
+        with pytest.raises(ValidationError):
+            self.factor.compute(
+                provider=provider,
+                universe=[],
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+
+    def test_異常系_開始日が終了日より後でValidationError(self) -> None:
+        """開始日が終了日より後の場合、ValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+
+        with pytest.raises(ValidationError):
+            self.factor.compute(
+                provider=provider,
+                universe=["AAPL"],
+                start_date="2024-12-31",
+                end_date="2024-01-01",
+            )
+
+    def test_異常系_開始日と終了日が同じでValidationError(self) -> None:
+        """開始日と終了日が同じ場合、ValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+
+        with pytest.raises(ValidationError):
+            self.factor.compute(
+                provider=provider,
+                universe=["AAPL"],
+                start_date="2024-01-01",
+                end_date="2024-01-01",
+            )
+
+
+class TestQualityFactorEdgeCases:
+    """QualityFactorのエッジケーステスト。"""
+
+    def _create_mock_provider(self, fundamentals_data: pd.DataFrame) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metric: str,
+        values: dict[str, list[float]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, [metric]],
+            names=["symbol", "metric"],
+        )
+        data = np.array([values[s] for s in symbols]).T
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_NaN値を含むデータの処理(self) -> None:
+        """NaN値を含むデータでも正しく処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        values = {
+            "AAPL": [0.15, np.nan],
+            "GOOGL": [0.20, 0.25],
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = QualityFactor(metric="roe")
+
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # NaN値を含む行も処理される
+        assert pd.isna(result.loc["2024-01-02", "AAPL"])
+        assert not pd.isna(result.loc["2024-01-02", "GOOGL"])
+
+    def test_正常系_ゼロ値を含むデータの処理(self) -> None:
+        """ゼロ値を含むデータでも正しく処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["ZERO", "POSITIVE"]
+        values = {"ZERO": [0.0, 0.0], "POSITIVE": [0.10, 0.10]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = QualityFactor(metric="roe")
+
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # ゼロ値も処理される（エラーにならない）
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_負のROE値を含むデータの処理(self) -> None:
+        """負のROE値（赤字企業）を含むデータでも処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["NEGATIVE", "POSITIVE"]
+        values = {"NEGATIVE": [-0.10, -0.10], "POSITIVE": [0.15, 0.15]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = QualityFactor(metric="roe")
+
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_日付文字列とdatetimeの両方を受け付ける(self) -> None:
+        """日付がstr形式とdatetime形式の両方で受け付けられることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        values = {"AAPL": [0.15, 0.16]}
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, "roe", values)
+        provider = self._create_mock_provider(fundamentals_df)
+        factor = QualityFactor(metric="roe")
+
+        # 文字列形式
+        result_str = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # datetime形式
+        result_dt = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 2),
+        )
+
+        assert isinstance(result_str, pd.DataFrame)
+        assert isinstance(result_dt, pd.DataFrame)
+
+
+class TestQualityFactorMetadata:
+    """QualityFactorメタデータのテスト。"""
+
+    def test_正常系_metadataプロパティが存在する(self) -> None:
+        """metadataプロパティが存在することを確認。"""
+        factor = QualityFactor()
+        assert hasattr(factor, "metadata")
+
+    def test_正常系_metadata_nameがqualityである(self) -> None:
+        """metadata.nameが'quality'であることを確認。"""
+        factor = QualityFactor()
+        assert factor.metadata.name == "quality"
+
+    def test_正常系_metadata_categoryがqualityである(self) -> None:
+        """metadata.categoryが'quality'であることを確認。"""
+        factor = QualityFactor()
+        assert factor.metadata.category == "quality"
+
+    def test_正常系_metadataがFactorMetadata型である(self) -> None:
+        """metadataがFactorMetadata型であることを確認。"""
+        from factor.core.base import FactorMetadata
+
+        factor = QualityFactor()
+        assert isinstance(factor.metadata, FactorMetadata)


### PR DESCRIPTION
## 概要
- QualityFactorクラスを追加
- ROE（自己資本利益率）、ROA（総資産利益率）、利益安定性（earnings_stability）、負債比率（debt_ratio）の4つのクオリティ指標を計算可能に
- Factor基底クラスを継承し、既存のValueFactor/MomentumFactorと同様のインターフェースを提供

## テストプラン
- [x] make check-all が成功することを確認
- [x] tests/factor/unit/factors/quality/test_quality.py で38テストケースがパス

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)