### PR TITLE
feat(factor): CompositeQualityFactor を実装 (#129)

### DIFF
--- a/src/factor/factors/quality/__init__.py
+++ b/src/factor/factors/quality/__init__.py
@@ -2,15 +2,18 @@
 
 This module provides quality factor implementations including:
 - QualityFactor: ROE, ROA, earnings stability, debt ratio
+- CompositeQualityFactor: Multiple quality metrics combined
 - ROIC (Return on Invested Capital) factor calculations
 - Transition labeling for factor analysis.
 """
 
+from .composite import CompositeQualityFactor
 from .quality import QualityFactor
 from .roic import ROICFactor
 from .roic_label import ROICTransitionLabeler
 
 __all__ = [
+    "CompositeQualityFactor",
     "QualityFactor",
     "ROICFactor",
     "ROICTransitionLabeler",

--- a/src/factor/factors/quality/composite.py
+++ b/src/factor/factors/quality/composite.py
@@ -1,0 +1,408 @@
+"""CompositeQualityFactor module for computing composite quality-based factor values.
+
+This module provides CompositeQualityFactor class that computes composite quality metrics
+by combining multiple quality indicators (ROE, ROA, earnings stability, debt ratio)
+with optional custom weights.
+
+Classes
+-------
+CompositeQualityFactor
+    Factor implementation for composite quality-based metrics.
+
+Examples
+--------
+>>> from factor.factors.quality.composite import CompositeQualityFactor
+>>> from factor.providers import YFinanceProvider
+>>>
+>>> provider = YFinanceProvider()
+>>> factor = CompositeQualityFactor(
+...     metrics=["roe", "roa", "earnings_stability"],
+...     weights=[0.4, 0.4, 0.2],
+... )
+>>> result = factor.compute(
+...     provider=provider,
+...     universe=["AAPL", "GOOGL", "MSFT"],
+...     start_date="2024-01-01",
+...     end_date="2024-12-31",
+... )
+>>> result.columns.tolist()
+['AAPL', 'GOOGL', 'MSFT']
+"""
+
+from datetime import datetime
+
+import pandas as pd
+
+from factor.core.base import Factor
+from factor.core.normalizer import Normalizer
+from factor.enums import FactorCategory
+from factor.errors import ValidationError
+from factor.providers.base import DataProvider
+from factor.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Metrics that should be inverted (lower is better)
+# For quality factors, only debt_ratio needs inversion
+_INVERTED_METRICS: frozenset[str] = frozenset({"debt_ratio"})
+
+
+class CompositeQualityFactor(Factor):
+    """Composite quality factor for computing combined quality metrics.
+
+    Computes a composite quality factor by combining multiple quality indicators.
+    Each indicator is normalized (z-score) and then combined using specified weights.
+    ROE, ROA, and earnings_stability are kept as-is (higher is better), while
+    debt_ratio is inverted (lower is better).
+
+    Parameters
+    ----------
+    metrics : list[str]
+        List of quality metrics to combine. Must be a non-empty list of valid
+        metric names from VALID_METRICS ("roe", "roa", "earnings_stability", "debt_ratio").
+    weights : list[float] | None, default=None
+        Weights for each metric. If None, equal weights are used.
+        Must have the same length as metrics if provided.
+
+    Attributes
+    ----------
+    name : str
+        Factor name, always "composite_quality".
+    description : str
+        Human-readable description of the factor.
+    category : FactorCategory
+        Factor category, always FactorCategory.QUALITY.
+    metrics : list[str]
+        The list of quality metrics being combined.
+    weights : list[float] | None
+        The weights for each metric.
+    VALID_METRICS : tuple[str, ...]
+        Class attribute containing valid metric names.
+
+    Raises
+    ------
+    ValidationError
+        If metrics is empty or contains invalid metric names.
+        If weights length does not match metrics length.
+
+    Examples
+    --------
+    >>> factor = CompositeQualityFactor(metrics=["roe", "roa"])
+    >>> factor.metrics
+    ['roe', 'roa']
+
+    >>> # With custom weights
+    >>> factor = CompositeQualityFactor(
+    ...     metrics=["roe", "roa", "earnings_stability"],
+    ...     weights=[0.5, 0.3, 0.2],
+    ... )
+
+    Notes
+    -----
+    The normalization uses z-score with robust estimators (median and MAD).
+    For metrics where lower is better (debt_ratio), the normalized
+    values are inverted so that better values result in higher factor scores.
+    ROE, ROA, and earnings_stability are kept as-is since higher is better.
+
+    References
+    ----------
+    Novy-Marx, R. (2013). The other side of value: The gross profitability
+    premium. Journal of Financial Economics, 108(1), 1-28.
+    """
+
+    # Class attributes required by Factor base class
+    name: str = "composite_quality"
+    description: str = (
+        "Composite quality factor combining multiple quality metrics "
+        "(ROE, ROA, earnings stability, debt ratio)"
+    )
+    category: FactorCategory = FactorCategory.QUALITY
+
+    # Class constant for valid metrics (same as QualityFactor)
+    VALID_METRICS: tuple[str, ...] = ("roe", "roa", "earnings_stability", "debt_ratio")
+
+    # Optional class attributes for metadata customization
+    _required_data: list[str] = ["fundamentals"]
+    _frequency: str = "daily"
+    _lookback_period: int | None = None
+    _higher_is_better: bool = True
+    _default_parameters: dict[str, int | float] = {}
+
+    def __init__(
+        self,
+        metrics: list[str],
+        weights: list[float] | None = None,
+    ) -> None:
+        """Initialize CompositeQualityFactor with the specified metrics and weights.
+
+        Parameters
+        ----------
+        metrics : list[str]
+            List of quality metrics to combine.
+        weights : list[float] | None, default=None
+            Weights for each metric. If None, equal weights are used.
+
+        Raises
+        ------
+        ValidationError
+            If metrics is empty, contains invalid metric names,
+            or if weights length does not match metrics length.
+        """
+        logger.debug(
+            "Initializing CompositeQualityFactor",
+            metrics=metrics,
+            weights=weights,
+        )
+
+        # Validate metrics is not empty
+        if not metrics:
+            logger.error("Empty metrics list provided")
+            raise ValidationError(
+                "metrics cannot be empty",
+                field="metrics",
+                value=metrics,
+            )
+
+        # Validate all metrics are valid
+        invalid_metrics = [m for m in metrics if m not in self.VALID_METRICS]
+        if invalid_metrics:
+            logger.error(
+                "Invalid metrics specified",
+                invalid_metrics=invalid_metrics,
+                valid_metrics=self.VALID_METRICS,
+            )
+            raise ValidationError(
+                f"Invalid metrics: {invalid_metrics}. "
+                f"Must be one of {self.VALID_METRICS}",
+                field="metrics",
+                value=invalid_metrics,
+            )
+
+        # Validate weights length matches metrics length if provided
+        if weights is not None and len(weights) != len(metrics):
+            logger.error(
+                "Weights length mismatch",
+                weights_len=len(weights),
+                metrics_len=len(metrics),
+            )
+            raise ValidationError(
+                f"weights length ({len(weights)}) must match "
+                f"metrics length ({len(metrics)})",
+                field="weights",
+                value=weights,
+            )
+
+        self.metrics = metrics
+        self.weights = weights
+
+        # Create normalizer for z-score normalization
+        # Use min_samples=1 to handle small universes
+        self._normalizer = Normalizer(min_samples=1)
+
+        logger.info(
+            "CompositeQualityFactor initialized",
+            metrics=metrics,
+            weights=weights,
+        )
+
+    def compute(
+        self,
+        provider: DataProvider,
+        universe: list[str],
+        start_date: datetime | str,
+        end_date: datetime | str,
+    ) -> pd.DataFrame:
+        """Compute composite quality factor values for the specified universe and date range.
+
+        Fetches fundamental data from the provider, normalizes each metric using
+        z-score, inverts metrics where lower is better, and combines them using
+        the specified weights.
+
+        Parameters
+        ----------
+        provider : DataProvider
+            Data provider implementing the DataProvider protocol.
+        universe : list[str]
+            List of ticker symbols to compute factors for.
+        start_date : datetime | str
+            Start date for the computation period.
+            Accepts datetime object or ISO format string (e.g., "2024-01-01").
+        end_date : datetime | str
+            End date for the computation period.
+            Accepts datetime object or ISO format string (e.g., "2024-12-31").
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with factor values:
+            - Index: DatetimeIndex named "Date"
+            - Columns: symbol names from universe
+            - Values: float64 factor values
+
+        Raises
+        ------
+        ValidationError
+            If universe is empty or date range is invalid.
+
+        Examples
+        --------
+        >>> provider = SomeDataProvider()
+        >>> factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        >>> result = factor.compute(
+        ...     provider=provider,
+        ...     universe=["AAPL", "GOOGL"],
+        ...     start_date="2024-01-01",
+        ...     end_date="2024-12-31",
+        ... )
+        >>> result.index.name
+        'Date'
+        >>> list(result.columns)
+        ['AAPL', 'GOOGL']
+        """
+        logger.debug(
+            "Computing CompositeQualityFactor",
+            metrics=self.metrics,
+            weights=self.weights,
+            universe_size=len(universe),
+            start_date=str(start_date),
+            end_date=str(end_date),
+        )
+
+        # Validate inputs using base class method
+        self.validate_inputs(universe, start_date, end_date)
+
+        # Fetch fundamental data from provider
+        logger.debug(
+            "Fetching fundamentals data",
+            symbols=universe,
+            metrics=self.metrics,
+        )
+        fundamentals = provider.get_fundamentals(
+            symbols=universe,
+            metrics=self.metrics,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        # Calculate weights (equal if not specified)
+        effective_weights = self.weights
+        if effective_weights is None:
+            effective_weights = [1.0 / len(self.metrics)] * len(self.metrics)
+
+        # Process each metric: extract, normalize, invert if needed
+        normalized_components: list[pd.DataFrame] = []
+
+        for metric, weight in zip(self.metrics, effective_weights, strict=True):
+            # Extract metric data for all symbols
+            metric_data = self._extract_metric_data(fundamentals, universe, metric)
+
+            # Normalize using z-score (cross-sectional)
+            # Apply row-wise normalization for each date
+            normalized = self._normalize_cross_sectional(metric_data)
+
+            # Invert if metric is one where lower is better
+            if metric in _INVERTED_METRICS:
+                logger.debug(f"Inverting metric: {metric}")
+                normalized = -normalized
+
+            # Apply weight
+            weighted = normalized * weight
+            normalized_components.append(weighted)
+
+        # Combine all weighted components
+        result = sum(normalized_components)
+
+        # Ensure result is a DataFrame (not Series)
+        if isinstance(result, pd.Series):
+            result = result.to_frame()
+
+        # Ensure index is named "Date"
+        result.index.name = "Date"
+
+        # Ensure column order matches universe
+        result = result.loc[:, universe]
+
+        logger.info(
+            "CompositeQualityFactor computation completed",
+            metrics=self.metrics,
+            rows=len(result),
+            columns=len(result.columns),
+        )
+
+        return result
+
+    def _extract_metric_data(
+        self,
+        fundamentals: pd.DataFrame,
+        universe: list[str],
+        metric: str,
+    ) -> pd.DataFrame:
+        """Extract a single metric's data for all symbols.
+
+        Parameters
+        ----------
+        fundamentals : pd.DataFrame
+            DataFrame with MultiIndex columns (symbol, metric).
+        universe : list[str]
+            List of symbols.
+        metric : str
+            The metric to extract.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with symbols as columns and dates as index.
+        """
+        result_data: dict[str, pd.Series] = {}
+
+        for symbol in universe:
+            try:
+                symbol_data = fundamentals[(symbol, metric)]
+                if isinstance(symbol_data, pd.Series):
+                    result_data[symbol] = symbol_data
+                else:
+                    result_data[symbol] = pd.Series(
+                        index=fundamentals.index,
+                        dtype=float,
+                    )
+            except KeyError:
+                logger.warning(
+                    "Symbol data not found in fundamentals",
+                    symbol=symbol,
+                    metric=metric,
+                )
+                result_data[symbol] = pd.Series(
+                    index=fundamentals.index,
+                    dtype=float,
+                )
+
+        return pd.DataFrame(result_data)
+
+    def _normalize_cross_sectional(
+        self,
+        data: pd.DataFrame,
+    ) -> pd.DataFrame:
+        """Normalize data cross-sectionally (row by row).
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            DataFrame with symbols as columns and dates as index.
+
+        Returns
+        -------
+        pd.DataFrame
+            Normalized DataFrame with same structure.
+        """
+        # Apply z-score normalization row by row (cross-sectional)
+        # Each row is normalized independently
+        normalized_rows = []
+        for idx in data.index:
+            row = data.loc[idx]
+            zscore_row = self._normalizer.zscore(row, robust=True)
+            normalized_rows.append(zscore_row)
+
+        return pd.DataFrame(normalized_rows, index=data.index)
+
+
+__all__ = ["CompositeQualityFactor"]

--- a/tests/factor/unit/factors/quality/test_composite.py
+++ b/tests/factor/unit/factors/quality/test_composite.py
@@ -1,0 +1,911 @@
+"""Unit tests for CompositeQualityFactor class.
+
+CompositeQualityFactorは複数のクオリティ指標（ROE、ROA、利益安定性、負債比率）を
+組み合わせた複合クオリティファクターを計算するクラスである。
+
+Issue #129: [factor] T15: CompositeQualityFactor (factors/quality/composite.py)
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# AIDEV-NOTE: 実装が存在しないため、インポートは失敗する（Red状態）
+# pytest.importorskipを使用して、実装後に自動的にテストが有効になる
+composite_module = pytest.importorskip("factor.factors.quality.composite")
+CompositeQualityFactor = composite_module.CompositeQualityFactor
+
+
+class TestCompositeQualityFactorInheritance:
+    """CompositeQualityFactorがFactor基底クラスを正しく継承していることのテスト。"""
+
+    def test_正常系_Factor基底クラスを継承している(self) -> None:
+        """CompositeQualityFactorがFactor基底クラスを継承していることを確認。"""
+        from factor.core.base import Factor
+
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert isinstance(factor, Factor)
+
+    def test_正常系_name属性が定義されている(self) -> None:
+        """CompositeQualityFactorにname属性が定義されていることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert hasattr(factor, "name")
+        assert factor.name == "composite_quality"
+
+    def test_正常系_description属性が定義されている(self) -> None:
+        """CompositeQualityFactorにdescription属性が定義されていることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert hasattr(factor, "description")
+        assert len(factor.description) > 0
+
+    def test_正常系_category属性がQUALITYである(self) -> None:
+        """CompositeQualityFactorのcategoryがFactorCategory.QUALITYであることを確認。"""
+        from factor.enums import FactorCategory
+
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert factor.category == FactorCategory.QUALITY
+
+    def test_正常系_computeメソッドが実装されている(self) -> None:
+        """CompositeQualityFactorにcomputeメソッドが実装されていることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert hasattr(factor, "compute")
+        assert callable(factor.compute)
+
+    def test_正常系_validate_inputsメソッドが使用可能(self) -> None:
+        """CompositeQualityFactorでvalidate_inputsメソッドが使用可能であることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert hasattr(factor, "validate_inputs")
+        assert callable(factor.validate_inputs)
+
+
+class TestCompositeQualityFactorInit:
+    """CompositeQualityFactor初期化のテスト。"""
+
+    def test_正常系_2つの指標で初期化できる(self) -> None:
+        """2つの指標リストで初期化できることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert factor.metrics == ["roe", "roa"]
+
+    def test_正常系_全4指標で初期化できる(self) -> None:
+        """全4指標で初期化できることを確認。"""
+        metrics = ["roe", "roa", "earnings_stability", "debt_ratio"]
+        factor = CompositeQualityFactor(metrics=metrics)
+        assert factor.metrics == metrics
+
+    def test_正常系_weightsなしでデフォルト等ウェイト(self) -> None:
+        """weightsを指定しない場合、等ウェイトになることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        # 等ウェイトなのでweightsはNoneまたは[0.5, 0.5]となる
+        # 実装によっては内部でNoneのままかもしれないので、両方許容
+        if factor.weights is not None:
+            assert factor.weights == [0.5, 0.5]
+
+    def test_正常系_カスタムウェイトを指定できる(self) -> None:
+        """カスタムウェイトを指定できることを確認。"""
+        factor = CompositeQualityFactor(
+            metrics=["roe", "roa"],
+            weights=[0.7, 0.3],
+        )
+        assert factor.weights == [0.7, 0.3]
+
+    def test_正常系_3つの指標とウェイトで初期化できる(self) -> None:
+        """3つの指標とウェイトで初期化できることを確認。"""
+        factor = CompositeQualityFactor(
+            metrics=["roe", "roa", "earnings_stability"],
+            weights=[0.4, 0.4, 0.2],
+        )
+        assert factor.metrics == ["roe", "roa", "earnings_stability"]
+        assert factor.weights == [0.4, 0.4, 0.2]
+
+    def test_正常系_VALID_METRICS定数が定義されている(self) -> None:
+        """VALID_METRICS定数が正しく定義されていることを確認。"""
+        assert hasattr(CompositeQualityFactor, "VALID_METRICS")
+        expected_metrics = ("roe", "roa", "earnings_stability", "debt_ratio")
+        assert expected_metrics == CompositeQualityFactor.VALID_METRICS
+
+    def test_異常系_無効な指標名でValidationError(self) -> None:
+        """無効な指標名を指定するとValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            CompositeQualityFactor(metrics=["roe", "invalid_metric"])
+
+    def test_異常系_空の指標リストでValidationError(self) -> None:
+        """空の指標リストを指定するとValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            CompositeQualityFactor(metrics=[])
+
+    def test_異常系_ウェイトと指標数が不一致でValidationError(self) -> None:
+        """ウェイトの数と指標の数が一致しない場合ValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            CompositeQualityFactor(
+                metrics=["roe", "roa"],
+                weights=[0.5, 0.3, 0.2],  # 3つのウェイトだが指標は2つ
+            )
+
+    def test_正常系_ウェイト合計が1でなくても動作する(self) -> None:
+        """ウェイトの合計が1でなくても動作する（警告は出るかもしれないが例外は発生しない）。"""
+        # ウェイトの合計が0.8でもエラーにはならない
+        factor = CompositeQualityFactor(
+            metrics=["roe", "roa"],
+            weights=[0.5, 0.3],  # 合計0.8
+        )
+        assert factor.weights == [0.5, 0.3]
+
+
+class TestCompositeQualityFactorCompute:
+    """CompositeQualityFactor.compute()の基本テスト。"""
+
+    def _create_mock_provider(
+        self,
+        fundamentals_data: pd.DataFrame,
+    ) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metrics: list[str],
+        values: dict[str, dict[str, list[float]]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。
+
+        Parameters
+        ----------
+        dates : list[str]
+            日付リスト
+        symbols : list[str]
+            シンボルリスト
+        metrics : list[str]
+            指標リスト
+        values : dict[str, dict[str, list[float]]]
+            values[symbol][metric] = [values...]
+
+        Returns
+        -------
+        pd.DataFrame
+            MultiIndex columns (symbol, metric) のDataFrame
+        """
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, metrics],
+            names=["symbol", "metric"],
+        )
+
+        data = []
+        for symbol in symbols:
+            for metric in metrics:
+                data.append(values[symbol][metric])
+
+        # Transpose to get dates as rows
+        df = pd.DataFrame(
+            np.array(data).T,
+            index=index,
+            columns=columns,
+        )
+        return df
+
+    def test_正常系_デフォルト等ウェイトで複合ファクターを計算できる(self) -> None:
+        """デフォルト等ウェイトで複合ファクター値が計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        metrics = ["roe", "roa"]
+        values = {
+            "AAPL": {"roe": [0.15, 0.16], "roa": [0.10, 0.11]},
+            "GOOGL": {"roe": [0.20, 0.21], "roa": [0.12, 0.13]},
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+        assert list(result.columns) == symbols
+
+    def test_正常系_カスタムウェイトで複合ファクターを計算できる(self) -> None:
+        """カスタムウェイトで複合ファクター値が計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        metrics = ["roe", "roa"]
+        values = {
+            "AAPL": {"roe": [0.15, 0.16], "roa": [0.10, 0.11]},
+            "GOOGL": {"roe": [0.20, 0.21], "roa": [0.12, 0.13]},
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(
+            metrics=["roe", "roa"],
+            weights=[0.7, 0.3],
+        )
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+
+    def test_正常系_3つの指標で複合ファクターを計算できる(self) -> None:
+        """3つの指標で複合ファクター値が計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        metrics = ["roe", "roa", "earnings_stability"]
+        values = {
+            "AAPL": {
+                "roe": [0.15, 0.16],
+                "roa": [0.10, 0.11],
+                "earnings_stability": [0.90, 0.91],
+            },
+            "GOOGL": {
+                "roe": [0.20, 0.21],
+                "roa": [0.12, 0.13],
+                "earnings_stability": [0.85, 0.86],
+            },
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+    def test_正常系_全4指標で複合ファクターを計算できる(self) -> None:
+        """全4指標で複合ファクター値が計算されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        metrics = ["roe", "roa", "earnings_stability", "debt_ratio"]
+        values = {
+            "AAPL": {
+                "roe": [0.15, 0.16],
+                "roa": [0.10, 0.11],
+                "earnings_stability": [0.90, 0.91],
+                "debt_ratio": [0.30, 0.31],
+            },
+            "GOOGL": {
+                "roe": [0.20, 0.21],
+                "roa": [0.12, 0.13],
+                "earnings_stability": [0.85, 0.86],
+                "debt_ratio": [0.40, 0.41],
+            },
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == symbols
+
+
+class TestCompositeQualityFactorNormalization:
+    """CompositeQualityFactorの各指標正規化テスト。"""
+
+    def _create_mock_provider(
+        self,
+        fundamentals_data: pd.DataFrame,
+    ) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metrics: list[str],
+        values: dict[str, dict[str, list[float]]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, metrics],
+            names=["symbol", "metric"],
+        )
+
+        data = []
+        for symbol in symbols:
+            for metric in metrics:
+                data.append(values[symbol][metric])
+
+        df = pd.DataFrame(
+            np.array(data).T,
+            index=index,
+            columns=columns,
+        )
+        return df
+
+    def test_正常系_各指標が正規化されてから合成される(self) -> None:
+        """各指標が正規化（z-scoreまたはpercentile rank）されてから合成されることを確認。
+
+        正規化により、スケールの異なる指標（ROE: 0.05-0.30 vs debt_ratio: 0.1-0.9）が
+        同等に扱われる。
+        """
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["HIGH_QUALITY", "MID_QUALITY", "LOW_QUALITY"]
+        metrics = ["roe", "roa"]
+
+        # ROEとROAで良い銘柄が高スコアになるべき
+        values = {
+            "HIGH_QUALITY": {
+                "roe": [0.30, 0.30],
+                "roa": [0.20, 0.20],
+            },  # 高ROE、高ROA（良い）
+            "MID_QUALITY": {"roe": [0.15, 0.15], "roa": [0.10, 0.10]},  # 中程度
+            "LOW_QUALITY": {
+                "roe": [0.05, 0.05],
+                "roa": [0.02, 0.02],
+            },  # 低ROE、低ROA（悪い）
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 高ROE・高ROA（HIGH_QUALITY）が最高スコアになるはず
+        # 低ROE・低ROA（LOW_QUALITY）が最低スコアになるはず
+        assert (
+            result.loc["2024-01-01", "HIGH_QUALITY"]
+            > result.loc["2024-01-01", "MID_QUALITY"]
+        )
+        assert (
+            result.loc["2024-01-01", "MID_QUALITY"]
+            > result.loc["2024-01-01", "LOW_QUALITY"]
+        )
+
+    def test_正常系_debt_ratioは符号反転される(self) -> None:
+        """debt_ratioは低いほど良いため、符号反転されてから合成されることを確認。
+
+        低負債比率の銘柄がより高いスコアを得るべき。
+        """
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["LOW_DEBT", "HIGH_DEBT"]
+        metrics = ["debt_ratio"]
+
+        values = {
+            "LOW_DEBT": {"debt_ratio": [0.20, 0.20]},  # 低負債（良い）
+            "HIGH_DEBT": {"debt_ratio": [0.80, 0.80]},  # 高負債（悪い）
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 低負債の方が高スコア（符号反転されている）
+        assert (
+            result.loc["2024-01-01", "LOW_DEBT"] > result.loc["2024-01-01", "HIGH_DEBT"]
+        )
+
+    def test_正常系_debt_ratio以外は符号反転されない(self) -> None:
+        """ROE、ROA、earnings_stabilityは高いほど良いため、符号反転されないことを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["HIGH_ROE", "LOW_ROE"]
+        metrics = ["roe"]
+
+        values = {
+            "HIGH_ROE": {"roe": [0.30, 0.30]},  # 高ROE（良い）
+            "LOW_ROE": {"roe": [0.05, 0.05]},  # 低ROE（悪い）
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # 高ROEの方が高スコア（符号反転されていない）
+        assert (
+            result.loc["2024-01-01", "HIGH_ROE"] > result.loc["2024-01-01", "LOW_ROE"]
+        )
+
+    def test_正常系_ウェイトが異なると結果が変わる(self) -> None:
+        """異なるウェイトで異なる結果が得られることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["A", "B"]
+        metrics = ["roe", "roa"]
+
+        # AはROE良好だがROA悪い、BはROE悪いがROA良好
+        values = {
+            "A": {
+                "roe": [0.30, 0.30],
+                "roa": [0.02, 0.02],
+            },  # 高ROE（良い）、低ROA（悪い）
+            "B": {
+                "roe": [0.05, 0.05],
+                "roa": [0.20, 0.20],
+            },  # 低ROE（悪い）、高ROA（良い）
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+
+        provider1 = self._create_mock_provider(fundamentals_df)
+        provider2 = self._create_mock_provider(fundamentals_df)
+
+        # ROE重視
+        factor_roe_heavy = CompositeQualityFactor(
+            metrics=metrics,
+            weights=[0.9, 0.1],
+        )
+        result_roe_heavy = factor_roe_heavy.compute(
+            provider=provider1,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # ROA重視
+        factor_roa_heavy = CompositeQualityFactor(
+            metrics=metrics,
+            weights=[0.1, 0.9],
+        )
+        result_roa_heavy = factor_roa_heavy.compute(
+            provider=provider2,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # ROE重視ならAが良い、ROA重視ならBが良い
+        assert (
+            result_roe_heavy.loc["2024-01-01", "A"]
+            > result_roe_heavy.loc["2024-01-01", "B"]
+        )
+        assert (
+            result_roa_heavy.loc["2024-01-01", "B"]
+            > result_roa_heavy.loc["2024-01-01", "A"]
+        )
+
+
+class TestCompositeQualityFactorDataFrameFormat:
+    """CompositeQualityFactor戻り値のDataFrameフォーマットテスト。"""
+
+    def _create_mock_provider(
+        self,
+        fundamentals_data: pd.DataFrame,
+    ) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metrics: list[str],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, metrics],
+            names=["symbol", "metric"],
+        )
+        np.random.seed(42)
+        data = np.random.rand(len(dates), len(symbols) * len(metrics)) * 0.3
+        return pd.DataFrame(data, index=index, columns=columns)
+
+    def test_正常系_戻り値がDataFrameである(self) -> None:
+        """戻り値がpd.DataFrameであることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        metrics = ["roe", "roa"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_インデックスがDatetimeIndexである(self) -> None:
+        """インデックスがDatetimeIndexであることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        metrics = ["roe", "roa"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result.index, pd.DatetimeIndex)
+
+    def test_正常系_インデックス名がDateである(self) -> None:
+        """インデックス名が'Date'であることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        metrics = ["roe", "roa"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert result.index.name == "Date"
+
+    def test_正常系_カラムがユニバースと一致する(self) -> None:
+        """カラムがユニバースのシンボルと一致することを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL", "MSFT"]
+        metrics = ["roe", "roa"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert list(result.columns) == symbols
+
+    def test_正常系_値がfloat型である(self) -> None:
+        """ファクター値がfloat型であることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        metrics = ["roe", "roa"]
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert result.dtypes["AAPL"] is np.float64 or np.issubdtype(
+            result.dtypes["AAPL"], np.floating
+        )
+
+
+class TestCompositeQualityFactorValidation:
+    """CompositeQualityFactor入力バリデーションのテスト。"""
+
+    def _create_mock_provider(self) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        return MagicMock()
+
+    def test_異常系_空のユニバースでValidationError(self) -> None:
+        """空のユニバースでValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+
+        with pytest.raises(ValidationError):
+            factor.compute(
+                provider=provider,
+                universe=[],
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+
+    def test_異常系_開始日が終了日より後でValidationError(self) -> None:
+        """開始日が終了日より後の場合、ValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+
+        with pytest.raises(ValidationError):
+            factor.compute(
+                provider=provider,
+                universe=["AAPL"],
+                start_date="2024-12-31",
+                end_date="2024-01-01",
+            )
+
+    def test_異常系_開始日と終了日が同じでValidationError(self) -> None:
+        """開始日と終了日が同じ場合、ValidationErrorが発生することを確認。"""
+        from factor.errors import ValidationError
+
+        provider = self._create_mock_provider()
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+
+        with pytest.raises(ValidationError):
+            factor.compute(
+                provider=provider,
+                universe=["AAPL"],
+                start_date="2024-01-01",
+                end_date="2024-01-01",
+            )
+
+
+class TestCompositeQualityFactorEdgeCases:
+    """CompositeQualityFactorのエッジケーステスト。"""
+
+    def _create_mock_provider(
+        self,
+        fundamentals_data: pd.DataFrame,
+    ) -> MagicMock:
+        """モックDataProviderを作成するヘルパーメソッド。"""
+        provider = MagicMock()
+        provider.get_fundamentals.return_value = fundamentals_data
+        return provider
+
+    def _create_fundamentals_df(
+        self,
+        dates: list[str],
+        symbols: list[str],
+        metrics: list[str],
+        values: dict[str, dict[str, list[float]]],
+    ) -> pd.DataFrame:
+        """ファンダメンタルズDataFrameを作成するヘルパーメソッド。"""
+        index = pd.DatetimeIndex(dates, name="Date")
+        columns = pd.MultiIndex.from_product(
+            [symbols, metrics],
+            names=["symbol", "metric"],
+        )
+
+        data = []
+        for symbol in symbols:
+            for metric in metrics:
+                data.append(values[symbol][metric])
+
+        df = pd.DataFrame(
+            np.array(data).T,
+            index=index,
+            columns=columns,
+        )
+        return df
+
+    def test_正常系_NaN値を含むデータの処理(self) -> None:
+        """NaN値を含むデータでも正しく処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        metrics = ["roe", "roa"]
+        values = {
+            "AAPL": {"roe": [0.15, np.nan], "roa": [0.10, 0.11]},
+            "GOOGL": {"roe": [0.20, 0.21], "roa": [0.12, 0.13]},
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # NaN値を含む場合は結果もNaNになることがある
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_日付文字列とdatetimeの両方を受け付ける(self) -> None:
+        """日付がstr形式とdatetime形式の両方で受け付けられることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL"]
+        metrics = ["roe", "roa"]
+        values = {
+            "AAPL": {"roe": [0.15, 0.16], "roa": [0.10, 0.11]},
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider1 = self._create_mock_provider(fundamentals_df)
+        provider2 = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+
+        # 文字列形式
+        result_str = factor.compute(
+            provider=provider1,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        # datetime形式
+        result_dt = factor.compute(
+            provider=provider2,
+            universe=symbols,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 2),
+        )
+
+        assert isinstance(result_str, pd.DataFrame)
+        assert isinstance(result_dt, pd.DataFrame)
+
+    def test_正常系_1つの指標のみでも動作する(self) -> None:
+        """1つの指標のみでも複合ファクターとして動作することを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["AAPL", "GOOGL"]
+        metrics = ["roe"]
+        values = {
+            "AAPL": {"roe": [0.15, 0.16]},
+            "GOOGL": {"roe": [0.20, 0.21]},
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=["roe"])
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+
+    def test_正常系_負のROE値を含むデータの処理(self) -> None:
+        """負のROE値（赤字企業）を含むデータでも処理されることを確認。"""
+        dates = ["2024-01-01", "2024-01-02"]
+        symbols = ["NEGATIVE_ROE", "POSITIVE_ROE"]
+        metrics = ["roe", "roa"]
+        values = {
+            "NEGATIVE_ROE": {"roe": [-0.10, -0.10], "roa": [-0.05, -0.05]},
+            "POSITIVE_ROE": {"roe": [0.15, 0.15], "roa": [0.10, 0.10]},
+        }
+        fundamentals_df = self._create_fundamentals_df(dates, symbols, metrics, values)
+        provider = self._create_mock_provider(fundamentals_df)
+
+        factor = CompositeQualityFactor(metrics=metrics)
+        result = factor.compute(
+            provider=provider,
+            universe=symbols,
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        # 正のROEの銘柄が高スコアになるはず
+        assert (
+            result.loc["2024-01-01", "POSITIVE_ROE"]
+            > result.loc["2024-01-01", "NEGATIVE_ROE"]
+        )
+
+
+class TestCompositeQualityFactorMetadata:
+    """CompositeQualityFactorメタデータのテスト。"""
+
+    def test_正常系_metadataプロパティが存在する(self) -> None:
+        """metadataプロパティが存在することを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert hasattr(factor, "metadata")
+
+    def test_正常系_metadata_nameがcomposite_qualityである(self) -> None:
+        """metadata.nameが'composite_quality'であることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert factor.metadata.name == "composite_quality"
+
+    def test_正常系_metadata_categoryがqualityである(self) -> None:
+        """metadata.categoryが'quality'であることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert factor.metadata.category == "quality"
+
+    def test_正常系_metadataがFactorMetadata型である(self) -> None:
+        """metadataがFactorMetadata型であることを確認。"""
+        from factor.core.base import FactorMetadata
+
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert isinstance(factor.metadata, FactorMetadata)
+
+
+class TestCompositeQualityFactorDocumentation:
+    """CompositeQualityFactorのドキュメントとサンプルコードのテスト。"""
+
+    def test_正常系_クラスにdocstringが存在する(self) -> None:
+        """CompositeQualityFactorクラスにdocstringが存在することを確認。"""
+        assert CompositeQualityFactor.__doc__ is not None
+        assert len(CompositeQualityFactor.__doc__) > 0
+
+    def test_正常系_computeメソッドにdocstringが存在する(self) -> None:
+        """computeメソッドにdocstringが存在することを確認。"""
+        assert CompositeQualityFactor.compute.__doc__ is not None
+        assert len(CompositeQualityFactor.compute.__doc__) > 0
+
+    def test_正常系_initメソッドにdocstringが存在する(self) -> None:
+        """__init__メソッドにdocstringが存在することを確認。"""
+        assert CompositeQualityFactor.__init__.__doc__ is not None
+        assert len(CompositeQualityFactor.__init__.__doc__) > 0
+
+
+class TestCompositeQualityFactorPyrightStrict:
+    """CompositeQualityFactorがpyright strictで型エラーがないことのテスト。
+
+    このテストクラスは型の一貫性を確認するためのものです。
+    実際の型チェックはpyrightで行われますが、
+    ここではランタイムで型の基本的な整合性を確認します。
+    """
+
+    def test_正常系_metricsの型がlist_strである(self) -> None:
+        """metrics属性の型がlist[str]であることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert isinstance(factor.metrics, list)
+        for metric in factor.metrics:
+            assert isinstance(metric, str)
+
+    def test_正常系_weightsの型がlist_floatまたはNoneである(self) -> None:
+        """weights属性の型がlist[float] | Noneであることを確認。"""
+        factor_no_weights = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert factor_no_weights.weights is None or isinstance(
+            factor_no_weights.weights, list
+        )
+
+        factor_with_weights = CompositeQualityFactor(
+            metrics=["roe", "roa"],
+            weights=[0.6, 0.4],
+        )
+        assert isinstance(factor_with_weights.weights, list)
+        for weight in factor_with_weights.weights:
+            assert isinstance(weight, float)
+
+    def test_正常系_name属性の型がstrである(self) -> None:
+        """name属性の型がstrであることを確認。"""
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert isinstance(factor.name, str)
+
+    def test_正常系_category属性の型がFactorCategoryである(self) -> None:
+        """category属性の型がFactorCategoryであることを確認。"""
+        from factor.enums import FactorCategory
+
+        factor = CompositeQualityFactor(metrics=["roe", "roa"])
+        assert isinstance(factor.category, FactorCategory)


### PR DESCRIPTION
## 概要
- 複合クオリティファクター（CompositeQualityFactor）を実装
- 複数のクオリティ指標を組み合わせた複合ファクターを計算できる

## 変更内容
- `src/factor/factors/quality/composite.py` を新規作成
- `CompositeQualityFactor` クラスを追加
- 各指標のクロスセクショナル正規化（z-score）と重み付け合成
- debt_ratio のみ符号反転（低いほど良い）

## テストプラン
- [x] 47 テストケースが全てパス
- [x] make check-all が成功することを確認
- [x] pyright strict でエラーがないことを確認

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)