### PR TITLE
refactor(agent): 金融ニュース収集エージェント群の機能改善

### DIFF
--- a/.claude/agents/finance-news-ai.md
+++ b/.claude/agents/finance-news-ai.md
@@ -2,7 +2,7 @@
 name: finance-news-ai
 description: AI（人工知能・テクノロジー）関連ニュースを収集・投稿するテーマ別エージェント
 input: .tmp/news-collection-{timestamp}.json, data/config/finance-news-themes.json
-output: GitHub Issues (Project 15, Status=Index)
+output: GitHub Issues (Project 15, Status=AI)
 model: inherit
 color: cyan
 depends_on: [finance-news-orchestrator]
@@ -17,662 +17,121 @@ priority: high
 
 ## テーマ: AI（人工知能・テクノロジー）
 
-**対象キーワード**: AI、人工知能、機械学習、ChatGPT、生成AI
-**GitHub Status ID**: `17189c86` (Index)
-**優先度キーワード**: AI規制、AI投資、AI企業、生成AI
+| 項目 | 値 |
+|------|-----|
+| **テーマキー** | `ai` |
+| **GitHub Status ID** | `17189c86` (AI) |
+| **対象キーワード** | AI, 人工知能, 機械学習, ChatGPT, 生成AI, LLM, NVIDIA |
+| **優先度キーワード** | AI規制, AI投資, AI企業, 生成AI, ChatGPT |
+| **Reliability Weight** | 1.1 |
 
 ## 重要ルール
 
-1. **テーマ特化**: Indexテーマに関連する記事のみを処理
+1. **テーマ特化**: AIテーマに関連する記事のみを処理
 2. **重複回避**: 既存Issueとの重複を厳密にチェック
-3. **Status自動設定**: GitHub Project StatusをIndex ("17189c86") に設定
+3. **Status自動設定**: GitHub Project StatusをAI (`17189c86`) に設定
 4. **エラーハンドリング**: 失敗時も処理継続、ログ記録
 
 ## 処理フロー
 
-### Phase 1: 初期化
+**共通処理ガイドを参照してください**:
+`.claude/agents/finance_news_collector/common-processing-guide.md`
+
+### 概要
 
 ```
-[1] 一時ファイル読み込み
-    ↓
-    .tmp/news-collection-{timestamp}.json を読み込む
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 1: 初期化
+├── 一時ファイル読み込み (.tmp/news-collection-{timestamp}.json)
+├── テーマ設定読み込み (themes["ai"])
+└── 統計カウンタ初期化
 
-[2] テーマ設定読み込み
-    ↓
-    data/config/finance-news-themes.json を読み込む
-    themes["ai"] セクションを取得
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 2: フィルタリング
+├── AIキーワードマッチング
+├── 除外キーワードチェック
+├── 信頼性スコアリング
+└── 重複チェック
 
-[3] 統計カウンタ初期化
-    ↓
-    processed = 0
-    matched = 0
-    excluded = 0
-    duplicates = 0
-    created = 0
-    failed = 0
+Phase 3: GitHub投稿
+├── 記事内容取得と要約生成
+├── Issue作成（Issueテンプレート準拠）
+├── Project 15に追加
+└── Status設定 (AI: 17189c86)
+
+Phase 4: 結果報告
+└── 統計サマリー出力
 ```
 
-### Phase 2: フィルタリング
+## 判定例
 
-#### ステップ2.1: テーマキーワードマッチング
-
-**各RSS記事に対してIndexキーワードをチェック**:
-
-```python
-def matches_ai_keywords(item: dict, theme: dict) -> tuple[bool, list[str]]:
-    """Indexテーマのキーワードにマッチするかチェック"""
-
-    # 検索対象テキスト
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-
-    # キーワードマッチング（単語境界認識）
-    matched_keywords = []
-    for keyword in theme['keywords']['include']:
-        # 単語境界パターン（\b）を使用
-        pattern = r'\b' + re.escape(keyword.lower()) + r'\b'
-        if re.search(pattern, text, re.IGNORECASE):
-            matched_keywords.append(keyword)
-
-    # 最低マッチ数チェック
-    min_matches = theme['min_keyword_matches']
-    is_match = len(matched_keywords) >= min_matches
-
-    return is_match, matched_keywords
 ```
+記事タイトル: "OpenAI、新モデルを発表"
+→ マッチ: ["AI", "OpenAI"] → True
 
-**判定例**:
-```
+記事タイトル: "NVIDIA、AI半導体で過去最高益"
+→ マッチ: ["AI", "NVIDIA"] → True
+
+記事タイトル: "生成AI、企業導入が加速"
+→ マッチ: ["生成AI", "AI"] → True
+
 記事タイトル: "日経平均、3万円台を回復"
-→ マッチ: ["日経平均", "株価"] → True
-
-記事タイトル: "トヨタ、決算を発表"
-→ マッチ: [] → False（Indexテーマではない）
+→ マッチ: [] → False（AIテーマではない、Indexテーマ）
 ```
 
-#### ステップ2.2: 除外キーワードチェック
+## 信頼性スコア計算例
 
-**除外キーワードが含まれる場合はスキップ**:
-
-```python
-def is_excluded(item: dict, common: dict) -> bool:
-    """除外対象かチェック"""
-
-    text = f"{item['title']} {item.get('summary', '')}".lower()
-
-    # 除外キーワードチェック
-    for category, keywords in common['exclude_keywords'].items():
-        for keyword in keywords:
-            if keyword.lower() in text:
-                # 金融キーワードも含む場合は除外しない
-                is_match, _ = matches_ai_keywords(item, theme)
-                if not is_match:
-                    ログ出力: f"除外: {item['title']} (理由: {category}:{keyword})"
-                    return True
-
-    return False
 ```
-
-#### ステップ2.3: 信頼性スコアリング
-
-**記事の信頼性スコアを計算（0-100）**:
-
-```python
-def calculate_reliability_score(item: dict, theme: dict, common: dict) -> int:
-    """信頼性スコアを計算"""
-
-    link = item.get('link', '')
-
-    # Tier判定（情報源の信頼性）
-    tier = 1
-    for domain in common['sources']['tier1']:
-        if domain in link:
-            tier = 3
-            break
-    if tier == 1:
-        for domain in common['sources']['tier2']:
-            if domain in link:
-                tier = 2
-                break
-
-    # キーワードマッチ度
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-    keyword_matches = sum(1 for kw in theme['keywords']['include'] if kw.lower() in text)
-    keyword_ratio = min(keyword_matches / 10, 1.0)  # 10キーワードで満点
-
-    # Priority boost（重要キーワードボーナス）
-    boost = 1.0
-    for priority_kw in theme['keywords']['priority_boost']:
-        if priority_kw.lower() in item['title'].lower():
-            boost = 1.5
-            break
-
-    # Reliability weight（テーマ別ウェイト）
-    weight = theme.get('reliability_weight', 1.0)
-
-    # スコア計算
-    score = tier * keyword_ratio * boost * weight * 100
-
-    return min(int(score), 100)
-```
-
-**スコア計算例**:
-```
-記事: "日経平均株価、3万円台を回復"
-ソース: nikkei.com (Tier 1)
+記事: "生成AI、企業導入が加速"
+ソース: bloomberg.com (Tier 1)
 
 tier = 3 (Tier 1)
-keyword_matches = 3 (日経平均, 株価, 回復)
-keyword_ratio = 0.3
-boost = 1.5 (priority_boost: "日経平均株価")
-weight = 1.0 (Indexテーマ)
+keyword_matches = 2 (生成AI, AI)
+keyword_ratio = 0.2
+boost = 1.5 (priority_boost: "生成AI")
+weight = 1.1 (AIテーマ)
 
-score = 3 × 0.3 × 1.5 × 1.0 × 100 = 135 → 100（上限）
+score = 3 × 0.2 × 1.5 × 1.1 × 100 = 99
 ```
 
-#### ステップ2.4: 重複チェック
-
-**既存Issueとの重複を判定**:
-
-```python
-def calculate_title_similarity(title1: str, title2: str) -> float:
-    """タイトルの類似度を計算（Jaccard係数）"""
-
-    words1 = set(title1.lower().split())
-    words2 = set(title2.lower().split())
-
-    if not words1 or not words2:
-        return 0.0
-
-    common = words1.intersection(words2)
-    total = words1.union(words2)
-
-    return len(common) / len(total)
-
-
-def is_duplicate(new_item: dict, existing_issues: list[dict], threshold: float) -> bool:
-    """既存Issueと重複しているかチェック"""
-
-    new_link = new_item.get('link', '')
-    new_title = new_item.get('title', '')
-
-    for issue in existing_issues:
-        # URL完全一致
-        body = issue.get('body', '')
-        if new_link and new_link in body:
-            ログ出力: f"重複: {new_title} (URL一致: Issue #{issue['number']})"
-            return True
-
-        # タイトル類似度チェック
-        issue_title = issue.get('title', '')
-        similarity = calculate_title_similarity(new_title, issue_title)
-
-        if similarity >= threshold:
-            ログ出力: f"重複: {new_title} (類似度{similarity:.2f}: Issue #{issue['number']})"
-            return True
-
-    return False
-```
-
-### Phase 3: GitHub投稿
-
-#### ステップ3.0: 記事内容取得と要約生成
-
-**重要**: Issue作成前に、必ず記事URLから実際の内容を取得して日本語要約を生成すること。
-
-**記事内容取得の手順**:
-
-```python
-def fetch_article_content(url: str, title: str) -> str:
-    """記事内容を取得（WebFetch → gemini検索の順で試行）"""
-
-    # 1. WebFetchで記事取得を試行
-    try:
-        content = WebFetch(
-            url=url,
-            prompt="""この記事の内容を詳しく要約してください。特に以下の点を含めてください:
-            1. 主要な事実と背景
-            2. 関連企業や機関の動き
-            3. 市場や業界への影響
-            4. 数値データや具体的な情報
-            5. 今後の展望や予測"""
-        )
-        return content
-    except Exception as e:
-        # 2. 失敗した場合（Financial Timesなど）は、gemini検索で代替
-        domain = url.split('/')[2]
-        query = f"{title} {domain}"
-
-        # gemini CLI経由でWeb検索
-        result = subprocess.run(
-            ["gemini", "--prompt", f"WebSearch: {query}"],
-            capture_output=True,
-            text=True
-        )
-        return result.stdout
-
-
-def generate_japanese_summary(content: str, max_length: int = 400) -> str:
-    """記事内容から日本語要約を生成（400字程度）"""
-
-    # Claude APIまたは内部ロジックで要約生成
-    # - 重要なポイントを抽出
-    # - 数値データを優先的に含める
-    # - 日本語で400字程度に整形
-
-    prompt = f"""以下の記事内容を、日本語で400字程度に要約してください。
-
-    要約のポイント:
-    - 主要な事実と数値データを優先
-    - 背景や影響を簡潔に説明
-    - 投資判断に有用な情報を強調
-    - 箇条書きではなく、文章形式で
-
-    記事内容:
-    {content}
-    """
-
-    summary = generate_summary(prompt)
-    return summary
-
-
-def format_published_jst(published_str: str) -> str:
-    """公開日をJST YYYY-MM-DD HH:MM形式に変換"""
-
-    from datetime import datetime
-    import pytz
-
-    # ISO 8601形式をパース
-    dt = datetime.fromisoformat(published_str.replace('Z', '+00:00'))
-
-    # JSTに変換
-    jst = pytz.timezone('Asia/Tokyo')
-    dt_jst = dt.astimezone(jst)
-
-    # YYYY-MM-DD HH:MM形式で出力
-    return dt_jst.strftime('%Y-%m-%d %H:%M')
-```
-
-**実装例**:
-```python
-# 各記事に対して
-for item in filtered_items:
-    # 記事内容を取得
-    article_content = fetch_article_content(item['link'], item['title'])
-
-    # 日本語要約を生成
-    japanese_summary = generate_japanese_summary(article_content, max_length=400)
-
-    # 公開日をJST形式に変換
-    published_jst = format_published_jst(item['published'])
-
-    # Issue作成（要約を含める）
-    create_issue(item, japanese_summary, published_jst)
-```
-
-#### ステップ3.1: Issue作成
-
-**GitHub CLIでIssueを作成**:
-
-```bash
-gh issue create \
-    --repo YH-05/finance \
-    --title "[NEWS] {title}" \
-    --body "$(cat <<'EOF'
-## 日本語要約（400字程度）
-
-{japanese_summary}
-
-## 記事概要
-- テーマ: AI（人工知能・テクノロジー）
-- ソース: {source}
-- 信頼性: {score}/100
-- 公開日: {published_jst}
-- URL: {link}
-
-## マッチしたキーワード
-{matched_keywords}
-EOF
-)" \
-    --label "news"
-```
-
-**注意事項**:
-- `{japanese_summary}`: 実際の記事から生成した400字程度の日本語要約
-- `{published_jst}`: JST形式（YYYY-MM-DD HH:MM）例: "2026-01-15 09:04"
-- 「サマリー」セクションは削除（RSSメタデータのサマリーは不要）
-- 「次のアクション」セクションは削除（要約済みのため不要）
-
-**作成後、Issue URLを取得**:
-```bash
-# 出力から Issue URL を抽出
-# 例: https://github.com/YH-05/finance/issues/200
-```
-
-#### ステップ3.2: Project追加
-
-**GitHub CLIでProject 15に追加**:
-
-```bash
-gh project item-add 15 \
-    --owner YH-05 \
-    --url {issue_url}
-```
-
-**出力から Project Item ID を取得**:
-```json
-{
-  "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-  "project": {
-    "id": "PVT_kwHOBoK6AM4BMpw_",
-    "number": 15
-  }
-}
-```
-
-#### ステップ3.3: Status設定（GraphQL API）
-
-**Step 1: Issue Node IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  repository(owner: "YH-05", name: "finance") {
-    issue(number: {issue_number}) {
-      id
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "repository": {
-      "issue": {
-        "id": "I_kwDOBoK6AM6YZ..."
-      }
-    }
-  }
-}
-```
-
-**Step 2: Project Item IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  node(id: "{issue_node_id}") {
-    ... on Issue {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project {
-            number
-          }
-        }
-      }
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "node": {
-      "projectItems": {
-        "nodes": [
-          {
-            "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-            "project": {
-              "number": 15
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-**Step 3: StatusフィールドをIndexに設定**
-
-```bash
-gh api graphql -f query='
-mutation {
-  updateProjectV2ItemFieldValue(
-    input: {
-      projectId: "PVT_kwHOBoK6AM4BMpw_"
-      itemId: "{project_item_id}"
-      fieldId: "PVTSSF_lAHOBoK6AM4BMpw_zg739ZE"
-      value: {
-        singleSelectOptionId: "17189c86"
-      }
-    }
-  ) {
-    projectV2Item {
-      id
-    }
-  }
-}'
-```
-
-**成功時の出力**:
-```json
-{
-  "data": {
-    "updateProjectV2ItemFieldValue": {
-      "projectV2Item": {
-        "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy..."
-      }
-    }
-  }
-}
-```
-
-### Phase 4: 結果報告
-
-#### ステップ4.1: 統計サマリー出力
-
-```markdown
-## AI（人工知能・テクノロジー）ニュース収集完了
-
-### 処理統計
-- **処理記事数**: {processed}件
-- **テーママッチ**: {matched}件
-- **除外**: {excluded}件
-- **重複**: {duplicates}件
-- **新規投稿**: {created}件
-- **投稿失敗**: {failed}件
-
-### 投稿されたニュース
-
-1. **日経平均、3万円台を回復** [#200]
-   - ソース: 日経新聞
-   - 信頼性: 95/100
-   - URL: https://github.com/YH-05/finance/issues/200
-
-2. **S&P500、史上最高値を更新** [#201]
-   - ソース: Reuters
-   - 信頼性: 90/100
-   - URL: https://github.com/YH-05/finance/issues/201
-
-### 除外されたニュース
-- スポーツ関連: 2件
-- エンタメ関連: 1件
-- テーマ不一致: 5件
-```
-
-## エラーハンドリング
-
-### E001: 一時ファイル読み込みエラー
-
-**発生条件**:
-- `.tmp/news-collection-{timestamp}.json` が存在しない
-- JSON形式が不正
-
-**対処法**:
-```python
-try:
-    with open(filepath) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    ログ出力: f"エラー: 一時ファイルが見つかりません: {filepath}"
-    ログ出力: "オーケストレーターが正しく実行されたか確認してください"
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    ログ出力: f"エラー: JSON形式が不正です: {e}"
-    sys.exit(1)
-```
-
-### E002: テーマ設定読み込みエラー
-
-**発生条件**:
-- `data/config/finance-news-themes.json` が存在しない
-- "ai"テーマが定義されていない
-
-**対処法**:
-```python
-try:
-    with open("data/config/finance-news-themes.json") as f:
-        config = json.load(f)
-    theme = config['themes']['ai']
-    common = config['common']
-except FileNotFoundError:
-    ログ出力: "エラー: テーマ設定ファイルが見つかりません"
-    sys.exit(1)
-except KeyError:
-    ログ出力: "エラー: 'ai' テーマが定義されていません"
-    sys.exit(1)
-```
-
-### E003: Issue作成エラー
-
-**発生条件**:
-- GitHub API エラー
-- 認証エラー
-- レート制限
-
-**対処法**:
-```python
-try:
-    result = subprocess.run(
-        ["gh", "issue", "create", ...],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Issue作成失敗: {item['title']}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-
-    # レート制限エラーの場合
-    if "rate limit" in str(e.stderr).lower():
-        ログ出力: "GitHub API レート制限に達しました。1時間待機してください。"
-
-    failed += 1
-    continue  # 次の記事の処理を継続
-```
-
-### E004: Status設定エラー
-
-**発生条件**:
-- GraphQL API エラー
-- Project Item IDが取得できない
-- 権限エラー
-
-**対処法**:
-```python
-try:
-    # GraphQL mutation実行
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={mutation}"],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Status設定失敗: Issue #{issue_number}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-    ログ出力: "Issue作成は成功しています。手動でStatusを設定してください。"
-
-    # 処理は継続（Issueは作成済み）
-    continue
-```
-
-### E005: ネットワークエラー
-
-**発生条件**:
-- GitHub APIへの接続失敗
-- タイムアウト
-
-**対処法**:
-- リトライロジック（最大3回、指数バックオフ）
-- エラーログ記録
-- 処理継続（失敗した記事をスキップ）
-
-## 実行例
-
-### 基本的な使用方法
-
-```
-1. Index エージェントを起動
-2. 一時ファイルからデータ読み込み
-3. Indexキーワードでフィルタリング
-4. 重複チェック
-5. GitHub Issueを作成（Status=Index）
-6. 結果サマリーを出力
-```
-
-### 実行ログの例
+## 実行ログの例
 
 ```
 [INFO] 一時ファイル読み込み: .tmp/news-collection-20260115-143000.json
 [INFO] テーマ設定読み込み: data/config/finance-news-themes.json
-[INFO] Index テーマ処理開始
+[INFO] AI テーマ処理開始
 [INFO] 処理記事数: 50件
 
 [INFO] テーママッチング中...
-[INFO] マッチ: 日経平均、3万円台を回復 (キーワード: 日経平均, 株価)
-[INFO] マッチ: S&P500、史上最高値を更新 (キーワード: S&P500, 指数)
+[INFO] マッチ: OpenAI、新モデルを発表 (キーワード: AI, OpenAI)
+[INFO] マッチ: NVIDIA、AI半導体で過去最高益 (キーワード: AI, NVIDIA)
 [INFO] 除外: サッカーW杯決勝 (理由: sports:サッカー)
-[INFO] テーママッチ: 12件
+[INFO] テーママッチ: 15件
 
 [INFO] 重複チェック中...
-[INFO] 重複: NYダウ、最高値更新 (URL一致: Issue #190)
-[INFO] 新規記事: 5件
+[INFO] 重複: ChatGPT、アップデートを発表 (URL一致: Issue #188)
+[INFO] 新規記事: 6件
 
 [INFO] GitHub Issue作成中...
-[INFO] Issue作成成功: #200 - 日経平均、3万円台を回復
-[INFO] Project追加成功: #200
-[INFO] Status設定成功: #200 → Index
-[INFO] Issue作成成功: #201 - S&P500、史上最高値を更新
-[INFO] Project追加成功: #201
-[INFO] Status設定成功: #201 → Index
+[INFO] Issue作成成功: #204 - OpenAI、新モデルを発表
+[INFO] Project追加成功: #204
+[INFO] Status設定成功: #204 → AI
 
 ## AI（人工知能・テクノロジー）ニュース収集完了
 
 ### 処理統計
 - **処理記事数**: 50件
-- **テーママッチ**: 12件
-- **除外**: 3件
-- **重複**: 7件
-- **新規投稿**: 5件
+- **テーママッチ**: 15件
+- **除外**: 2件
+- **重複**: 9件
+- **新規投稿**: 6件
 - **投稿失敗**: 0件
 ```
 
 ## 参考資料
 
+- **共通処理ガイド**: `.claude/agents/finance_news_collector/common-processing-guide.md`
 - **テーマ設定**: `data/config/finance-news-themes.json`
+- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.yml`
 - **オーケストレーター**: `.claude/agents/finance-news-orchestrator.md`
-- **他のテーマエージェント**: `.claude/agents/finance-news-{theme}.md`
-- **コマンド**: `.claude/commands/collect-finance-news.md`
 - **GitHub Project**: https://github.com/users/YH-05/projects/15
 
 ## 制約事項

--- a/.claude/agents/finance-news-index.md
+++ b/.claude/agents/finance-news-index.md
@@ -17,620 +17,79 @@ priority: high
 
 ## テーマ: Index（株価指数）
 
-**対象キーワード**: 株価、指数、日経平均、S&P500、TOPIX、ダウ、ナスダック
-**GitHub Status ID**: `f75ad846` (Index)
-**優先度キーワード**: 日経平均株価、NYダウ、TOPIX、S&P500
+| 項目 | 値 |
+|------|-----|
+| **テーマキー** | `index` |
+| **GitHub Status ID** | `f75ad846` (Index) |
+| **対象キーワード** | 株価, 指数, 日経平均, S&P500, TOPIX, ダウ, ナスダック |
+| **優先度キーワード** | 日経平均株価, NYダウ, TOPIX, S&P500 |
+| **Reliability Weight** | 1.0 |
 
 ## 重要ルール
 
 1. **テーマ特化**: Indexテーマに関連する記事のみを処理
 2. **重複回避**: 既存Issueとの重複を厳密にチェック
-3. **Status自動設定**: GitHub Project StatusをIndex ("f75ad846") に設定
+3. **Status自動設定**: GitHub Project StatusをIndex (`f75ad846`) に設定
 4. **エラーハンドリング**: 失敗時も処理継続、ログ記録
 
 ## 処理フロー
 
-### Phase 1: 初期化
+**共通処理ガイドを参照してください**:
+`.claude/agents/finance_news_collector/common-processing-guide.md`
+
+### 概要
 
 ```
-[1] 一時ファイル読み込み
-    ↓
-    .tmp/news-collection-{timestamp}.json を読み込む
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 1: 初期化
+├── 一時ファイル読み込み (.tmp/news-collection-{timestamp}.json)
+├── テーマ設定読み込み (themes["index"])
+└── 統計カウンタ初期化
 
-[2] テーマ設定読み込み
-    ↓
-    data/config/finance-news-themes.json を読み込む
-    themes["index"] セクションを取得
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 2: フィルタリング
+├── Indexキーワードマッチング
+├── 除外キーワードチェック
+├── 信頼性スコアリング
+└── 重複チェック
 
-[3] 統計カウンタ初期化
-    ↓
-    processed = 0
-    matched = 0
-    excluded = 0
-    duplicates = 0
-    created = 0
-    failed = 0
+Phase 3: GitHub投稿
+├── 記事内容取得と要約生成
+├── Issue作成（Issueテンプレート準拠）
+├── Project 15に追加
+└── Status設定 (Index: f75ad846)
+
+Phase 4: 結果報告
+└── 統計サマリー出力
 ```
 
-### Phase 2: フィルタリング
+## 判定例
 
-#### ステップ2.1: テーマキーワードマッチング
-
-**各RSS記事に対してIndexキーワードをチェック**:
-
-```python
-def matches_index_keywords(item: dict, theme: dict) -> tuple[bool, list[str]]:
-    """Indexテーマのキーワードにマッチするかチェック"""
-
-    # 検索対象テキスト
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-
-    # キーワードマッチング（単語境界認識）
-    matched_keywords = []
-    for keyword in theme['keywords']['include']:
-        # 単語境界パターン（\b）を使用
-        pattern = r'\b' + re.escape(keyword.lower()) + r'\b'
-        if re.search(pattern, text, re.IGNORECASE):
-            matched_keywords.append(keyword)
-
-    # 最低マッチ数チェック
-    min_matches = theme['min_keyword_matches']
-    is_match = len(matched_keywords) >= min_matches
-
-    return is_match, matched_keywords
-```
-
-**判定例**:
 ```
 記事タイトル: "日経平均、3万円台を回復"
 → マッチ: ["日経平均", "株価"] → True
 
 記事タイトル: "トヨタ、決算を発表"
 → マッチ: [] → False（Indexテーマではない）
+
+記事タイトル: "S&P500、史上最高値を更新"
+→ マッチ: ["S&P500", "指数"] → True
 ```
 
-#### ステップ2.2: 除外キーワードチェック
+## 信頼性スコア計算例
 
-**除外キーワードが含まれる場合はスキップ**:
-
-```python
-def is_excluded(item: dict, common: dict) -> bool:
-    """除外対象かチェック"""
-
-    text = f"{item['title']} {item.get('summary', '')}".lower()
-
-    # 除外キーワードチェック
-    for category, keywords in common['exclude_keywords'].items():
-        for keyword in keywords:
-            if keyword.lower() in text:
-                # 金融キーワードも含む場合は除外しない
-                is_match, _ = matches_index_keywords(item, theme)
-                if not is_match:
-                    ログ出力: f"除外: {item['title']} (理由: {category}:{keyword})"
-                    return True
-
-    return False
-```
-
-#### ステップ2.3: 信頼性スコアリング
-
-**記事の信頼性スコアを計算（0-100）**:
-
-```python
-def calculate_reliability_score(item: dict, theme: dict, common: dict) -> int:
-    """信頼性スコアを計算"""
-
-    link = item.get('link', '')
-
-    # Tier判定（情報源の信頼性）
-    tier = 1
-    for domain in common['sources']['tier1']:
-        if domain in link:
-            tier = 3
-            break
-    if tier == 1:
-        for domain in common['sources']['tier2']:
-            if domain in link:
-                tier = 2
-                break
-
-    # キーワードマッチ度
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-    keyword_matches = sum(1 for kw in theme['keywords']['include'] if kw.lower() in text)
-    keyword_ratio = min(keyword_matches / 10, 1.0)  # 10キーワードで満点
-
-    # Priority boost（重要キーワードボーナス）
-    boost = 1.0
-    for priority_kw in theme['keywords']['priority_boost']:
-        if priority_kw.lower() in item['title'].lower():
-            boost = 1.5
-            break
-
-    # Reliability weight（テーマ別ウェイト）
-    weight = theme.get('reliability_weight', 1.0)
-
-    # スコア計算
-    score = tier * keyword_ratio * boost * weight * 100
-
-    return min(int(score), 100)
-```
-
-**スコア計算例**:
 ```
 記事: "日経平均株価、3万円台を回復"
 ソース: nikkei.com (Tier 1)
 
 tier = 3 (Tier 1)
-keyword_matches = 3 (日経平均, 株価, 回復)
-keyword_ratio = 0.3
+keyword_matches = 2 (日経平均, 株価)
+keyword_ratio = 0.2
 boost = 1.5 (priority_boost: "日経平均株価")
 weight = 1.0 (Indexテーマ)
 
-score = 3 × 0.3 × 1.5 × 1.0 × 100 = 135 → 100（上限）
+score = 3 × 0.2 × 1.5 × 1.0 × 100 = 90
 ```
 
-#### ステップ2.4: 重複チェック
-
-**既存Issueとの重複を判定**:
-
-```python
-def calculate_title_similarity(title1: str, title2: str) -> float:
-    """タイトルの類似度を計算（Jaccard係数）"""
-
-    words1 = set(title1.lower().split())
-    words2 = set(title2.lower().split())
-
-    if not words1 or not words2:
-        return 0.0
-
-    common = words1.intersection(words2)
-    total = words1.union(words2)
-
-    return len(common) / len(total)
-
-
-def is_duplicate(new_item: dict, existing_issues: list[dict], threshold: float) -> bool:
-    """既存Issueと重複しているかチェック"""
-
-    new_link = new_item.get('link', '')
-    new_title = new_item.get('title', '')
-
-    for issue in existing_issues:
-        # URL完全一致
-        body = issue.get('body', '')
-        if new_link and new_link in body:
-            ログ出力: f"重複: {new_title} (URL一致: Issue #{issue['number']})"
-            return True
-
-        # タイトル類似度チェック
-        issue_title = issue.get('title', '')
-        similarity = calculate_title_similarity(new_title, issue_title)
-
-        if similarity >= threshold:
-            ログ出力: f"重複: {new_title} (類似度{similarity:.2f}: Issue #{issue['number']})"
-            return True
-
-    return False
-```
-
-### Phase 3: GitHub投稿
-
-#### ステップ3.0: 記事内容取得と要約生成
-
-**重要**: Issue作成前に、必ず記事URLから実際の内容を取得して日本語要約を生成すること。
-
-**記事内容取得の手順**:
-
-```python
-def fetch_article_content(url: str, title: str) -> str:
-    """記事内容を取得（WebFetch → gemini検索の順で試行）"""
-
-    # 1. WebFetchで記事取得を試行
-    try:
-        content = WebFetch(
-            url=url,
-            prompt="""この記事の内容を詳しく要約してください。特に以下の点を含めてください:
-            1. 主要な事実と背景
-            2. 関連企業や機関の動き
-            3. 市場や業界への影響
-            4. 数値データや具体的な情報
-            5. 今後の展望や予測"""
-        )
-        return content
-    except Exception as e:
-        # 2. 失敗した場合（Financial Timesなど）は、gemini検索で代替
-        domain = url.split('/')[2]
-        query = f"{title} {domain}"
-
-        # gemini CLI経由でWeb検索
-        result = subprocess.run(
-            ["gemini", "--prompt", f"WebSearch: {query}"],
-            capture_output=True,
-            text=True
-        )
-        return result.stdout
-
-
-def generate_japanese_summary(content: str, max_length: int = 400) -> str:
-    """記事内容から日本語要約を生成（400字程度）"""
-
-    # Claude APIまたは内部ロジックで要約生成
-    # - 重要なポイントを抽出
-    # - 数値データを優先的に含める
-    # - 日本語で400字程度に整形
-
-    prompt = f"""以下の記事内容を、日本語で400字程度に要約してください。
-
-    要約のポイント:
-    - 主要な事実と数値データを優先
-    - 背景や影響を簡潔に説明
-    - 投資判断に有用な情報を強調
-    - 箇条書きではなく、文章形式で
-
-    記事内容:
-    {content}
-    """
-
-    summary = generate_summary(prompt)
-    return summary
-
-
-def format_published_jst(published_str: str) -> str:
-    """公開日をJST YYYY-MM-DD HH:MM形式に変換"""
-
-    from datetime import datetime
-    import pytz
-
-    # ISO 8601形式をパース
-    dt = datetime.fromisoformat(published_str.replace('Z', '+00:00'))
-
-    # JSTに変換
-    jst = pytz.timezone('Asia/Tokyo')
-    dt_jst = dt.astimezone(jst)
-
-    # YYYY-MM-DD HH:MM形式で出力
-    return dt_jst.strftime('%Y-%m-%d %H:%M')
-```
-
-**実装例**:
-```python
-# 各記事に対して
-for item in filtered_items:
-    # 記事内容を取得
-    article_content = fetch_article_content(item['link'], item['title'])
-
-    # 日本語要約を生成
-    japanese_summary = generate_japanese_summary(article_content, max_length=400)
-
-    # 公開日をJST形式に変換
-    published_jst = format_published_jst(item['published'])
-
-    # Issue作成（要約を含める）
-    create_issue(item, japanese_summary, published_jst)
-```
-
-#### ステップ3.1: Issue作成
-
-**GitHub CLIでIssueを作成**:
-
-```bash
-gh issue create \
-    --repo YH-05/finance \
-    --title "[NEWS] {title}" \
-    --body "$(cat <<'EOF'
-## 日本語要約（400字程度）
-
-{japanese_summary}
-
-## 記事概要
-- テーマ: Index（株価指数）
-- ソース: {source}
-- 信頼性: {score}/100
-- 公開日: {published_jst}
-- URL: {link}
-
-## マッチしたキーワード
-{matched_keywords}
-EOF
-)" \
-    --label "news"
-```
-
-**注意事項**:
-- `{japanese_summary}`: 実際の記事から生成した400字程度の日本語要約
-- `{published_jst}`: JST形式（YYYY-MM-DD HH:MM）例: "2026-01-15 09:04"
-- 「サマリー」セクションは削除（RSSメタデータのサマリーは不要）
-- 「次のアクション」セクションは削除（要約済みのため不要）
-
-**作成後、Issue URLを取得**:
-```bash
-# 出力から Issue URL を抽出
-# 例: https://github.com/YH-05/finance/issues/200
-```
-
-#### ステップ3.2: Project追加
-
-**GitHub CLIでProject 15に追加**:
-
-```bash
-gh project item-add 15 \
-    --owner YH-05 \
-    --url {issue_url}
-```
-
-**出力から Project Item ID を取得**:
-```json
-{
-  "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-  "project": {
-    "id": "PVT_kwHOBoK6AM4BMpw_",
-    "number": 15
-  }
-}
-```
-
-#### ステップ3.3: Status設定（GraphQL API）
-
-**Step 1: Issue Node IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  repository(owner: "YH-05", name: "finance") {
-    issue(number: {issue_number}) {
-      id
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "repository": {
-      "issue": {
-        "id": "I_kwDOBoK6AM6YZ..."
-      }
-    }
-  }
-}
-```
-
-**Step 2: Project Item IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  node(id: "{issue_node_id}") {
-    ... on Issue {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project {
-            number
-          }
-        }
-      }
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "node": {
-      "projectItems": {
-        "nodes": [
-          {
-            "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-            "project": {
-              "number": 15
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-**Step 3: StatusフィールドをIndexに設定**
-
-```bash
-gh api graphql -f query='
-mutation {
-  updateProjectV2ItemFieldValue(
-    input: {
-      projectId: "PVT_kwHOBoK6AM4BMpw_"
-      itemId: "{project_item_id}"
-      fieldId: "PVTSSF_lAHOBoK6AM4BMpw_zg739ZE"
-      value: {
-        singleSelectOptionId: "f75ad846"
-      }
-    }
-  ) {
-    projectV2Item {
-      id
-    }
-  }
-}'
-```
-
-**成功時の出力**:
-```json
-{
-  "data": {
-    "updateProjectV2ItemFieldValue": {
-      "projectV2Item": {
-        "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy..."
-      }
-    }
-  }
-}
-```
-
-### Phase 4: 結果報告
-
-#### ステップ4.1: 統計サマリー出力
-
-```markdown
-## Index（株価指数）ニュース収集完了
-
-### 処理統計
-- **処理記事数**: {processed}件
-- **テーママッチ**: {matched}件
-- **除外**: {excluded}件
-- **重複**: {duplicates}件
-- **新規投稿**: {created}件
-- **投稿失敗**: {failed}件
-
-### 投稿されたニュース
-
-1. **日経平均、3万円台を回復** [#200]
-   - ソース: 日経新聞
-   - 信頼性: 95/100
-   - URL: https://github.com/YH-05/finance/issues/200
-
-2. **S&P500、史上最高値を更新** [#201]
-   - ソース: Reuters
-   - 信頼性: 90/100
-   - URL: https://github.com/YH-05/finance/issues/201
-
-### 除外されたニュース
-- スポーツ関連: 2件
-- エンタメ関連: 1件
-- テーマ不一致: 5件
-```
-
-## エラーハンドリング
-
-### E001: 一時ファイル読み込みエラー
-
-**発生条件**:
-- `.tmp/news-collection-{timestamp}.json` が存在しない
-- JSON形式が不正
-
-**対処法**:
-```python
-try:
-    with open(filepath) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    ログ出力: f"エラー: 一時ファイルが見つかりません: {filepath}"
-    ログ出力: "オーケストレーターが正しく実行されたか確認してください"
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    ログ出力: f"エラー: JSON形式が不正です: {e}"
-    sys.exit(1)
-```
-
-### E002: テーマ設定読み込みエラー
-
-**発生条件**:
-- `data/config/finance-news-themes.json` が存在しない
-- "index"テーマが定義されていない
-
-**対処法**:
-```python
-try:
-    with open("data/config/finance-news-themes.json") as f:
-        config = json.load(f)
-    theme = config['themes']['index']
-    common = config['common']
-except FileNotFoundError:
-    ログ出力: "エラー: テーマ設定ファイルが見つかりません"
-    sys.exit(1)
-except KeyError:
-    ログ出力: "エラー: 'index' テーマが定義されていません"
-    sys.exit(1)
-```
-
-### E003: Issue作成エラー
-
-**発生条件**:
-- GitHub API エラー
-- 認証エラー
-- レート制限
-
-**対処法**:
-```python
-try:
-    result = subprocess.run(
-        ["gh", "issue", "create", ...],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Issue作成失敗: {item['title']}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-
-    # レート制限エラーの場合
-    if "rate limit" in str(e.stderr).lower():
-        ログ出力: "GitHub API レート制限に達しました。1時間待機してください。"
-
-    failed += 1
-    continue  # 次の記事の処理を継続
-```
-
-### E004: Status設定エラー
-
-**発生条件**:
-- GraphQL API エラー
-- Project Item IDが取得できない
-- 権限エラー
-
-**対処法**:
-```python
-try:
-    # GraphQL mutation実行
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={mutation}"],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Status設定失敗: Issue #{issue_number}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-    ログ出力: "Issue作成は成功しています。手動でStatusを設定してください。"
-
-    # 処理は継続（Issueは作成済み）
-    continue
-```
-
-### E005: ネットワークエラー
-
-**発生条件**:
-- GitHub APIへの接続失敗
-- タイムアウト
-
-**対処法**:
-- リトライロジック（最大3回、指数バックオフ）
-- エラーログ記録
-- 処理継続（失敗した記事をスキップ）
-
-## 実行例
-
-### 基本的な使用方法
-
-```
-1. Index エージェントを起動
-2. 一時ファイルからデータ読み込み
-3. Indexキーワードでフィルタリング
-4. 重複チェック
-5. GitHub Issueを作成（Status=Index）
-6. 結果サマリーを出力
-```
-
-### 実行ログの例
+## 実行ログの例
 
 ```
 [INFO] 一時ファイル読み込み: .tmp/news-collection-20260115-143000.json
@@ -652,9 +111,6 @@ except subprocess.CalledProcessError as e:
 [INFO] Issue作成成功: #200 - 日経平均、3万円台を回復
 [INFO] Project追加成功: #200
 [INFO] Status設定成功: #200 → Index
-[INFO] Issue作成成功: #201 - S&P500、史上最高値を更新
-[INFO] Project追加成功: #201
-[INFO] Status設定成功: #201 → Index
 
 ## Index（株価指数）ニュース収集完了
 
@@ -669,10 +125,10 @@ except subprocess.CalledProcessError as e:
 
 ## 参考資料
 
+- **共通処理ガイド**: `.claude/agents/finance_news_collector/common-processing-guide.md`
 - **テーマ設定**: `data/config/finance-news-themes.json`
+- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.yml`
 - **オーケストレーター**: `.claude/agents/finance-news-orchestrator.md`
-- **他のテーマエージェント**: `.claude/agents/finance-news-{theme}.md`
-- **コマンド**: `.claude/commands/collect-finance-news.md`
 - **GitHub Project**: https://github.com/users/YH-05/projects/15
 
 ## 制約事項

--- a/.claude/agents/finance-news-macro.md
+++ b/.claude/agents/finance-news-macro.md
@@ -2,7 +2,7 @@
 name: finance-news-macro
 description: Macro Economics（マクロ経済）関連ニュースを収集・投稿するテーマ別エージェント
 input: .tmp/news-collection-{timestamp}.json, data/config/finance-news-themes.json
-output: GitHub Issues (Project 15, Status=Index)
+output: GitHub Issues (Project 15, Status=Macro)
 model: inherit
 color: red
 depends_on: [finance-news-orchestrator]
@@ -17,662 +17,121 @@ priority: high
 
 ## テーマ: Macro Economics（マクロ経済）
 
-**対象キーワード**: 金利、日銀、FRB、GDP、CPI、失業率
-**GitHub Status ID**: `c40731f6` (Index)
-**優先度キーワード**: 金融政策、経済指標、日銀決定会合、FOMC
+| 項目 | 値 |
+|------|-----|
+| **テーマキー** | `macro` |
+| **GitHub Status ID** | `c40731f6` (Macro) |
+| **対象キーワード** | 金利, 日銀, FRB, GDP, CPI, 失業率, 為替, 円高, 円安 |
+| **優先度キーワード** | 金融政策, 経済指標, 日銀決定会合, FOMC, 政策金利 |
+| **Reliability Weight** | 1.3 |
 
 ## 重要ルール
 
-1. **テーマ特化**: Indexテーマに関連する記事のみを処理
+1. **テーマ特化**: Macroテーマに関連する記事のみを処理
 2. **重複回避**: 既存Issueとの重複を厳密にチェック
-3. **Status自動設定**: GitHub Project StatusをIndex ("c40731f6") に設定
+3. **Status自動設定**: GitHub Project StatusをMacro (`c40731f6`) に設定
 4. **エラーハンドリング**: 失敗時も処理継続、ログ記録
 
 ## 処理フロー
 
-### Phase 1: 初期化
+**共通処理ガイドを参照してください**:
+`.claude/agents/finance_news_collector/common-processing-guide.md`
+
+### 概要
 
 ```
-[1] 一時ファイル読み込み
-    ↓
-    .tmp/news-collection-{timestamp}.json を読み込む
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 1: 初期化
+├── 一時ファイル読み込み (.tmp/news-collection-{timestamp}.json)
+├── テーマ設定読み込み (themes["macro"])
+└── 統計カウンタ初期化
 
-[2] テーマ設定読み込み
-    ↓
-    data/config/finance-news-themes.json を読み込む
-    themes["macro"] セクションを取得
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 2: フィルタリング
+├── Macroキーワードマッチング
+├── 除外キーワードチェック
+├── 信頼性スコアリング
+└── 重複チェック
 
-[3] 統計カウンタ初期化
-    ↓
-    processed = 0
-    matched = 0
-    excluded = 0
-    duplicates = 0
-    created = 0
-    failed = 0
+Phase 3: GitHub投稿
+├── 記事内容取得と要約生成
+├── Issue作成（Issueテンプレート準拠）
+├── Project 15に追加
+└── Status設定 (Macro: c40731f6)
+
+Phase 4: 結果報告
+└── 統計サマリー出力
 ```
 
-### Phase 2: フィルタリング
+## 判定例
 
-#### ステップ2.1: テーマキーワードマッチング
-
-**各RSS記事に対してIndexキーワードをチェック**:
-
-```python
-def matches_macro_keywords(item: dict, theme: dict) -> tuple[bool, list[str]]:
-    """Indexテーマのキーワードにマッチするかチェック"""
-
-    # 検索対象テキスト
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-
-    # キーワードマッチング（単語境界認識）
-    matched_keywords = []
-    for keyword in theme['keywords']['include']:
-        # 単語境界パターン（\b）を使用
-        pattern = r'\b' + re.escape(keyword.lower()) + r'\b'
-        if re.search(pattern, text, re.IGNORECASE):
-            matched_keywords.append(keyword)
-
-    # 最低マッチ数チェック
-    min_matches = theme['min_keyword_matches']
-    is_match = len(matched_keywords) >= min_matches
-
-    return is_match, matched_keywords
 ```
+記事タイトル: "FRB、利上げを決定"
+→ マッチ: ["FRB", "金利"] → True
 
-**判定例**:
-```
+記事タイトル: "日銀、金融政策を維持"
+→ マッチ: ["日銀", "金融政策"] → True
+
+記事タイトル: "円安進行、1ドル150円に"
+→ マッチ: ["為替", "円安"] → True
+
 記事タイトル: "日経平均、3万円台を回復"
-→ マッチ: ["日経平均", "株価"] → True
-
-記事タイトル: "トヨタ、決算を発表"
-→ マッチ: [] → False（Indexテーマではない）
+→ マッチ: [] → False（Macroテーマではない、Indexテーマ）
 ```
 
-#### ステップ2.2: 除外キーワードチェック
+## 信頼性スコア計算例
 
-**除外キーワードが含まれる場合はスキップ**:
-
-```python
-def is_excluded(item: dict, common: dict) -> bool:
-    """除外対象かチェック"""
-
-    text = f"{item['title']} {item.get('summary', '')}".lower()
-
-    # 除外キーワードチェック
-    for category, keywords in common['exclude_keywords'].items():
-        for keyword in keywords:
-            if keyword.lower() in text:
-                # 金融キーワードも含む場合は除外しない
-                is_match, _ = matches_macro_keywords(item, theme)
-                if not is_match:
-                    ログ出力: f"除外: {item['title']} (理由: {category}:{keyword})"
-                    return True
-
-    return False
 ```
-
-#### ステップ2.3: 信頼性スコアリング
-
-**記事の信頼性スコアを計算（0-100）**:
-
-```python
-def calculate_reliability_score(item: dict, theme: dict, common: dict) -> int:
-    """信頼性スコアを計算"""
-
-    link = item.get('link', '')
-
-    # Tier判定（情報源の信頼性）
-    tier = 1
-    for domain in common['sources']['tier1']:
-        if domain in link:
-            tier = 3
-            break
-    if tier == 1:
-        for domain in common['sources']['tier2']:
-            if domain in link:
-                tier = 2
-                break
-
-    # キーワードマッチ度
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-    keyword_matches = sum(1 for kw in theme['keywords']['include'] if kw.lower() in text)
-    keyword_ratio = min(keyword_matches / 10, 1.0)  # 10キーワードで満点
-
-    # Priority boost（重要キーワードボーナス）
-    boost = 1.0
-    for priority_kw in theme['keywords']['priority_boost']:
-        if priority_kw.lower() in item['title'].lower():
-            boost = 1.5
-            break
-
-    # Reliability weight（テーマ別ウェイト）
-    weight = theme.get('reliability_weight', 1.0)
-
-    # スコア計算
-    score = tier * keyword_ratio * boost * weight * 100
-
-    return min(int(score), 100)
-```
-
-**スコア計算例**:
-```
-記事: "日経平均株価、3万円台を回復"
-ソース: nikkei.com (Tier 1)
+記事: "FOMC、金融政策を据え置き"
+ソース: reuters.com (Tier 1)
 
 tier = 3 (Tier 1)
-keyword_matches = 3 (日経平均, 株価, 回復)
-keyword_ratio = 0.3
-boost = 1.5 (priority_boost: "日経平均株価")
-weight = 1.0 (Indexテーマ)
+keyword_matches = 2 (FOMC, 金融政策)
+keyword_ratio = 0.2
+boost = 1.5 (priority_boost: "FOMC")
+weight = 1.3 (Macroテーマ)
 
-score = 3 × 0.3 × 1.5 × 1.0 × 100 = 135 → 100（上限）
+score = 3 × 0.2 × 1.5 × 1.3 × 100 = 117 → 100（上限）
 ```
 
-#### ステップ2.4: 重複チェック
-
-**既存Issueとの重複を判定**:
-
-```python
-def calculate_title_similarity(title1: str, title2: str) -> float:
-    """タイトルの類似度を計算（Jaccard係数）"""
-
-    words1 = set(title1.lower().split())
-    words2 = set(title2.lower().split())
-
-    if not words1 or not words2:
-        return 0.0
-
-    common = words1.intersection(words2)
-    total = words1.union(words2)
-
-    return len(common) / len(total)
-
-
-def is_duplicate(new_item: dict, existing_issues: list[dict], threshold: float) -> bool:
-    """既存Issueと重複しているかチェック"""
-
-    new_link = new_item.get('link', '')
-    new_title = new_item.get('title', '')
-
-    for issue in existing_issues:
-        # URL完全一致
-        body = issue.get('body', '')
-        if new_link and new_link in body:
-            ログ出力: f"重複: {new_title} (URL一致: Issue #{issue['number']})"
-            return True
-
-        # タイトル類似度チェック
-        issue_title = issue.get('title', '')
-        similarity = calculate_title_similarity(new_title, issue_title)
-
-        if similarity >= threshold:
-            ログ出力: f"重複: {new_title} (類似度{similarity:.2f}: Issue #{issue['number']})"
-            return True
-
-    return False
-```
-
-### Phase 3: GitHub投稿
-
-#### ステップ3.0: 記事内容取得と要約生成
-
-**重要**: Issue作成前に、必ず記事URLから実際の内容を取得して日本語要約を生成すること。
-
-**記事内容取得の手順**:
-
-```python
-def fetch_article_content(url: str, title: str) -> str:
-    """記事内容を取得（WebFetch → gemini検索の順で試行）"""
-
-    # 1. WebFetchで記事取得を試行
-    try:
-        content = WebFetch(
-            url=url,
-            prompt="""この記事の内容を詳しく要約してください。特に以下の点を含めてください:
-            1. 主要な事実と背景
-            2. 関連企業や機関の動き
-            3. 市場や業界への影響
-            4. 数値データや具体的な情報
-            5. 今後の展望や予測"""
-        )
-        return content
-    except Exception as e:
-        # 2. 失敗した場合（Financial Timesなど）は、gemini検索で代替
-        domain = url.split('/')[2]
-        query = f"{title} {domain}"
-
-        # gemini CLI経由でWeb検索
-        result = subprocess.run(
-            ["gemini", "--prompt", f"WebSearch: {query}"],
-            capture_output=True,
-            text=True
-        )
-        return result.stdout
-
-
-def generate_japanese_summary(content: str, max_length: int = 400) -> str:
-    """記事内容から日本語要約を生成（400字程度）"""
-
-    # Claude APIまたは内部ロジックで要約生成
-    # - 重要なポイントを抽出
-    # - 数値データを優先的に含める
-    # - 日本語で400字程度に整形
-
-    prompt = f"""以下の記事内容を、日本語で400字程度に要約してください。
-
-    要約のポイント:
-    - 主要な事実と数値データを優先
-    - 背景や影響を簡潔に説明
-    - 投資判断に有用な情報を強調
-    - 箇条書きではなく、文章形式で
-
-    記事内容:
-    {content}
-    """
-
-    summary = generate_summary(prompt)
-    return summary
-
-
-def format_published_jst(published_str: str) -> str:
-    """公開日をJST YYYY-MM-DD HH:MM形式に変換"""
-
-    from datetime import datetime
-    import pytz
-
-    # ISO 8601形式をパース
-    dt = datetime.fromisoformat(published_str.replace('Z', '+00:00'))
-
-    # JSTに変換
-    jst = pytz.timezone('Asia/Tokyo')
-    dt_jst = dt.astimezone(jst)
-
-    # YYYY-MM-DD HH:MM形式で出力
-    return dt_jst.strftime('%Y-%m-%d %H:%M')
-```
-
-**実装例**:
-```python
-# 各記事に対して
-for item in filtered_items:
-    # 記事内容を取得
-    article_content = fetch_article_content(item['link'], item['title'])
-
-    # 日本語要約を生成
-    japanese_summary = generate_japanese_summary(article_content, max_length=400)
-
-    # 公開日をJST形式に変換
-    published_jst = format_published_jst(item['published'])
-
-    # Issue作成（要約を含める）
-    create_issue(item, japanese_summary, published_jst)
-```
-
-#### ステップ3.1: Issue作成
-
-**GitHub CLIでIssueを作成**:
-
-```bash
-gh issue create \
-    --repo YH-05/finance \
-    --title "[NEWS] {title}" \
-    --body "$(cat <<'EOF'
-## 日本語要約（400字程度）
-
-{japanese_summary}
-
-## 記事概要
-- テーマ: Macro Economics（マクロ経済）
-- ソース: {source}
-- 信頼性: {score}/100
-- 公開日: {published_jst}
-- URL: {link}
-
-## マッチしたキーワード
-{matched_keywords}
-EOF
-)" \
-    --label "news"
-```
-
-**注意事項**:
-- `{japanese_summary}`: 実際の記事から生成した400字程度の日本語要約
-- `{published_jst}`: JST形式（YYYY-MM-DD HH:MM）例: "2026-01-15 09:04"
-- 「サマリー」セクションは削除（RSSメタデータのサマリーは不要）
-- 「次のアクション」セクションは削除（要約済みのため不要）
-
-**作成後、Issue URLを取得**:
-```bash
-# 出力から Issue URL を抽出
-# 例: https://github.com/YH-05/finance/issues/200
-```
-
-#### ステップ3.2: Project追加
-
-**GitHub CLIでProject 15に追加**:
-
-```bash
-gh project item-add 15 \
-    --owner YH-05 \
-    --url {issue_url}
-```
-
-**出力から Project Item ID を取得**:
-```json
-{
-  "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-  "project": {
-    "id": "PVT_kwHOBoK6AM4BMpw_",
-    "number": 15
-  }
-}
-```
-
-#### ステップ3.3: Status設定（GraphQL API）
-
-**Step 1: Issue Node IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  repository(owner: "YH-05", name: "finance") {
-    issue(number: {issue_number}) {
-      id
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "repository": {
-      "issue": {
-        "id": "I_kwDOBoK6AM6YZ..."
-      }
-    }
-  }
-}
-```
-
-**Step 2: Project Item IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  node(id: "{issue_node_id}") {
-    ... on Issue {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project {
-            number
-          }
-        }
-      }
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "node": {
-      "projectItems": {
-        "nodes": [
-          {
-            "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-            "project": {
-              "number": 15
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-**Step 3: StatusフィールドをIndexに設定**
-
-```bash
-gh api graphql -f query='
-mutation {
-  updateProjectV2ItemFieldValue(
-    input: {
-      projectId: "PVT_kwHOBoK6AM4BMpw_"
-      itemId: "{project_item_id}"
-      fieldId: "PVTSSF_lAHOBoK6AM4BMpw_zg739ZE"
-      value: {
-        singleSelectOptionId: "c40731f6"
-      }
-    }
-  ) {
-    projectV2Item {
-      id
-    }
-  }
-}'
-```
-
-**成功時の出力**:
-```json
-{
-  "data": {
-    "updateProjectV2ItemFieldValue": {
-      "projectV2Item": {
-        "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy..."
-      }
-    }
-  }
-}
-```
-
-### Phase 4: 結果報告
-
-#### ステップ4.1: 統計サマリー出力
-
-```markdown
-## Macro Economics（マクロ経済）ニュース収集完了
-
-### 処理統計
-- **処理記事数**: {processed}件
-- **テーママッチ**: {matched}件
-- **除外**: {excluded}件
-- **重複**: {duplicates}件
-- **新規投稿**: {created}件
-- **投稿失敗**: {failed}件
-
-### 投稿されたニュース
-
-1. **日経平均、3万円台を回復** [#200]
-   - ソース: 日経新聞
-   - 信頼性: 95/100
-   - URL: https://github.com/YH-05/finance/issues/200
-
-2. **S&P500、史上最高値を更新** [#201]
-   - ソース: Reuters
-   - 信頼性: 90/100
-   - URL: https://github.com/YH-05/finance/issues/201
-
-### 除外されたニュース
-- スポーツ関連: 2件
-- エンタメ関連: 1件
-- テーマ不一致: 5件
-```
-
-## エラーハンドリング
-
-### E001: 一時ファイル読み込みエラー
-
-**発生条件**:
-- `.tmp/news-collection-{timestamp}.json` が存在しない
-- JSON形式が不正
-
-**対処法**:
-```python
-try:
-    with open(filepath) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    ログ出力: f"エラー: 一時ファイルが見つかりません: {filepath}"
-    ログ出力: "オーケストレーターが正しく実行されたか確認してください"
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    ログ出力: f"エラー: JSON形式が不正です: {e}"
-    sys.exit(1)
-```
-
-### E002: テーマ設定読み込みエラー
-
-**発生条件**:
-- `data/config/finance-news-themes.json` が存在しない
-- "macro"テーマが定義されていない
-
-**対処法**:
-```python
-try:
-    with open("data/config/finance-news-themes.json") as f:
-        config = json.load(f)
-    theme = config['themes']['macro']
-    common = config['common']
-except FileNotFoundError:
-    ログ出力: "エラー: テーマ設定ファイルが見つかりません"
-    sys.exit(1)
-except KeyError:
-    ログ出力: "エラー: 'macro' テーマが定義されていません"
-    sys.exit(1)
-```
-
-### E003: Issue作成エラー
-
-**発生条件**:
-- GitHub API エラー
-- 認証エラー
-- レート制限
-
-**対処法**:
-```python
-try:
-    result = subprocess.run(
-        ["gh", "issue", "create", ...],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Issue作成失敗: {item['title']}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-
-    # レート制限エラーの場合
-    if "rate limit" in str(e.stderr).lower():
-        ログ出力: "GitHub API レート制限に達しました。1時間待機してください。"
-
-    failed += 1
-    continue  # 次の記事の処理を継続
-```
-
-### E004: Status設定エラー
-
-**発生条件**:
-- GraphQL API エラー
-- Project Item IDが取得できない
-- 権限エラー
-
-**対処法**:
-```python
-try:
-    # GraphQL mutation実行
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={mutation}"],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Status設定失敗: Issue #{issue_number}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-    ログ出力: "Issue作成は成功しています。手動でStatusを設定してください。"
-
-    # 処理は継続（Issueは作成済み）
-    continue
-```
-
-### E005: ネットワークエラー
-
-**発生条件**:
-- GitHub APIへの接続失敗
-- タイムアウト
-
-**対処法**:
-- リトライロジック（最大3回、指数バックオフ）
-- エラーログ記録
-- 処理継続（失敗した記事をスキップ）
-
-## 実行例
-
-### 基本的な使用方法
-
-```
-1. Index エージェントを起動
-2. 一時ファイルからデータ読み込み
-3. Indexキーワードでフィルタリング
-4. 重複チェック
-5. GitHub Issueを作成（Status=Index）
-6. 結果サマリーを出力
-```
-
-### 実行ログの例
+## 実行ログの例
 
 ```
 [INFO] 一時ファイル読み込み: .tmp/news-collection-20260115-143000.json
 [INFO] テーマ設定読み込み: data/config/finance-news-themes.json
-[INFO] Index テーマ処理開始
+[INFO] Macro テーマ処理開始
 [INFO] 処理記事数: 50件
 
 [INFO] テーママッチング中...
-[INFO] マッチ: 日経平均、3万円台を回復 (キーワード: 日経平均, 株価)
-[INFO] マッチ: S&P500、史上最高値を更新 (キーワード: S&P500, 指数)
+[INFO] マッチ: FRB、利上げを決定 (キーワード: FRB, 金利)
+[INFO] マッチ: 日銀、金融政策を維持 (キーワード: 日銀, 金融政策)
 [INFO] 除外: サッカーW杯決勝 (理由: sports:サッカー)
-[INFO] テーママッチ: 12件
+[INFO] テーママッチ: 10件
 
 [INFO] 重複チェック中...
-[INFO] 重複: NYダウ、最高値更新 (URL一致: Issue #190)
-[INFO] 新規記事: 5件
+[INFO] 重複: 円安進行、1ドル150円 (URL一致: Issue #185)
+[INFO] 新規記事: 4件
 
 [INFO] GitHub Issue作成中...
-[INFO] Issue作成成功: #200 - 日経平均、3万円台を回復
-[INFO] Project追加成功: #200
-[INFO] Status設定成功: #200 → Index
-[INFO] Issue作成成功: #201 - S&P500、史上最高値を更新
-[INFO] Project追加成功: #201
-[INFO] Status設定成功: #201 → Index
+[INFO] Issue作成成功: #202 - FRB、利上げを決定
+[INFO] Project追加成功: #202
+[INFO] Status設定成功: #202 → Macro
 
 ## Macro Economics（マクロ経済）ニュース収集完了
 
 ### 処理統計
 - **処理記事数**: 50件
-- **テーママッチ**: 12件
-- **除外**: 3件
-- **重複**: 7件
-- **新規投稿**: 5件
+- **テーママッチ**: 10件
+- **除外**: 2件
+- **重複**: 6件
+- **新規投稿**: 4件
 - **投稿失敗**: 0件
 ```
 
 ## 参考資料
 
+- **共通処理ガイド**: `.claude/agents/finance_news_collector/common-processing-guide.md`
 - **テーマ設定**: `data/config/finance-news-themes.json`
+- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.yml`
 - **オーケストレーター**: `.claude/agents/finance-news-orchestrator.md`
-- **他のテーマエージェント**: `.claude/agents/finance-news-{theme}.md`
-- **コマンド**: `.claude/commands/collect-finance-news.md`
 - **GitHub Project**: https://github.com/users/YH-05/projects/15
 
 ## 制約事項

--- a/.claude/agents/finance-news-sector.md
+++ b/.claude/agents/finance-news-sector.md
@@ -17,74 +17,52 @@ priority: high
 
 ## テーマ: Sector（セクター分析）
 
-**対象キーワード**: 銀行、証券、保険、フィンテック、自動車、半導体
-**GitHub Status ID**: `98236657` (Sector)
-**優先度キーワード**: 業界再編、セクター分析、産業動向
+| 項目 | 値 |
+|------|-----|
+| **テーマキー** | `sector` |
+| **GitHub Status ID** | `98236657` (Sector) |
+| **対象キーワード** | 銀行, 証券, 保険, フィンテック, 自動車, 半導体, エネルギー |
+| **優先度キーワード** | 業界再編, セクター分析, 産業動向 |
+| **Reliability Weight** | 1.0 |
 
 ## 重要ルール
 
 1. **テーマ特化**: Sectorテーマに関連する記事のみを処理
 2. **重複回避**: 既存Issueとの重複を厳密にチェック
-3. **Status自動設定**: GitHub Project StatusをSector ("98236657") に設定
+3. **Status自動設定**: GitHub Project StatusをSector (`98236657`) に設定
 4. **エラーハンドリング**: 失敗時も処理継続、ログ記録
 
 ## 処理フロー
 
-### Phase 1: 初期化
+**共通処理ガイドを参照してください**:
+`.claude/agents/finance_news_collector/common-processing-guide.md`
+
+### 概要
 
 ```
-[1] 一時ファイル読み込み
-    ↓
-    .tmp/news-collection-{timestamp}.json を読み込む
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 1: 初期化
+├── 一時ファイル読み込み (.tmp/news-collection-{timestamp}.json)
+├── テーマ設定読み込み (themes["sector"])
+└── 統計カウンタ初期化
 
-[2] テーマ設定読み込み
-    ↓
-    data/config/finance-news-themes.json を読み込む
-    themes["sector"] セクションを取得
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 2: フィルタリング
+├── Sectorキーワードマッチング
+├── 除外キーワードチェック
+├── 信頼性スコアリング
+└── 重複チェック
 
-[3] 統計カウンタ初期化
-    ↓
-    processed = 0
-    matched = 0
-    excluded = 0
-    duplicates = 0
-    created = 0
-    failed = 0
+Phase 3: GitHub投稿
+├── 記事内容取得と要約生成
+├── Issue作成（Issueテンプレート準拠）
+├── Project 15に追加
+└── Status設定 (Sector: 98236657)
+
+Phase 4: 結果報告
+└── 統計サマリー出力
 ```
 
-### Phase 2: フィルタリング
+## 判定例
 
-#### ステップ2.1: テーマキーワードマッチング
-
-**各RSS記事に対してSectorキーワードをチェック**:
-
-```python
-def matches_sector_keywords(item: dict, theme: dict) -> tuple[bool, list[str]]:
-    """Sectorテーマのキーワードにマッチするかチェック"""
-
-    # 検索対象テキスト
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-
-    # キーワードマッチング（単語境界認識）
-    matched_keywords = []
-    for keyword in theme['keywords']['include']:
-        # 単語境界パターン（\b）を使用
-        pattern = r'\b' + re.escape(keyword.lower()) + r'\b'
-        if re.search(pattern, text, re.IGNORECASE):
-            matched_keywords.append(keyword)
-
-    # 最低マッチ数チェック
-    min_matches = theme['min_keyword_matches']
-    is_match = len(matched_keywords) >= min_matches
-
-    return is_match, matched_keywords
-```
-
-**判定例**:
 ```
 記事タイトル: "三菱UFJ、デジタル決済強化へ"
 → マッチ: ["銀行", "決済"] → True
@@ -92,77 +70,15 @@ def matches_sector_keywords(item: dict, theme: dict) -> tuple[bool, list[str]]:
 記事タイトル: "トヨタ、EV半導体を内製化"
 → マッチ: ["自動車", "半導体"] → True
 
+記事タイトル: "半導体業界、AI需要で活況"
+→ マッチ: ["半導体", "業界"] → True
+
 記事タイトル: "日経平均、3万円台を回復"
 → マッチ: [] → False（Sectorテーマではない、Indexテーマ）
 ```
 
-#### ステップ2.2: 除外キーワードチェック
+## 信頼性スコア計算例
 
-**除外キーワードが含まれる場合はスキップ**:
-
-```python
-def is_excluded(item: dict, common: dict) -> bool:
-    """除外対象かチェック"""
-
-    text = f"{item['title']} {item.get('summary', '')}".lower()
-
-    # 除外キーワードチェック
-    for category, keywords in common['exclude_keywords'].items():
-        for keyword in keywords:
-            if keyword.lower() in text:
-                # 金融キーワードも含む場合は除外しない
-                is_match, _ = matches_sector_keywords(item, theme)
-                if not is_match:
-                    ログ出力: f"除外: {item['title']} (理由: {category}:{keyword})"
-                    return True
-
-    return False
-```
-
-#### ステップ2.3: 信頼性スコアリング
-
-**記事の信頼性スコアを計算（0-100）**:
-
-```python
-def calculate_reliability_score(item: dict, theme: dict, common: dict) -> int:
-    """信頼性スコアを計算"""
-
-    link = item.get('link', '')
-
-    # Tier判定（情報源の信頼性）
-    tier = 1
-    for domain in common['sources']['tier1']:
-        if domain in link:
-            tier = 3
-            break
-    if tier == 1:
-        for domain in common['sources']['tier2']:
-            if domain in link:
-                tier = 2
-                break
-
-    # キーワードマッチ度
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-    keyword_matches = sum(1 for kw in theme['keywords']['include'] if kw.lower() in text)
-    keyword_ratio = min(keyword_matches / 10, 1.0)  # 10キーワードで満点
-
-    # Priority boost（重要キーワードボーナス）
-    boost = 1.0
-    for priority_kw in theme['keywords']['priority_boost']:
-        if priority_kw.lower() in item['title'].lower():
-            boost = 1.5
-            break
-
-    # Reliability weight（テーマ別ウェイト）
-    weight = theme.get('reliability_weight', 1.0)
-
-    # スコア計算
-    score = tier * keyword_ratio * boost * weight * 100
-
-    return min(int(score), 100)
-```
-
-**スコア計算例**:
 ```
 記事: "自動車業界、EV化で大規模再編"
 ソース: nikkei.com (Tier 1)
@@ -176,464 +92,7 @@ weight = 1.0 (Sectorテーマ)
 score = 3 × 0.3 × 1.5 × 1.0 × 100 = 135 → 100（上限）
 ```
 
-#### ステップ2.4: 重複チェック
-
-**既存Issueとの重複を判定**:
-
-```python
-def calculate_title_similarity(title1: str, title2: str) -> float:
-    """タイトルの類似度を計算（Jaccard係数）"""
-
-    words1 = set(title1.lower().split())
-    words2 = set(title2.lower().split())
-
-    if not words1 or not words2:
-        return 0.0
-
-    common = words1.intersection(words2)
-    total = words1.union(words2)
-
-    return len(common) / len(total)
-
-
-def is_duplicate(new_item: dict, existing_issues: list[dict], threshold: float) -> bool:
-    """既存Issueと重複しているかチェック"""
-
-    new_link = new_item.get('link', '')
-    new_title = new_item.get('title', '')
-
-    for issue in existing_issues:
-        # URL完全一致
-        body = issue.get('body', '')
-        if new_link and new_link in body:
-            ログ出力: f"重複: {new_title} (URL一致: Issue #{issue['number']})"
-            return True
-
-        # タイトル類似度チェック
-        issue_title = issue.get('title', '')
-        similarity = calculate_title_similarity(new_title, issue_title)
-
-        if similarity >= threshold:
-            ログ出力: f"重複: {new_title} (類似度{similarity:.2f}: Issue #{issue['number']})"
-            return True
-
-    return False
-```
-
-### Phase 3: GitHub投稿
-
-#### ステップ3.0: 記事内容取得と要約生成
-
-**重要**: Issue作成前に、必ず記事URLから実際の内容を取得して日本語要約を生成すること。
-
-**記事内容取得の手順**:
-
-```python
-def fetch_article_content(url: str, title: str) -> str:
-    """記事内容を取得（WebFetch → gemini検索の順で試行）"""
-
-    # 1. WebFetchで記事取得を試行
-    try:
-        content = WebFetch(
-            url=url,
-            prompt="""この記事の内容を詳しく要約してください。特に以下の点を含めてください:
-            1. 主要な事実と背景
-            2. 関連企業や機関の動き
-            3. 市場や業界への影響
-            4. 数値データや具体的な情報
-            5. 今後の展望や予測"""
-        )
-        return content
-    except Exception as e:
-        # 2. 失敗した場合（Financial Timesなど）は、gemini検索で代替
-        domain = url.split('/')[2]
-        query = f"{title} {domain}"
-
-        # gemini CLI経由でWeb検索
-        result = subprocess.run(
-            ["gemini", "--prompt", f"WebSearch: {query}"],
-            capture_output=True,
-            text=True
-        )
-        return result.stdout
-
-
-def generate_japanese_summary(content: str, max_length: int = 400) -> str:
-    """記事内容から日本語要約を生成（400字程度）"""
-
-    # Claude APIまたは内部ロジックで要約生成
-    # - 重要なポイントを抽出
-    # - 数値データを優先的に含める
-    # - 日本語で400字程度に整形
-
-    prompt = f"""以下の記事内容を、日本語で400字程度に要約してください。
-
-    要約のポイント:
-    - 主要な事実と数値データを優先
-    - 背景や影響を簡潔に説明
-    - 投資判断に有用な情報を強調
-    - 箇条書きではなく、文章形式で
-
-    記事内容:
-    {content}
-    """
-
-    summary = generate_summary(prompt)
-    return summary
-
-
-def format_published_jst(published_str: str) -> str:
-    """公開日をJST YYYY-MM-DD HH:MM形式に変換"""
-
-    from datetime import datetime
-    import pytz
-
-    # ISO 8601形式をパース
-    dt = datetime.fromisoformat(published_str.replace('Z', '+00:00'))
-
-    # JSTに変換
-    jst = pytz.timezone('Asia/Tokyo')
-    dt_jst = dt.astimezone(jst)
-
-    # YYYY-MM-DD HH:MM形式で出力
-    return dt_jst.strftime('%Y-%m-%d %H:%M')
-```
-
-**実装例**:
-```python
-# 各記事に対して
-for item in filtered_items:
-    # 記事内容を取得
-    article_content = fetch_article_content(item['link'], item['title'])
-
-    # 日本語要約を生成
-    japanese_summary = generate_japanese_summary(article_content, max_length=400)
-
-    # 公開日をJST形式に変換
-    published_jst = format_published_jst(item['published'])
-
-    # Issue作成（要約を含める）
-    create_issue(item, japanese_summary, published_jst)
-```
-
-#### ステップ3.1: Issue作成
-
-**GitHub CLIでIssueを作成**:
-
-```bash
-gh issue create \
-    --repo YH-05/finance \
-    --title "[NEWS] {title}" \
-    --body "$(cat <<'EOF'
-## 日本語要約（400字程度）
-
-{japanese_summary}
-
-## 記事概要
-- テーマ: Sector（セクター分析）
-- ソース: {source}
-- 信頼性: {score}/100
-- 公開日: {published_jst}
-- URL: {link}
-
-## マッチしたキーワード
-{matched_keywords}
-EOF
-)" \
-    --label "news"
-```
-
-**注意事項**:
-- `{japanese_summary}`: 実際の記事から生成した400字程度の日本語要約
-- `{published_jst}`: JST形式（YYYY-MM-DD HH:MM）例: "2026-01-15 09:04"
-- 「サマリー」セクションは削除（RSSメタデータのサマリーは不要）
-- 「次のアクション」セクションは削除（要約済みのため不要）
-
-**作成後、Issue URLを取得**:
-```bash
-# 出力から Issue URL を抽出
-# 例: https://github.com/YH-05/finance/issues/200
-```
-
-#### ステップ3.2: Project追加
-
-**GitHub CLIでProject 15に追加**:
-
-```bash
-gh project item-add 15 \
-    --owner YH-05 \
-    --url {issue_url}
-```
-
-**出力から Project Item ID を取得**:
-```json
-{
-  "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-  "project": {
-    "id": "PVT_kwHOBoK6AM4BMpw_",
-    "number": 15
-  }
-}
-```
-
-#### ステップ3.3: Status設定（GraphQL API）
-
-**Step 1: Issue Node IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  repository(owner: "YH-05", name: "finance") {
-    issue(number: {issue_number}) {
-      id
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "repository": {
-      "issue": {
-        "id": "I_kwDOBoK6AM6YZ..."
-      }
-    }
-  }
-}
-```
-
-**Step 2: Project Item IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  node(id: "{issue_node_id}") {
-    ... on Issue {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project {
-            number
-          }
-        }
-      }
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "node": {
-      "projectItems": {
-        "nodes": [
-          {
-            "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-            "project": {
-              "number": 15
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-**Step 3: StatusフィールドをSectorに設定**
-
-```bash
-gh api graphql -f query='
-mutation {
-  updateProjectV2ItemFieldValue(
-    input: {
-      projectId: "PVT_kwHOBoK6AM4BMpw_"
-      itemId: "{project_item_id}"
-      fieldId: "PVTSSF_lAHOBoK6AM4BMpw_zg739ZE"
-      value: {
-        singleSelectOptionId: "98236657"
-      }
-    }
-  ) {
-    projectV2Item {
-      id
-    }
-  }
-}'
-```
-
-**成功時の出力**:
-```json
-{
-  "data": {
-    "updateProjectV2ItemFieldValue": {
-      "projectV2Item": {
-        "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy..."
-      }
-    }
-  }
-}
-```
-
-### Phase 4: 結果報告
-
-#### ステップ4.1: 統計サマリー出力
-
-```markdown
-## Sector（セクター分析）ニュース収集完了
-
-### 処理統計
-- **処理記事数**: {processed}件
-- **テーママッチ**: {matched}件
-- **除外**: {excluded}件
-- **重複**: {duplicates}件
-- **新規投稿**: {created}件
-- **投稿失敗**: {failed}件
-
-### 投稿されたニュース
-
-1. **三菱UFJ、デジタル決済事業を強化** [#200]
-   - ソース: 日経新聞
-   - 信頼性: 95/100
-   - URL: https://github.com/YH-05/finance/issues/200
-
-2. **半導体業界、AI需要で活況** [#201]
-   - ソース: Reuters
-   - 信頼性: 90/100
-   - URL: https://github.com/YH-05/finance/issues/201
-
-### 除外されたニュース
-- スポーツ関連: 2件
-- エンタメ関連: 1件
-- テーマ不一致: 5件
-```
-
-## エラーハンドリング
-
-### E001: 一時ファイル読み込みエラー
-
-**発生条件**:
-- `.tmp/news-collection-{timestamp}.json` が存在しない
-- JSON形式が不正
-
-**対処法**:
-```python
-try:
-    with open(filepath) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    ログ出力: f"エラー: 一時ファイルが見つかりません: {filepath}"
-    ログ出力: "オーケストレーターが正しく実行されたか確認してください"
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    ログ出力: f"エラー: JSON形式が不正です: {e}"
-    sys.exit(1)
-```
-
-### E002: テーマ設定読み込みエラー
-
-**発生条件**:
-- `data/config/finance-news-themes.json` が存在しない
-- "sector"テーマが定義されていない
-
-**対処法**:
-```python
-try:
-    with open("data/config/finance-news-themes.json") as f:
-        config = json.load(f)
-    theme = config['themes']['sector']
-    common = config['common']
-except FileNotFoundError:
-    ログ出力: "エラー: テーマ設定ファイルが見つかりません"
-    sys.exit(1)
-except KeyError:
-    ログ出力: "エラー: 'sector' テーマが定義されていません"
-    sys.exit(1)
-```
-
-### E003: Issue作成エラー
-
-**発生条件**:
-- GitHub API エラー
-- 認証エラー
-- レート制限
-
-**対処法**:
-```python
-try:
-    result = subprocess.run(
-        ["gh", "issue", "create", ...],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Issue作成失敗: {item['title']}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-
-    # レート制限エラーの場合
-    if "rate limit" in str(e.stderr).lower():
-        ログ出力: "GitHub API レート制限に達しました。1時間待機してください。"
-
-    failed += 1
-    continue  # 次の記事の処理を継続
-```
-
-### E004: Status設定エラー
-
-**発生条件**:
-- GraphQL API エラー
-- Project Item IDが取得できない
-- 権限エラー
-
-**対処法**:
-```python
-try:
-    # GraphQL mutation実行
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={mutation}"],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Status設定失敗: Issue #{issue_number}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-    ログ出力: "Issue作成は成功しています。手動でStatusを設定してください。"
-
-    # 処理は継続（Issueは作成済み）
-    continue
-```
-
-### E005: ネットワークエラー
-
-**発生条件**:
-- GitHub APIへの接続失敗
-- タイムアウト
-
-**対処法**:
-- リトライロジック（最大3回、指数バックオフ）
-- エラーログ記録
-- 処理継続（失敗した記事をスキップ）
-
-## 実行例
-
-### 基本的な使用方法
-
-```
-1. Sector エージェントを起動
-2. 一時ファイルからデータ読み込み
-3. Sectorキーワードでフィルタリング
-4. 重複チェック
-5. GitHub Issueを作成（Status=Sector）
-6. 結果サマリーを出力
-```
-
-### 実行ログの例
+## 実行ログの例
 
 ```
 [INFO] 一時ファイル読み込み: .tmp/news-collection-20260115-143000.json
@@ -652,30 +111,27 @@ except subprocess.CalledProcessError as e:
 [INFO] 新規記事: 5件
 
 [INFO] GitHub Issue作成中...
-[INFO] Issue作成成功: #200 - 三菱UFJ、デジタル決済強化へ
-[INFO] Project追加成功: #200
-[INFO] Status設定成功: #200 → Sector
-[INFO] Issue作成成功: #201 - 半導体業界、AI需要で活況
-[INFO] Project追加成功: #201
-[INFO] Status設定成功: #201 → Sector
+[INFO] Issue作成成功: #203 - 三菱UFJ、デジタル決済強化へ
+[INFO] Project追加成功: #203
+[INFO] Status設定成功: #203 → Sector
 
 ## Sector（セクター分析）ニュース収集完了
 
 ### 処理統計
 - **処理記事数**: 50件
-- **テーママッチ**: 12件
+- **テーママッチ**: 8件
 - **除外**: 3件
-- **重複**: 7件
+- **重複**: 3件
 - **新規投稿**: 5件
 - **投稿失敗**: 0件
 ```
 
 ## 参考資料
 
+- **共通処理ガイド**: `.claude/agents/finance_news_collector/common-processing-guide.md`
 - **テーマ設定**: `data/config/finance-news-themes.json`
+- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.yml`
 - **オーケストレーター**: `.claude/agents/finance-news-orchestrator.md`
-- **他のテーマエージェント**: `.claude/agents/finance-news-{theme}.md`
-- **コマンド**: `.claude/commands/collect-finance-news.md`
 - **GitHub Project**: https://github.com/users/YH-05/projects/15
 
 ## 制約事項

--- a/.claude/agents/finance-news-stock.md
+++ b/.claude/agents/finance-news-stock.md
@@ -2,7 +2,7 @@
 name: finance-news-stock
 description: Stock（個別銘柄）関連ニュースを収集・投稿するテーマ別エージェント
 input: .tmp/news-collection-{timestamp}.json, data/config/finance-news-themes.json
-output: GitHub Issues (Project 15, Status=Index)
+output: GitHub Issues (Project 15, Status=Stock)
 model: inherit
 color: green
 depends_on: [finance-news-orchestrator]
@@ -17,664 +17,121 @@ priority: high
 
 ## テーマ: Stock（個別銘柄）
 
-**対象キーワード**: 決算、業績、EPS、ROE、M&A、買収
-**GitHub Status ID**: `47fc9ee4` (Index)
-**優先度キーワード**: 決算短信、M&A、買収、合併
+| 項目 | 値 |
+|------|-----|
+| **テーマキー** | `stock` |
+| **GitHub Status ID** | `47fc9ee4` (Stock) |
+| **対象キーワード** | 決算, 業績, EPS, ROE, ROA, M&A, 買収, 合併, 増収, 減益 |
+| **優先度キーワード** | 決算短信, M&A, 買収, 合併, 業績予想 |
+| **Reliability Weight** | 1.2 |
 
 ## 重要ルール
 
-1. **テーマ特化**: Indexテーマに関連する記事のみを処理
+1. **テーマ特化**: Stockテーマに関連する記事のみを処理
 2. **重複回避**: 既存Issueとの重複を厳密にチェック
-3. **Status自動設定**: GitHub Project StatusをIndex ("47fc9ee4") に設定
+3. **Status自動設定**: GitHub Project StatusをStock (`47fc9ee4`) に設定
 4. **エラーハンドリング**: 失敗時も処理継続、ログ記録
 
 ## 処理フロー
 
-### Phase 1: 初期化
+**共通処理ガイドを参照してください**:
+`.claude/agents/finance_news_collector/common-processing-guide.md`
+
+### 概要
 
 ```
-[1] 一時ファイル読み込み
-    ↓
-    .tmp/news-collection-{timestamp}.json を読み込む
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 1: 初期化
+├── 一時ファイル読み込み (.tmp/news-collection-{timestamp}.json)
+├── テーマ設定読み込み (themes["stock"])
+└── 統計カウンタ初期化
 
-[2] テーマ設定読み込み
-    ↓
-    data/config/finance-news-themes.json を読み込む
-    themes["stock"] セクションを取得
-    ↓ エラーの場合
-    エラーログ出力 → 処理中断
+Phase 2: フィルタリング
+├── Stockキーワードマッチング
+├── 除外キーワードチェック
+├── 信頼性スコアリング
+└── 重複チェック
 
-[3] 統計カウンタ初期化
-    ↓
-    processed = 0
-    matched = 0
-    excluded = 0
-    duplicates = 0
-    created = 0
-    failed = 0
+Phase 3: GitHub投稿
+├── 記事内容取得と要約生成
+├── Issue作成（Issueテンプレート準拠）
+├── Project 15に追加
+└── Status設定 (Stock: 47fc9ee4)
+
+Phase 4: 結果報告
+└── 統計サマリー出力
 ```
 
-### Phase 2: フィルタリング
+## 判定例
 
-#### ステップ2.1: テーマキーワードマッチング
-
-**各RSS記事に対してIndexキーワードをチェック**:
-
-```python
-import re
-
-def matches_stock_keywords(item: dict, theme: dict) -> tuple[bool, list[str]]:
-    """Stockテーマのキーワードにマッチするかチェック（単語境界認識版）"""
-
-    # 検索対象テキスト
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-
-    # キーワードマッチング（単語境界認識）
-    matched_keywords = []
-    for keyword in theme['keywords']['include']:
-        # 単語境界パターン（\b）を使用
-        pattern = r'\b' + re.escape(keyword.lower()) + r'\b'
-        if re.search(pattern, text, re.IGNORECASE):
-            matched_keywords.append(keyword)
-
-    # 最低マッチ数チェック
-    min_matches = theme['min_keyword_matches']
-    is_match = len(matched_keywords) >= min_matches
-
-    return is_match, matched_keywords
 ```
+記事タイトル: "トヨタ、決算を発表 増収増益"
+→ マッチ: ["決算", "増収"] → True
 
-**判定例**:
-```
+記事タイトル: "ソフトバンク、ARM買収を完了"
+→ マッチ: ["買収", "M&A"] → True
+
+記事タイトル: "三菱商事、上方修正を発表"
+→ マッチ: ["上方修正", "業績"] → True
+
 記事タイトル: "日経平均、3万円台を回復"
-→ マッチ: ["日経平均", "株価"] → True
-
-記事タイトル: "トヨタ、決算を発表"
-→ マッチ: [] → False（Indexテーマではない）
+→ マッチ: [] → False（Stockテーマではない、Indexテーマ）
 ```
 
-#### ステップ2.2: 除外キーワードチェック
+## 信頼性スコア計算例
 
-**除外キーワードが含まれる場合はスキップ**:
-
-```python
-def is_excluded(item: dict, common: dict) -> bool:
-    """除外対象かチェック"""
-
-    text = f"{item['title']} {item.get('summary', '')}".lower()
-
-    # 除外キーワードチェック
-    for category, keywords in common['exclude_keywords'].items():
-        for keyword in keywords:
-            if keyword.lower() in text:
-                # 金融キーワードも含む場合は除外しない
-                is_match, _ = matches_stock_keywords(item, theme)
-                if not is_match:
-                    ログ出力: f"除外: {item['title']} (理由: {category}:{keyword})"
-                    return True
-
-    return False
 ```
-
-#### ステップ2.3: 信頼性スコアリング
-
-**記事の信頼性スコアを計算（0-100）**:
-
-```python
-def calculate_reliability_score(item: dict, theme: dict, common: dict) -> int:
-    """信頼性スコアを計算"""
-
-    link = item.get('link', '')
-
-    # Tier判定（情報源の信頼性）
-    tier = 1
-    for domain in common['sources']['tier1']:
-        if domain in link:
-            tier = 3
-            break
-    if tier == 1:
-        for domain in common['sources']['tier2']:
-            if domain in link:
-                tier = 2
-                break
-
-    # キーワードマッチ度
-    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
-    keyword_matches = sum(1 for kw in theme['keywords']['include'] if kw.lower() in text)
-    keyword_ratio = min(keyword_matches / 10, 1.0)  # 10キーワードで満点
-
-    # Priority boost（重要キーワードボーナス）
-    boost = 1.0
-    for priority_kw in theme['keywords']['priority_boost']:
-        if priority_kw.lower() in item['title'].lower():
-            boost = 1.5
-            break
-
-    # Reliability weight（テーマ別ウェイト）
-    weight = theme.get('reliability_weight', 1.0)
-
-    # スコア計算
-    score = tier * keyword_ratio * boost * weight * 100
-
-    return min(int(score), 100)
-```
-
-**スコア計算例**:
-```
-記事: "日経平均株価、3万円台を回復"
+記事: "トヨタ、決算短信を発表 過去最高益"
 ソース: nikkei.com (Tier 1)
 
 tier = 3 (Tier 1)
-keyword_matches = 3 (日経平均, 株価, 回復)
-keyword_ratio = 0.3
-boost = 1.5 (priority_boost: "日経平均株価")
-weight = 1.0 (Indexテーマ)
+keyword_matches = 2 (決算, 決算短信)
+keyword_ratio = 0.2
+boost = 1.5 (priority_boost: "決算短信")
+weight = 1.2 (Stockテーマ)
 
-score = 3 × 0.3 × 1.5 × 1.0 × 100 = 135 → 100（上限）
+score = 3 × 0.2 × 1.5 × 1.2 × 100 = 108 → 100（上限）
 ```
 
-#### ステップ2.4: 重複チェック
-
-**既存Issueとの重複を判定**:
-
-```python
-def calculate_title_similarity(title1: str, title2: str) -> float:
-    """タイトルの類似度を計算（Jaccard係数）"""
-
-    words1 = set(title1.lower().split())
-    words2 = set(title2.lower().split())
-
-    if not words1 or not words2:
-        return 0.0
-
-    common = words1.intersection(words2)
-    total = words1.union(words2)
-
-    return len(common) / len(total)
-
-
-def is_duplicate(new_item: dict, existing_issues: list[dict], threshold: float) -> bool:
-    """既存Issueと重複しているかチェック"""
-
-    new_link = new_item.get('link', '')
-    new_title = new_item.get('title', '')
-
-    for issue in existing_issues:
-        # URL完全一致
-        body = issue.get('body', '')
-        if new_link and new_link in body:
-            ログ出力: f"重複: {new_title} (URL一致: Issue #{issue['number']})"
-            return True
-
-        # タイトル類似度チェック
-        issue_title = issue.get('title', '')
-        similarity = calculate_title_similarity(new_title, issue_title)
-
-        if similarity >= threshold:
-            ログ出力: f"重複: {new_title} (類似度{similarity:.2f}: Issue #{issue['number']})"
-            return True
-
-    return False
-```
-
-### Phase 3: GitHub投稿
-
-#### ステップ3.0: 記事内容取得と要約生成
-
-**重要**: Issue作成前に、必ず記事URLから実際の内容を取得して日本語要約を生成すること。
-
-**記事内容取得の手順**:
-
-```python
-def fetch_article_content(url: str, title: str) -> str:
-    """記事内容を取得（WebFetch → gemini検索の順で試行）"""
-
-    # 1. WebFetchで記事取得を試行
-    try:
-        content = WebFetch(
-            url=url,
-            prompt="""この記事の内容を詳しく要約してください。特に以下の点を含めてください:
-            1. 主要な事実と背景
-            2. 関連企業や機関の動き
-            3. 市場や業界への影響
-            4. 数値データや具体的な情報
-            5. 今後の展望や予測"""
-        )
-        return content
-    except Exception as e:
-        # 2. 失敗した場合（Financial Timesなど）は、gemini検索で代替
-        domain = url.split('/')[2]
-        query = f"{title} {domain}"
-
-        # gemini CLI経由でWeb検索
-        result = subprocess.run(
-            ["gemini", "--prompt", f"WebSearch: {query}"],
-            capture_output=True,
-            text=True
-        )
-        return result.stdout
-
-
-def generate_japanese_summary(content: str, max_length: int = 400) -> str:
-    """記事内容から日本語要約を生成（400字程度）"""
-
-    # Claude APIまたは内部ロジックで要約生成
-    # - 重要なポイントを抽出
-    # - 数値データを優先的に含める
-    # - 日本語で400字程度に整形
-
-    prompt = f"""以下の記事内容を、日本語で400字程度に要約してください。
-
-    要約のポイント:
-    - 主要な事実と数値データを優先
-    - 背景や影響を簡潔に説明
-    - 投資判断に有用な情報を強調
-    - 箇条書きではなく、文章形式で
-
-    記事内容:
-    {content}
-    """
-
-    summary = generate_summary(prompt)
-    return summary
-
-
-def format_published_jst(published_str: str) -> str:
-    """公開日をJST YYYY-MM-DD HH:MM形式に変換"""
-
-    from datetime import datetime
-    import pytz
-
-    # ISO 8601形式をパース
-    dt = datetime.fromisoformat(published_str.replace('Z', '+00:00'))
-
-    # JSTに変換
-    jst = pytz.timezone('Asia/Tokyo')
-    dt_jst = dt.astimezone(jst)
-
-    # YYYY-MM-DD HH:MM形式で出力
-    return dt_jst.strftime('%Y-%m-%d %H:%M')
-```
-
-**実装例**:
-```python
-# 各記事に対して
-for item in filtered_items:
-    # 記事内容を取得
-    article_content = fetch_article_content(item['link'], item['title'])
-
-    # 日本語要約を生成
-    japanese_summary = generate_japanese_summary(article_content, max_length=400)
-
-    # 公開日をJST形式に変換
-    published_jst = format_published_jst(item['published'])
-
-    # Issue作成（要約を含める）
-    create_issue(item, japanese_summary, published_jst)
-```
-
-#### ステップ3.1: Issue作成
-
-**GitHub CLIでIssueを作成**:
-
-```bash
-gh issue create \
-    --repo YH-05/finance \
-    --title "[NEWS] {title}" \
-    --body "$(cat <<'EOF'
-## 日本語要約（400字程度）
-
-{japanese_summary}
-
-## 記事概要
-- テーマ: Stock（個別銘柄）
-- ソース: {source}
-- 信頼性: {score}/100
-- 公開日: {published_jst}
-- URL: {link}
-
-## マッチしたキーワード
-{matched_keywords}
-EOF
-)" \
-    --label "news"
-```
-
-**注意事項**:
-- `{japanese_summary}`: 実際の記事から生成した400字程度の日本語要約
-- `{published_jst}`: JST形式（YYYY-MM-DD HH:MM）例: "2026-01-15 09:04"
-- 「サマリー」セクションは削除（RSSメタデータのサマリーは不要）
-- 「次のアクション」セクションは削除（要約済みのため不要）
-
-**作成後、Issue URLを取得**:
-```bash
-# 出力から Issue URL を抽出
-# 例: https://github.com/YH-05/finance/issues/200
-```
-
-#### ステップ3.2: Project追加
-
-**GitHub CLIでProject 15に追加**:
-
-```bash
-gh project item-add 15 \
-    --owner YH-05 \
-    --url {issue_url}
-```
-
-**出力から Project Item ID を取得**:
-```json
-{
-  "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-  "project": {
-    "id": "PVT_kwHOBoK6AM4BMpw_",
-    "number": 15
-  }
-}
-```
-
-#### ステップ3.3: Status設定（GraphQL API）
-
-**Step 1: Issue Node IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  repository(owner: "YH-05", name: "finance") {
-    issue(number: {issue_number}) {
-      id
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "repository": {
-      "issue": {
-        "id": "I_kwDOBoK6AM6YZ..."
-      }
-    }
-  }
-}
-```
-
-**Step 2: Project Item IDを取得**
-
-```bash
-gh api graphql -f query='
-query {
-  node(id: "{issue_node_id}") {
-    ... on Issue {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project {
-            number
-          }
-        }
-      }
-    }
-  }
-}'
-```
-
-**出力例**:
-```json
-{
-  "data": {
-    "node": {
-      "projectItems": {
-        "nodes": [
-          {
-            "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy...",
-            "project": {
-              "number": 15
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-**Step 3: StatusフィールドをIndexに設定**
-
-```bash
-gh api graphql -f query='
-mutation {
-  updateProjectV2ItemFieldValue(
-    input: {
-      projectId: "PVT_kwHOBoK6AM4BMpw_"
-      itemId: "{project_item_id}"
-      fieldId: "PVTSSF_lAHOBoK6AM4BMpw_zg739ZE"
-      value: {
-        singleSelectOptionId: "47fc9ee4"
-      }
-    }
-  ) {
-    projectV2Item {
-      id
-    }
-  }
-}'
-```
-
-**成功時の出力**:
-```json
-{
-  "data": {
-    "updateProjectV2ItemFieldValue": {
-      "projectV2Item": {
-        "id": "PVTI_lAHOBoK6AM4BMpw_zgZxy..."
-      }
-    }
-  }
-}
-```
-
-### Phase 4: 結果報告
-
-#### ステップ4.1: 統計サマリー出力
-
-```markdown
-## Stock（個別銘柄）ニュース収集完了
-
-### 処理統計
-- **処理記事数**: {processed}件
-- **テーママッチ**: {matched}件
-- **除外**: {excluded}件
-- **重複**: {duplicates}件
-- **新規投稿**: {created}件
-- **投稿失敗**: {failed}件
-
-### 投稿されたニュース
-
-1. **日経平均、3万円台を回復** [#200]
-   - ソース: 日経新聞
-   - 信頼性: 95/100
-   - URL: https://github.com/YH-05/finance/issues/200
-
-2. **S&P500、史上最高値を更新** [#201]
-   - ソース: Reuters
-   - 信頼性: 90/100
-   - URL: https://github.com/YH-05/finance/issues/201
-
-### 除外されたニュース
-- スポーツ関連: 2件
-- エンタメ関連: 1件
-- テーマ不一致: 5件
-```
-
-## エラーハンドリング
-
-### E001: 一時ファイル読み込みエラー
-
-**発生条件**:
-- `.tmp/news-collection-{timestamp}.json` が存在しない
-- JSON形式が不正
-
-**対処法**:
-```python
-try:
-    with open(filepath) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    ログ出力: f"エラー: 一時ファイルが見つかりません: {filepath}"
-    ログ出力: "オーケストレーターが正しく実行されたか確認してください"
-    sys.exit(1)
-except json.JSONDecodeError as e:
-    ログ出力: f"エラー: JSON形式が不正です: {e}"
-    sys.exit(1)
-```
-
-### E002: テーマ設定読み込みエラー
-
-**発生条件**:
-- `data/config/finance-news-themes.json` が存在しない
-- "stock"テーマが定義されていない
-
-**対処法**:
-```python
-try:
-    with open("data/config/finance-news-themes.json") as f:
-        config = json.load(f)
-    theme = config['themes']['stock']
-    common = config['common']
-except FileNotFoundError:
-    ログ出力: "エラー: テーマ設定ファイルが見つかりません"
-    sys.exit(1)
-except KeyError:
-    ログ出力: "エラー: 'stock' テーマが定義されていません"
-    sys.exit(1)
-```
-
-### E003: Issue作成エラー
-
-**発生条件**:
-- GitHub API エラー
-- 認証エラー
-- レート制限
-
-**対処法**:
-```python
-try:
-    result = subprocess.run(
-        ["gh", "issue", "create", ...],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Issue作成失敗: {item['title']}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-
-    # レート制限エラーの場合
-    if "rate limit" in str(e.stderr).lower():
-        ログ出力: "GitHub API レート制限に達しました。1時間待機してください。"
-
-    failed += 1
-    continue  # 次の記事の処理を継続
-```
-
-### E004: Status設定エラー
-
-**発生条件**:
-- GraphQL API エラー
-- Project Item IDが取得できない
-- 権限エラー
-
-**対処法**:
-```python
-try:
-    # GraphQL mutation実行
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={mutation}"],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-except subprocess.CalledProcessError as e:
-    ログ出力: f"警告: Status設定失敗: Issue #{issue_number}"
-    ログ出力: f"エラー詳細: {e.stderr}"
-    ログ出力: "Issue作成は成功しています。手動でStatusを設定してください。"
-
-    # 処理は継続（Issueは作成済み）
-    continue
-```
-
-### E005: ネットワークエラー
-
-**発生条件**:
-- GitHub APIへの接続失敗
-- タイムアウト
-
-**対処法**:
-- リトライロジック（最大3回、指数バックオフ）
-- エラーログ記録
-- 処理継続（失敗した記事をスキップ）
-
-## 実行例
-
-### 基本的な使用方法
-
-```
-1. Index エージェントを起動
-2. 一時ファイルからデータ読み込み
-3. Indexキーワードでフィルタリング
-4. 重複チェック
-5. GitHub Issueを作成（Status=Index）
-6. 結果サマリーを出力
-```
-
-### 実行ログの例
+## 実行ログの例
 
 ```
 [INFO] 一時ファイル読み込み: .tmp/news-collection-20260115-143000.json
 [INFO] テーマ設定読み込み: data/config/finance-news-themes.json
-[INFO] Index テーマ処理開始
+[INFO] Stock テーマ処理開始
 [INFO] 処理記事数: 50件
 
 [INFO] テーママッチング中...
-[INFO] マッチ: 日経平均、3万円台を回復 (キーワード: 日経平均, 株価)
-[INFO] マッチ: S&P500、史上最高値を更新 (キーワード: S&P500, 指数)
+[INFO] マッチ: トヨタ、決算を発表 (キーワード: 決算, 業績)
+[INFO] マッチ: ソフトバンク、ARM買収を完了 (キーワード: 買収, M&A)
 [INFO] 除外: サッカーW杯決勝 (理由: sports:サッカー)
-[INFO] テーママッチ: 12件
+[INFO] テーママッチ: 10件
 
 [INFO] 重複チェック中...
-[INFO] 重複: NYダウ、最高値更新 (URL一致: Issue #190)
-[INFO] 新規記事: 5件
+[INFO] 重複: トヨタ、四半期決算 (URL一致: Issue #192)
+[INFO] 新規記事: 4件
 
 [INFO] GitHub Issue作成中...
-[INFO] Issue作成成功: #200 - 日経平均、3万円台を回復
-[INFO] Project追加成功: #200
-[INFO] Status設定成功: #200 → Index
-[INFO] Issue作成成功: #201 - S&P500、史上最高値を更新
-[INFO] Project追加成功: #201
-[INFO] Status設定成功: #201 → Index
+[INFO] Issue作成成功: #205 - トヨタ、決算を発表
+[INFO] Project追加成功: #205
+[INFO] Status設定成功: #205 → Stock
 
 ## Stock（個別銘柄）ニュース収集完了
 
 ### 処理統計
 - **処理記事数**: 50件
-- **テーママッチ**: 12件
-- **除外**: 3件
-- **重複**: 7件
-- **新規投稿**: 5件
+- **テーママッチ**: 10件
+- **除外**: 2件
+- **重複**: 6件
+- **新規投稿**: 4件
 - **投稿失敗**: 0件
 ```
 
 ## 参考資料
 
+- **共通処理ガイド**: `.claude/agents/finance_news_collector/common-processing-guide.md`
 - **テーマ設定**: `data/config/finance-news-themes.json`
+- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.yml`
 - **オーケストレーター**: `.claude/agents/finance-news-orchestrator.md`
-- **他のテーマエージェント**: `.claude/agents/finance-news-{theme}.md`
-- **コマンド**: `.claude/commands/collect-finance-news.md`
 - **GitHub Project**: https://github.com/users/YH-05/projects/15
 
 ## 制約事項

--- a/.claude/agents/finance_news_collector/common-processing-guide.md
+++ b/.claude/agents/finance_news_collector/common-processing-guide.md
@@ -1,0 +1,467 @@
+# 金融ニュース収集エージェント共通処理ガイド
+
+このガイドは、テーマ別ニュース収集エージェント（finance-news-{theme}）の共通処理を定義します。
+
+## 共通設定ファイル
+
+- **テーマ設定**: `data/config/finance-news-themes.json`
+- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.yml`
+- **GitHub Project**: #15 (`PVT_kwHOBoK6AM4BMpw_`)
+- **Statusフィールド**: `PVTSSF_lAHOBoK6AM4BMpw_zg739ZE`
+
+## Phase 1: 初期化
+
+### ステップ1.1: 一時ファイル読み込み
+
+```
+[1] 一時ファイル読み込み
+    ↓
+    .tmp/news-collection-{timestamp}.json を読み込む
+    ↓ エラーの場合
+    エラーログ出力 → 処理中断
+
+[2] テーマ設定読み込み
+    ↓
+    data/config/finance-news-themes.json を読み込む
+    themes["{theme}"] セクションを取得
+    ↓ エラーの場合
+    エラーログ出力 → 処理中断
+
+[3] 統計カウンタ初期化
+    ↓
+    processed = 0
+    matched = 0
+    excluded = 0
+    duplicates = 0
+    created = 0
+    failed = 0
+```
+
+## Phase 2: フィルタリング
+
+### ステップ2.1: テーマキーワードマッチング
+
+```python
+def matches_theme_keywords(item: dict, theme: dict) -> tuple[bool, list[str]]:
+    """テーマのキーワードにマッチするかチェック"""
+
+    # 検索対象テキスト
+    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
+
+    # キーワードマッチング（単語境界認識）
+    matched_keywords = []
+    for keyword in theme['keywords']['include']:
+        # 単語境界パターン（\b）を使用
+        pattern = r'\b' + re.escape(keyword.lower()) + r'\b'
+        if re.search(pattern, text, re.IGNORECASE):
+            matched_keywords.append(keyword)
+
+    # 最低マッチ数チェック
+    min_matches = theme['min_keyword_matches']
+    is_match = len(matched_keywords) >= min_matches
+
+    return is_match, matched_keywords
+```
+
+### ステップ2.2: 除外キーワードチェック
+
+```python
+def is_excluded(item: dict, common: dict, theme: dict) -> bool:
+    """除外対象かチェック"""
+
+    text = f"{item['title']} {item.get('summary', '')}".lower()
+
+    # 除外キーワードチェック
+    for category, keywords in common['exclude_keywords'].items():
+        for keyword in keywords:
+            if keyword.lower() in text:
+                # 金融キーワードも含む場合は除外しない
+                is_match, _ = matches_theme_keywords(item, theme)
+                if not is_match:
+                    return True
+
+    return False
+```
+
+### ステップ2.3: 信頼性スコアリング
+
+```python
+def calculate_reliability_score(item: dict, theme: dict, common: dict) -> int:
+    """信頼性スコアを計算（0-100）"""
+
+    link = item.get('link', '')
+
+    # Tier判定（情報源の信頼性）
+    tier = 1
+    for domain in common['sources']['tier1']:
+        if domain in link:
+            tier = 3
+            break
+    if tier == 1:
+        for domain in common['sources']['tier2']:
+            if domain in link:
+                tier = 2
+                break
+
+    # キーワードマッチ度
+    text = f"{item['title']} {item.get('summary', '')} {item.get('content', '')}".lower()
+    keyword_matches = sum(1 for kw in theme['keywords']['include'] if kw.lower() in text)
+    keyword_ratio = min(keyword_matches / 10, 1.0)
+
+    # Priority boost（重要キーワードボーナス）
+    boost = 1.0
+    for priority_kw in theme['keywords']['priority_boost']:
+        if priority_kw.lower() in item['title'].lower():
+            boost = 1.5
+            break
+
+    # Reliability weight（テーマ別ウェイト）
+    weight = theme.get('reliability_weight', 1.0)
+
+    # スコア計算
+    score = tier * keyword_ratio * boost * weight * 100
+
+    return min(int(score), 100)
+```
+
+### ステップ2.4: 重複チェック
+
+```python
+def calculate_title_similarity(title1: str, title2: str) -> float:
+    """タイトルの類似度を計算（Jaccard係数）"""
+
+    words1 = set(title1.lower().split())
+    words2 = set(title2.lower().split())
+
+    if not words1 or not words2:
+        return 0.0
+
+    common = words1.intersection(words2)
+    total = words1.union(words2)
+
+    return len(common) / len(total)
+
+
+def is_duplicate(new_item: dict, existing_issues: list[dict], threshold: float = 0.85) -> bool:
+    """既存Issueと重複しているかチェック"""
+
+    new_link = new_item.get('link', '')
+    new_title = new_item.get('title', '')
+
+    for issue in existing_issues:
+        # URL完全一致
+        body = issue.get('body', '')
+        if new_link and new_link in body:
+            return True
+
+        # タイトル類似度チェック
+        issue_title = issue.get('title', '')
+        similarity = calculate_title_similarity(new_title, issue_title)
+
+        if similarity >= threshold:
+            return True
+
+    return False
+```
+
+## Phase 3: GitHub投稿
+
+### ステップ3.0: 記事内容取得と要約生成
+
+**重要**: Issue作成前に、必ず記事URLから実際の内容を取得して日本語要約を生成すること。
+
+```python
+def fetch_article_content(url: str, title: str) -> str:
+    """記事内容を取得（WebFetch → gemini検索の順で試行）"""
+
+    # 1. WebFetchで記事取得を試行
+    try:
+        content = WebFetch(
+            url=url,
+            prompt="""この記事の内容を詳しく要約してください。特に以下の点を含めてください:
+            1. 主要な事実と背景
+            2. 関連企業や機関の動き
+            3. 市場や業界への影響
+            4. 数値データや具体的な情報
+            5. 今後の展望や予測"""
+        )
+        return content
+    except Exception as e:
+        # 2. 失敗した場合は gemini CLI で代替
+        domain = url.split('/')[2]
+        query = f"{title} {domain}"
+
+        result = subprocess.run(
+            ["gemini", "--prompt", f"WebSearch: {query}"],
+            capture_output=True,
+            text=True
+        )
+        return result.stdout
+
+
+def generate_japanese_summary(content: str, max_length: int = 400) -> str:
+    """記事内容から日本語要約を生成（400字程度）"""
+
+    prompt = f"""以下の記事内容を、日本語で400字程度に要約してください。
+
+    要約のポイント:
+    - 主要な事実と数値データを優先
+    - 背景や影響を簡潔に説明
+    - 投資判断に有用な情報を強調
+    - 箇条書きではなく、文章形式で
+
+    記事内容:
+    {content}
+    """
+
+    summary = generate_summary(prompt)
+    return summary
+
+
+def format_published_jst(published_str: str) -> str:
+    """公開日をJST YYYY-MM-DD HH:MM形式に変換"""
+
+    from datetime import datetime
+    import pytz
+
+    dt = datetime.fromisoformat(published_str.replace('Z', '+00:00'))
+    jst = pytz.timezone('Asia/Tokyo')
+    dt_jst = dt.astimezone(jst)
+
+    return dt_jst.strftime('%Y-%m-%d %H:%M')
+```
+
+### ステップ3.1: Issue作成
+
+**Issueテンプレート** (`.github/ISSUE_TEMPLATE/news-article.yml`) に準拠した形式で作成:
+
+```bash
+gh issue create \
+    --repo YH-05/finance \
+    --title "[NEWS] {title}" \
+    --body "$(cat <<'EOF'
+### 概要
+
+{japanese_summary}
+
+### 情報源URL
+
+{link}
+
+### 公開日
+
+{published_jst}(JST)
+
+### 信頼性スコア
+
+{credibility_score}点
+
+### カテゴリ
+
+{category}
+
+### フィード/情報源名
+
+{source}
+
+### 優先度
+
+{priority}
+
+### 備考・メモ
+
+- テーマ: {theme_name}
+- マッチキーワード: {matched_keywords}
+- 信頼性: {score}/100
+EOF
+)" \
+    --label "news"
+```
+
+### ステップ3.2: Project追加
+
+```bash
+gh project item-add 15 \
+    --owner YH-05 \
+    --url {issue_url}
+```
+
+### ステップ3.3: Status設定（GraphQL API）
+
+**Step 1: Issue Node IDを取得**
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "YH-05", name: "finance") {
+    issue(number: {issue_number}) {
+      id
+    }
+  }
+}'
+```
+
+**Step 2: Project Item IDを取得**
+
+```bash
+gh api graphql -f query='
+query {
+  node(id: "{issue_node_id}") {
+    ... on Issue {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project {
+            number
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+**Step 3: Statusフィールドを設定**
+
+```bash
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: "PVT_kwHOBoK6AM4BMpw_"
+      itemId: "{project_item_id}"
+      fieldId: "PVTSSF_lAHOBoK6AM4BMpw_zg739ZE"
+      value: {
+        singleSelectOptionId: "{status_option_id}"
+      }
+    }
+  ) {
+    projectV2Item {
+      id
+    }
+  }
+}'
+```
+
+## Phase 4: 結果報告
+
+### 統計サマリー出力フォーマット
+
+```markdown
+## {theme_name} ニュース収集完了
+
+### 処理統計
+- **処理記事数**: {processed}件
+- **テーママッチ**: {matched}件
+- **除外**: {excluded}件
+- **重複**: {duplicates}件
+- **新規投稿**: {created}件
+- **投稿失敗**: {failed}件
+
+### 投稿されたニュース
+
+1. **{title}** [#{issue_number}]
+   - ソース: {source}
+   - 信頼性: {score}/100
+   - URL: https://github.com/YH-05/finance/issues/{issue_number}
+
+### 除外されたニュース
+- スポーツ関連: {sports_count}件
+- エンタメ関連: {entertainment_count}件
+- テーマ不一致: {mismatch_count}件
+```
+
+## 共通エラーハンドリング
+
+### E001: 一時ファイル読み込みエラー
+
+```python
+try:
+    with open(filepath) as f:
+        data = json.load(f)
+except FileNotFoundError:
+    ログ出力: f"エラー: 一時ファイルが見つかりません: {filepath}"
+    ログ出力: "オーケストレーターが正しく実行されたか確認してください"
+    sys.exit(1)
+except json.JSONDecodeError as e:
+    ログ出力: f"エラー: JSON形式が不正です: {e}"
+    sys.exit(1)
+```
+
+### E002: テーマ設定読み込みエラー
+
+```python
+try:
+    with open("data/config/finance-news-themes.json") as f:
+        config = json.load(f)
+    theme = config['themes']['{theme}']
+    common = config['common']
+except FileNotFoundError:
+    ログ出力: "エラー: テーマ設定ファイルが見つかりません"
+    sys.exit(1)
+except KeyError:
+    ログ出力: "エラー: '{theme}' テーマが定義されていません"
+    sys.exit(1)
+```
+
+### E003: Issue作成エラー
+
+```python
+try:
+    result = subprocess.run(
+        ["gh", "issue", "create", ...],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+except subprocess.CalledProcessError as e:
+    ログ出力: f"警告: Issue作成失敗: {item['title']}"
+    ログ出力: f"エラー詳細: {e.stderr}"
+
+    if "rate limit" in str(e.stderr).lower():
+        ログ出力: "GitHub API レート制限に達しました。1時間待機してください。"
+
+    failed += 1
+    continue
+```
+
+### E004: Status設定エラー
+
+```python
+try:
+    result = subprocess.run(
+        ["gh", "api", "graphql", "-f", f"query={mutation}"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+except subprocess.CalledProcessError as e:
+    ログ出力: f"警告: Status設定失敗: Issue #{issue_number}"
+    ログ出力: f"エラー詳細: {e.stderr}"
+    ログ出力: "Issue作成は成功しています。手動でStatusを設定してください。"
+    continue
+```
+
+### E005: ネットワークエラー
+
+- リトライロジック（最大3回、指数バックオフ）
+- エラーログ記録
+- 処理継続（失敗した記事をスキップ）
+
+## テーマ別Status ID一覧
+
+| テーマ | Status名 | Option ID |
+|--------|----------|-----------|
+| index | Index | `f75ad846` |
+| stock | Stock | `47fc9ee4` |
+| sector | Sector | `98236657` |
+| macro | Macro | `c40731f6` |
+| ai | AI | `17189c86` |
+
+## 参考資料
+
+- **テーマ設定**: `data/config/finance-news-themes.json`
+- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.yml`
+- **オーケストレーター**: `.claude/agents/finance-news-orchestrator.md`
+- **コマンド**: `.claude/commands/collect-finance-news.md`
+- **GitHub Project**: https://github.com/users/YH-05/projects/15


### PR DESCRIPTION
## 概要

金融ニュース収集エージェント群（finance-news-*）の機能改善を実施しました。

- エージェント定義ファイルの軽量化（60%削減: 3,818行→1,500行）
- 共通処理ロジックの外部化
- MCPエラーハンドリング強化（3段階フォールバック）
- テーマ混同エラーの修正
- Issueテンプレート準拠の明示

## 変更内容

### 1. 共通処理ガイドの作成
- `.claude/agents/finance_news_collector/common-processing-guide.md` を新規作成
- 全テーマエージェント共通の処理フロー、重複検出、スコアリング、エラーハンドリングを集約

### 2. テーマ別エージェントの軽量化
| ファイル | 変更前 | 変更後 | 削減率 |
|---------|--------|--------|--------|
| finance-news-index.md | 684行 | 139行 | 80% |
| finance-news-macro.md | 684行 | 142行 | 79% |
| finance-news-sector.md | 687行 | 142行 | 79% |
| finance-news-ai.md | 684行 | 142行 | 79% |
| finance-news-stock.md | 685行 | 142行 | 79% |
| **合計** | **3,424行** | **707行** | **79%** |

### 3. テーマ混同エラーの修正
- `finance-news-macro.md`: Status ID コメントを "Index" → "Macro" に修正
- `finance-news-ai.md`: Status ID コメントを "Index" → "AI" に修正
- `finance-news-stock.md`: Status ID コメントを "Index" → "Stock" に修正

### 4. MCPエラーハンドリング強化
`finance-news-orchestrator.md` に3段階フォールバックを実装:
1. MCP経由で取得を試行
2. ローカルキャッシュ（`data/raw/rss/`）から取得
3. 空リストで継続（警告付き）

## テストプラン

- [x] 各エージェントファイルの構文確認
- [x] 共通処理ガイドの参照パスが正しいことを確認
- [x] Status ID が正しいテーマを指していることを確認

Fixes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)