### PR TITLE
Tab 2: マクロ指標実装

### DIFF
--- a/notebook/market_dashboard.py
+++ b/notebook/market_dashboard.py
@@ -8,8 +8,11 @@ app = marimo.App(width="medium")
 def _():
     """Initialize marimo and imports."""
     import marimo as mo
+    import pandas as pd
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
 
-    return (mo,)
+    return go, make_subplots, mo, pd
 
 
 @app.cell(hide_code=True)
@@ -51,20 +54,6 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
-    """Tab navigation for dashboard sections."""
-    tabs = mo.ui.tabs(
-        {
-            "パフォーマンス概要": mo.md("## Tab 1: パフォーマンス概要\n\n- S&P500 & 主要指数のパフォーマンス\n- Magnificent 7 & SOX指数\n- セクターETF（XL系）\n- 貴金属"),
-            "マクロ指標": mo.md("## Tab 2: マクロ指標\n\n- 米国金利（10Y, 2Y, FF）\n- イールドスプレッド\n- VIX & ハイイールドスプレッド"),
-            "相関・ベータ分析": mo.md("## Tab 3: 相関・ベータ分析\n\n- セクターETFローリングベータ（vs S&P500）\n- ドルインデックス vs 貴金属相関\n- 相関ヒートマップ"),
-            "リターン分布": mo.md("## Tab 4: リターン分布\n\n- 週次リターンヒストグラム\n- 統計サマリー"),
-        }
-    )
-    return (tabs,)
-
-
-@app.cell
 def _(PERIOD_OPTIONS, period_dropdown):
     """Get selected period value for data fetching."""
     selected_period = PERIOD_OPTIONS.get(period_dropdown.value, "1y")
@@ -73,11 +62,10 @@ def _(PERIOD_OPTIONS, period_dropdown):
 
 @app.cell
 def _():
-    """Data fetching function skeleton.
-
-    TODO: Implement actual data fetching using market_analysis API.
-    """
+    """Data fetching functions using MarketData API."""
     from datetime import datetime, timedelta
+
+    from market_analysis import MarketData
 
     def get_date_range(period: str) -> tuple[datetime, datetime]:
         """Calculate date range from period string.
@@ -108,43 +96,53 @@ def _():
 
         return start_date, end_date
 
-    def fetch_stock_data(symbols: list[str], period: str) -> dict:
-        """Fetch stock data for given symbols.
+    def fetch_stock_data(symbol: str, period: str) -> dict:
+        """Fetch stock data for a symbol.
 
         Parameters
         ----------
-        symbols : list[str]
-            List of ticker symbols
+        symbol : str
+            Ticker symbol
         period : str
             Period string
 
         Returns
         -------
         dict
-            Dictionary of symbol -> DataFrame
+            Dictionary with 'data' key containing DataFrame or 'error' key
         """
-        # Skeleton: To be implemented with MarketData API
-        return {}
+        try:
+            market_data = MarketData()
+            start_date, end_date = get_date_range(period)
+            df = market_data.fetch_stock(symbol, start=start_date, end=end_date)
+            return {"data": df, "error": None}
+        except Exception as e:
+            return {"data": None, "error": str(e)}
 
-    def fetch_fred_data(series_ids: list[str], period: str) -> dict:
+    def fetch_fred_data(series_id: str, period: str) -> dict:
         """Fetch FRED economic indicator data.
 
         Parameters
         ----------
-        series_ids : list[str]
-            List of FRED series IDs
+        series_id : str
+            FRED series ID
         period : str
             Period string
 
         Returns
         -------
         dict
-            Dictionary of series_id -> DataFrame
+            Dictionary with 'data' key containing DataFrame or 'error' key
         """
-        # Skeleton: To be implemented with MarketData API
-        return {}
+        try:
+            market_data = MarketData()
+            start_date, end_date = get_date_range(period)
+            df = market_data.fetch_fred(series_id, start=start_date, end=end_date)
+            return {"data": df, "error": None}
+        except Exception as e:
+            return {"data": None, "error": str(e)}
 
-    return fetch_fred_data, fetch_stock_data, get_date_range
+    return MarketData, fetch_fred_data, fetch_stock_data, get_date_range
 
 
 @app.cell
@@ -187,18 +185,304 @@ def _():
     return FRED_SERIES, MAG7_SOX, MAJOR_INDICES, METALS, SECTOR_ETFS
 
 
-@app.cell(hide_code=True)
-def _(mo, selected_period):
-    """Display current selection status."""
-    _status = mo.md(
-        f"""
-        ---
-        **現在の選択**: 期間 = {selected_period}
+@app.cell
+def _(fetch_fred_data, mo, pd, selected_period):
+    """Fetch macro indicator data from FRED."""
+    # FRED series IDs for interest rates
+    interest_rate_series = ["DGS10", "DGS2", "DFF"]
 
-        > このダッシュボードは開発中です。データ取得機能は後続の Issue で実装予定です。
-        """
+    # Fetch interest rate data
+    macro_data = {}
+    macro_errors = []
+
+    for series_id in interest_rate_series:
+        result = fetch_fred_data(series_id, selected_period)
+        if result["error"]:
+            macro_errors.append(f"{series_id}: {result['error']}")
+        else:
+            macro_data[series_id] = result["data"]
+
+    # Fetch high yield spread
+    hy_result = fetch_fred_data("BAMLH0A0HYM2", selected_period)
+    if hy_result["error"]:
+        macro_errors.append(f"BAMLH0A0HYM2: {hy_result['error']}")
+    else:
+        macro_data["BAMLH0A0HYM2"] = hy_result["data"]
+
+    # Calculate yield spread (10Y - 2Y)
+    yield_spread_df = None
+    if "DGS10" in macro_data and "DGS2" in macro_data:
+        dgs10 = macro_data["DGS10"]["close"].dropna()
+        dgs2 = macro_data["DGS2"]["close"].dropna()
+        common_idx = dgs10.index.intersection(dgs2.index)
+        if len(common_idx) > 0:
+            spread = dgs10.loc[common_idx] - dgs2.loc[common_idx]
+            yield_spread_df = pd.DataFrame({"spread": spread}, index=common_idx)
+
+    # Show loading status
+    if macro_errors:
+        _macro_status = mo.callout(
+            mo.md("データ取得エラー:\n" + "\n".join(macro_errors)),
+            kind="warn",
+        )
+    else:
+        _macro_status = mo.callout(
+            mo.md(f"✓ マクロ指標データ取得完了 ({len(macro_data)} シリーズ)"),
+            kind="success",
+        )
+
+    return _macro_status, macro_data, macro_errors, yield_spread_df
+
+
+@app.cell
+def _(fetch_stock_data, selected_period):
+    """Fetch VIX data from Yahoo Finance."""
+    vix_result = fetch_stock_data("^VIX", selected_period)
+    vix_data = vix_result["data"]
+    vix_error = vix_result["error"]
+
+    return vix_data, vix_error
+
+
+@app.cell
+def _(go, macro_data, mo):
+    """Create US interest rates chart (10Y, 2Y, FF)."""
+    # Create interest rates chart
+    interest_rates_chart = None
+
+    if all(key in macro_data for key in ["DGS10", "DGS2", "DFF"]):
+        fig = go.Figure()
+
+        # Add 10Y Treasury
+        dgs10 = macro_data["DGS10"]
+        fig.add_trace(
+            go.Scatter(
+                x=dgs10.index,
+                y=dgs10["close"],
+                name="10年国債",
+                line={"color": "#1f77b4", "width": 2},
+            )
+        )
+
+        # Add 2Y Treasury
+        dgs2 = macro_data["DGS2"]
+        fig.add_trace(
+            go.Scatter(
+                x=dgs2.index,
+                y=dgs2["close"],
+                name="2年国債",
+                line={"color": "#ff7f0e", "width": 2},
+            )
+        )
+
+        # Add Fed Funds Rate
+        dff = macro_data["DFF"]
+        fig.add_trace(
+            go.Scatter(
+                x=dff.index,
+                y=dff["close"],
+                name="FF金利",
+                line={"color": "#2ca02c", "width": 2},
+            )
+        )
+
+        fig.update_layout(
+            title="米国金利推移",
+            xaxis_title="日付",
+            yaxis_title="金利 (%)",
+            legend={"orientation": "h", "yanchor": "bottom", "y": 1.02, "xanchor": "right", "x": 1},
+            hovermode="x unified",
+            template="plotly_white",
+            height=400,
+        )
+
+        interest_rates_chart = mo.ui.plotly(fig)
+    else:
+        interest_rates_chart = mo.callout(
+            mo.md("金利データの取得に失敗しました"),
+            kind="danger",
+        )
+
+    return (interest_rates_chart,)
+
+
+@app.cell
+def _(go, mo, yield_spread_df):
+    """Create yield spread chart (10Y - 2Y)."""
+    yield_spread_chart = None
+
+    if yield_spread_df is not None and len(yield_spread_df) > 0:
+        fig = go.Figure()
+
+        # Add yield spread line
+        fig.add_trace(
+            go.Scatter(
+                x=yield_spread_df.index,
+                y=yield_spread_df["spread"],
+                name="イールドスプレッド (10Y-2Y)",
+                line={"color": "#9467bd", "width": 2},
+                fill="tozeroy",
+                fillcolor="rgba(148, 103, 189, 0.2)",
+            )
+        )
+
+        # Add zero line
+        fig.add_hline(
+            y=0,
+            line_dash="dash",
+            line_color="red",
+            annotation_text="逆イールド基準",
+            annotation_position="right",
+        )
+
+        fig.update_layout(
+            title="イールドスプレッド (10年 - 2年国債)",
+            xaxis_title="日付",
+            yaxis_title="スプレッド (%)",
+            hovermode="x unified",
+            template="plotly_white",
+            height=350,
+        )
+
+        yield_spread_chart = mo.ui.plotly(fig)
+    else:
+        yield_spread_chart = mo.callout(
+            mo.md("イールドスプレッドの計算に失敗しました"),
+            kind="danger",
+        )
+
+    return (yield_spread_chart,)
+
+
+@app.cell
+def _(go, macro_data, make_subplots, mo, vix_data, vix_error):
+    """Create VIX and High Yield Spread chart."""
+    vix_hy_chart = None
+
+    has_vix = vix_data is not None and not vix_error
+    has_hy = "BAMLH0A0HYM2" in macro_data
+
+    if has_vix or has_hy:
+        fig = make_subplots(
+            rows=2,
+            cols=1,
+            shared_xaxes=True,
+            vertical_spacing=0.1,
+            subplot_titles=("VIX 恐怖指数", "ハイイールドスプレッド"),
+        )
+
+        if has_vix:
+            fig.add_trace(
+                go.Scatter(
+                    x=vix_data.index,
+                    y=vix_data["close"],
+                    name="VIX",
+                    line={"color": "#d62728", "width": 2},
+                ),
+                row=1,
+                col=1,
+            )
+            # Add VIX threshold lines
+            fig.add_hline(
+                y=20,
+                line_dash="dash",
+                line_color="orange",
+                annotation_text="警戒水準",
+                row=1,
+                col=1,
+            )
+            fig.add_hline(
+                y=30,
+                line_dash="dash",
+                line_color="red",
+                annotation_text="高リスク",
+                row=1,
+                col=1,
+            )
+
+        if has_hy:
+            hy_data = macro_data["BAMLH0A0HYM2"]
+            fig.add_trace(
+                go.Scatter(
+                    x=hy_data.index,
+                    y=hy_data["close"],
+                    name="ハイイールドスプレッド",
+                    line={"color": "#8c564b", "width": 2},
+                ),
+                row=2,
+                col=1,
+            )
+
+        fig.update_layout(
+            title="リスク指標",
+            hovermode="x unified",
+            template="plotly_white",
+            height=500,
+            showlegend=True,
+            legend={"orientation": "h", "yanchor": "bottom", "y": 1.02, "xanchor": "right", "x": 1},
+        )
+
+        fig.update_yaxes(title_text="VIX", row=1, col=1)
+        fig.update_yaxes(title_text="スプレッド (%)", row=2, col=1)
+
+        vix_hy_chart = mo.ui.plotly(fig)
+    else:
+        errors = []
+        if vix_error:
+            errors.append(f"VIX: {vix_error}")
+        if not has_hy:
+            errors.append("ハイイールドスプレッド: データなし")
+        vix_hy_chart = mo.callout(
+            mo.md("リスク指標データの取得に失敗しました:\n" + "\n".join(errors)),
+            kind="danger",
+        )
+
+    return (vix_hy_chart,)
+
+
+@app.cell
+def _(interest_rates_chart, mo, vix_hy_chart, yield_spread_chart):
+    """Tab 2: Macro indicators content."""
+    tab2_content = mo.vstack(
+        [
+            mo.md("## マクロ指標"),
+            mo.md("### 米国金利"),
+            interest_rates_chart,
+            mo.md("### イールドスプレッド"),
+            yield_spread_chart,
+            mo.md("### リスク指標"),
+            vix_hy_chart,
+        ],
+        gap=2,
     )
-    return (_status,)
+    return (tab2_content,)
+
+
+@app.cell
+def _(mo, tab2_content):
+    """Tab navigation for dashboard sections with implemented Tab 2."""
+    tabs_with_macro = mo.ui.tabs(
+        {
+            "パフォーマンス概要": mo.md("## Tab 1: パフォーマンス概要\n\n- S&P500 & 主要指数のパフォーマンス\n- Magnificent 7 & SOX指数\n- セクターETF（XL系）\n- 貴金属\n\n> 未実装"),
+            "マクロ指標": tab2_content,
+            "相関・ベータ分析": mo.md("## Tab 3: 相関・ベータ分析\n\n- セクターETFローリングベータ（vs S&P500）\n- ドルインデックス vs 貴金属相関\n- 相関ヒートマップ\n\n> 未実装"),
+            "リターン分布": mo.md("## Tab 4: リターン分布\n\n- 週次リターンヒストグラム\n- 統計サマリー\n\n> 未実装"),
+        }
+    )
+    return (tabs_with_macro,)
+
+
+@app.cell(hide_code=True)
+def _(mo, selected_period, tabs_with_macro):
+    """Display main dashboard with tabs."""
+    _dashboard = mo.vstack(
+        [
+            mo.md(f"**選択期間**: {selected_period}"),
+            tabs_with_macro,
+        ],
+        gap=2,
+    )
+    return (_dashboard,)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
- Issue #306 に基づき、marimo Market Dashboard の Tab 2（マクロ指標）を実装
- FRED データと Yahoo Finance データを使用したインタラクティブチャートを追加

## 変更内容
- 米国金利チャート（10Y, 2Y, FF金利）を追加
- イールドスプレッドチャート（10Y-2Y）を追加
- VIX & ハイイールドスプレッドチャートを追加
- MarketData API を使用したデータ取得機能を実装

## テストプラン
- [x] `make format` 実行済み
- [x] `make lint` エラーなし（notebook対象ファイル）
- [x] `make typecheck` エラーなし（notebook対象ファイル）
- [x] `make test` market_analysis テストパス

Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)