### PR TITLE
feat(agents): ニュース収集エージェントに収集日時フィールドを追加

### DIFF
--- a/.claude/agents/finance-news-ai.md
+++ b/.claude/agents/finance-news-ai.md
@@ -70,10 +70,13 @@ Phase 4: 結果報告
 - 英語記事の場合は日本語に翻訳
 
 ```bash
+# 収集日時を取得（Issue作成直前に実行）
+collected_at=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+
 gh issue create \
     --repo YH-05/finance \
     --title "[AI] {japanese_title}" \
-    --body "$(cat <<'EOF'
+    --body "$(cat <<EOF
 ### 概要
 
 {japanese_summary}
@@ -85,6 +88,10 @@ gh issue create \
 ### 公開日
 
 {published_jst}(JST)
+
+### 収集日時
+
+${collected_at}(JST)
 
 ### カテゴリ
 

--- a/.claude/agents/finance-news-index.md
+++ b/.claude/agents/finance-news-index.md
@@ -70,10 +70,13 @@ Phase 4: 結果報告
 - 英語記事の場合は日本語に翻訳
 
 ```bash
+# 収集日時を取得（Issue作成直前に実行）
+collected_at=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+
 gh issue create \
     --repo YH-05/finance \
     --title "[株価指数] {japanese_title}" \
-    --body "$(cat <<'EOF'
+    --body "$(cat <<EOF
 ### 概要
 
 {japanese_summary}
@@ -85,6 +88,10 @@ gh issue create \
 ### 公開日
 
 {published_jst}(JST)
+
+### 収集日時
+
+${collected_at}(JST)
 
 ### カテゴリ
 

--- a/.claude/agents/finance-news-macro.md
+++ b/.claude/agents/finance-news-macro.md
@@ -70,10 +70,13 @@ Phase 4: 結果報告
 - 英語記事の場合は日本語に翻訳
 
 ```bash
+# 収集日時を取得（Issue作成直前に実行）
+collected_at=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+
 gh issue create \
     --repo YH-05/finance \
     --title "[マクロ経済] {japanese_title}" \
-    --body "$(cat <<'EOF'
+    --body "$(cat <<EOF
 ### 概要
 
 {japanese_summary}
@@ -85,6 +88,10 @@ gh issue create \
 ### 公開日
 
 {published_jst}(JST)
+
+### 収集日時
+
+${collected_at}(JST)
 
 ### カテゴリ
 

--- a/.claude/agents/finance-news-sector.md
+++ b/.claude/agents/finance-news-sector.md
@@ -70,10 +70,13 @@ Phase 4: 結果報告
 - 英語記事の場合は日本語に翻訳
 
 ```bash
+# 収集日時を取得（Issue作成直前に実行）
+collected_at=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+
 gh issue create \
     --repo YH-05/finance \
     --title "[セクター] {japanese_title}" \
-    --body "$(cat <<'EOF'
+    --body "$(cat <<EOF
 ### 概要
 
 {japanese_summary}
@@ -85,6 +88,10 @@ gh issue create \
 ### 公開日
 
 {published_jst}(JST)
+
+### 収集日時
+
+${collected_at}(JST)
 
 ### カテゴリ
 

--- a/.claude/agents/finance-news-stock.md
+++ b/.claude/agents/finance-news-stock.md
@@ -70,10 +70,13 @@ Phase 4: 結果報告
 - 英語記事の場合は日本語に翻訳
 
 ```bash
+# 収集日時を取得（Issue作成直前に実行）
+collected_at=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+
 gh issue create \
     --repo YH-05/finance \
     --title "[個別銘柄] {japanese_title}" \
-    --body "$(cat <<'EOF'
+    --body "$(cat <<EOF
 ### 概要
 
 {japanese_summary}
@@ -85,6 +88,10 @@ gh issue create \
 ### 公開日
 
 {published_jst}(JST)
+
+### 収集日時
+
+${collected_at}(JST)
 
 ### カテゴリ
 

--- a/.claude/agents/finance_news_collector/common-processing-guide.md
+++ b/.claude/agents/finance_news_collector/common-processing-guide.md
@@ -174,9 +174,10 @@ def generate_japanese_summary(content: str, max_length: int = 400) -> str:
     return summary
 ```
 
-### ステップ3.1: 公開日時のISO形式変換
+### ステップ3.1: 日時フォーマット関数
 
 **重要**: GitHub Projectでソートするため、公開日時をISO 8601形式に変換します。
+また、Issue本文には「収集日時」（Issue作成時の日時）も必ず記載します。
 
 ```python
 from datetime import datetime, timezone
@@ -217,6 +218,16 @@ def format_published_jst(published_str: str | None) -> str:
 
     dt_jst = dt.astimezone(jst)
     return dt_jst.strftime('%Y-%m-%d %H:%M')
+
+
+def get_collected_at_jst() -> str:
+    """収集日時（現在時刻）をJST形式で取得（YYYY-MM-DD HH:MM）
+
+    Issue作成時に呼び出し、収集日時として記録する。
+    """
+
+    jst = pytz.timezone('Asia/Tokyo')
+    return datetime.now(jst).strftime('%Y-%m-%d %H:%M')
 ```
 
 ### ステップ3.2: Issue作成
@@ -228,10 +239,13 @@ def format_published_jst(published_str: str | None) -> str:
 3. **タイトル翻訳**: 英語記事の場合は日本語に翻訳（要約生成時に同時に実施）
 
 ```bash
+# 収集日時を取得（Issue作成直前に実行）
+collected_at=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+
 gh issue create \
     --repo YH-05/finance \
     --title "[{theme_ja}] {japanese_title}" \
-    --body "$(cat <<'EOF'
+    --body "$(cat <<EOF
 ### 概要
 
 {japanese_summary}
@@ -243,6 +257,10 @@ gh issue create \
 ### 公開日
 
 {published_jst}(JST)
+
+### 収集日時
+
+${collected_at}(JST)
 
 ### カテゴリ
 

--- a/.github/ISSUE_TEMPLATE/news-article.yml
+++ b/.github/ISSUE_TEMPLATE/news-article.yml
@@ -40,6 +40,15 @@ body:
     validations:
       required: false
 
+  - type: input
+    id: collected_at
+    attributes:
+      label: 収集日時
+      description: ニュースを収集した日時（YYYY-MM-DD HH:MM形式。JST。自動入力）
+      placeholder: "2026-01-15 09:30(JST)"
+    validations:
+      required: false
+
   - type: dropdown
     id: credibility
     attributes:


### PR DESCRIPTION
## 概要

テーマ別ニュース収集エージェントとIssueテンプレートに「収集日時」フィールドを追加しました。

- finance-news-ai/index/macro/sector/stock.md に収集日時セクション追加
- common-processing-guide.md に `get_collected_at_jst()` 関数を追加
- news-article.yml テンプレートに収集日時入力フィールドを追加
- heredoc を `'EOF'` → `EOF` に変更（変数展開を有効化）

## 背景

公開日時（記事が公開された時点）とは別に、ニュースを収集した時点のタイムスタンプを記録することで、収集タイミングの追跡が可能になります。

## テストプラン

- [x] make check-all が成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)