### PR TITLE
決算カレンダーモジュールの実装 (earnings.py)

### DIFF
--- a/src/market_analysis/analysis/__init__.py
+++ b/src/market_analysis/analysis/__init__.py
@@ -2,10 +2,14 @@
 
 from .analyzer import Analyzer
 from .correlation import CorrelationAnalyzer
+from .earnings import EarningsCalendar, EarningsData, get_upcoming_earnings
 from .indicators import IndicatorCalculator
 
 __all__ = [
     "Analyzer",
     "CorrelationAnalyzer",
+    "EarningsCalendar",
+    "EarningsData",
     "IndicatorCalculator",
+    "get_upcoming_earnings",
 ]

--- a/src/market_analysis/analysis/earnings.py
+++ b/src/market_analysis/analysis/earnings.py
@@ -1,0 +1,414 @@
+"""Earnings calendar module for fetching upcoming earnings dates.
+
+This module provides functionality to:
+- Fetch earnings dates from Yahoo Finance using yfinance
+- Filter earnings within a specified time range
+- Extract EPS and revenue estimates when available
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pandas as pd
+
+from ..utils.logging_config import get_logger
+
+logger = get_logger(__name__, module="earnings")
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class EarningsData:
+    """Data class representing a single earnings event.
+
+    Parameters
+    ----------
+    ticker : str
+        Stock ticker symbol
+    name : str
+        Company name
+    earnings_date : datetime
+        Expected earnings announcement date
+    eps_estimate : float | None
+        Estimated earnings per share (if available)
+    revenue_estimate : float | None
+        Estimated revenue (if available)
+
+    Examples
+    --------
+    >>> data = EarningsData(
+    ...     ticker="NVDA",
+    ...     name="NVIDIA Corporation",
+    ...     earnings_date=datetime(2026, 1, 28, tzinfo=timezone.utc),
+    ...     eps_estimate=0.85,
+    ...     revenue_estimate=38_500_000_000,
+    ... )
+    >>> data.to_dict()
+    {'ticker': 'NVDA', 'name': 'NVIDIA Corporation', ...}
+    """
+
+    ticker: str
+    name: str
+    earnings_date: datetime
+    eps_estimate: float | None = None
+    revenue_estimate: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary representation of the earnings data
+        """
+        return {
+            "ticker": self.ticker,
+            "name": self.name,
+            "earnings_date": self.earnings_date.strftime("%Y-%m-%d"),
+            "eps_estimate": self.eps_estimate,
+            "revenue_estimate": self.revenue_estimate,
+        }
+
+
+# =============================================================================
+# Earnings Calendar Class
+# =============================================================================
+
+
+@dataclass
+class EarningsCalendar:
+    """Fetches and filters upcoming earnings dates.
+
+    Provides functionality to retrieve earnings dates for major stocks
+    and filter them based on a time range.
+
+    Attributes
+    ----------
+    default_symbols : list[str]
+        Default list of symbols to check (Mag7 + sector representatives)
+
+    Examples
+    --------
+    >>> calendar = EarningsCalendar()
+    >>> results = calendar.get_upcoming_earnings(days_ahead=14)
+    >>> for r in results:
+    ...     print(f"{r.ticker}: {r.earnings_date}")
+    """
+
+    default_symbols: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Initialize default symbols if not provided."""
+        if not self.default_symbols:
+            self.default_symbols = self._get_default_symbols()
+        logger.debug(
+            "EarningsCalendar initialized",
+            symbol_count=len(self.default_symbols),
+        )
+
+    @staticmethod
+    def _get_default_symbols() -> list[str]:
+        """Get default list of symbols (Mag7 + sector representatives).
+
+        Returns
+        -------
+        list[str]
+            List of ticker symbols
+        """
+        # Magnificent 7
+        mag7 = ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA"]
+
+        # Sector representatives
+        sector_reps = [
+            # Financials
+            "JPM",
+            "BAC",
+            "GS",
+            # Healthcare
+            "JNJ",
+            "UNH",
+            "PFE",
+            # Consumer Discretionary
+            "HD",
+            "NKE",
+            "MCD",
+            # Consumer Staples
+            "PG",
+            "KO",
+            "WMT",
+            # Industrials
+            "CAT",
+            "BA",
+            "UPS",
+            # Energy
+            "XOM",
+            "CVX",
+            # Utilities
+            "NEE",
+            "DUK",
+            # Materials
+            "LIN",
+            "APD",
+            # Real Estate
+            "AMT",
+            "PLD",
+            # Communication Services (beyond META/GOOGL)
+            "DIS",
+            "NFLX",
+        ]
+
+        return mag7 + sector_reps
+
+    def get_earnings_for_symbol(
+        self,
+        symbol: str,
+        limit: int = 100,
+    ) -> EarningsData | None:
+        """Get the next upcoming earnings date for a symbol.
+
+        Parameters
+        ----------
+        symbol : str
+            Stock ticker symbol
+        limit : int, default=100
+            Maximum number of earnings dates to fetch
+
+        Returns
+        -------
+        EarningsData | None
+            Earnings data if available, None otherwise
+        """
+        import yfinance as yf
+
+        logger.debug("Fetching earnings for symbol", symbol=symbol, limit=limit)
+
+        try:
+            ticker = yf.Ticker(symbol)
+            earnings_df = ticker.get_earnings_dates(limit=limit)
+
+            if earnings_df is None or earnings_df.empty:
+                logger.debug("No earnings data available", symbol=symbol)
+                return None
+
+            # Get ticker info for company name
+            info = ticker.info
+            company_name = info.get("shortName", symbol)
+
+            # Find the next upcoming earnings date
+            now = datetime.now(tz=timezone.utc)
+
+            # Iterate through dates to find the next future earnings
+            for idx in earnings_df.index:
+                # Convert to pandas Timestamp for consistent handling
+                ts = pd.Timestamp(str(idx))
+                if bool(pd.isna(ts)):
+                    continue
+                if ts.tzinfo is None:
+                    dt = ts.tz_localize(timezone.utc).to_pydatetime()
+                else:
+                    dt = ts.to_pydatetime()
+
+                # Type guard: ensure dt is datetime, not NaTType
+                if not isinstance(dt, datetime):
+                    continue
+
+                if dt > now:
+                    row = earnings_df.loc[idx]
+                    return self._create_earnings_data(symbol, company_name, dt, row)
+
+            logger.debug("No future earnings dates found", symbol=symbol)
+            return None
+
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch earnings",
+                symbol=symbol,
+                error=str(e),
+            )
+            return None
+
+    def _create_earnings_data(
+        self,
+        symbol: str,
+        company_name: str,
+        earnings_date: datetime,
+        row: pd.Series,
+    ) -> EarningsData:
+        """Create EarningsData from a DataFrame row.
+
+        Parameters
+        ----------
+        symbol : str
+            Stock ticker symbol
+        company_name : str
+            Company name
+        earnings_date : datetime
+            Earnings date
+        row : pd.Series
+            Row from earnings DataFrame
+
+        Returns
+        -------
+        EarningsData
+            Populated earnings data object
+        """
+        # Extract estimates (may be NaN)
+        eps_estimate = None
+        revenue_estimate = None
+
+        if "EPS Estimate" in row.index:
+            val = row["EPS Estimate"]
+            if bool(pd.notna(val)):
+                eps_estimate = float(val)
+
+        if "Revenue Estimate" in row.index:
+            val = row["Revenue Estimate"]
+            if bool(pd.notna(val)):
+                revenue_estimate = float(val)
+
+        return EarningsData(
+            ticker=symbol,
+            name=company_name,
+            earnings_date=earnings_date,
+            eps_estimate=eps_estimate,
+            revenue_estimate=revenue_estimate,
+        )
+
+    def get_upcoming_earnings(
+        self,
+        symbols: list[str] | None = None,
+        days_ahead: int = 14,
+    ) -> list[EarningsData]:
+        """Get upcoming earnings within the specified time range.
+
+        Parameters
+        ----------
+        symbols : list[str] | None, default=None
+            List of symbols to check. If None, uses default_symbols.
+        days_ahead : int, default=14
+            Number of days ahead to look for earnings
+
+        Returns
+        -------
+        list[EarningsData]
+            List of upcoming earnings, sorted by date
+        """
+        if symbols is None:
+            symbols = self.default_symbols
+
+        logger.info(
+            "Fetching upcoming earnings",
+            symbol_count=len(symbols),
+            days_ahead=days_ahead,
+        )
+
+        now = datetime.now(tz=timezone.utc)
+        cutoff_date = now + timedelta(days=days_ahead)
+
+        results: list[EarningsData] = []
+
+        for symbol in symbols:
+            earnings = self.get_earnings_for_symbol(symbol)
+            if earnings is None:
+                continue
+
+            # Filter by date range
+            if now < earnings.earnings_date <= cutoff_date:
+                results.append(earnings)
+                logger.debug(
+                    "Found upcoming earnings",
+                    symbol=symbol,
+                    earnings_date=earnings.earnings_date.isoformat(),
+                )
+
+        # Sort by earnings date
+        results.sort(key=lambda x: x.earnings_date)
+
+        logger.info(
+            "Upcoming earnings fetch completed",
+            total_found=len(results),
+            symbols_checked=len(symbols),
+        )
+
+        return results
+
+    def to_json_output(
+        self,
+        earnings_list: list[EarningsData],
+    ) -> dict[str, Any]:
+        """Convert earnings list to JSON output format.
+
+        Parameters
+        ----------
+        earnings_list : list[EarningsData]
+            List of earnings data
+
+        Returns
+        -------
+        dict[str, Any]
+            JSON-serializable output
+        """
+        return {
+            "upcoming_earnings": [e.to_dict() for e in earnings_list],
+        }
+
+
+# =============================================================================
+# Convenience Function
+# =============================================================================
+
+
+def get_upcoming_earnings(
+    symbols: list[str] | None = None,
+    days_ahead: int = 14,
+) -> dict[str, Any]:
+    """Get upcoming earnings for the specified symbols.
+
+    This is a convenience function that creates an EarningsCalendar
+    and returns the results in JSON format.
+
+    Parameters
+    ----------
+    symbols : list[str] | None, default=None
+        List of symbols to check. If None, uses default symbols.
+    days_ahead : int, default=14
+        Number of days ahead to look for earnings
+
+    Returns
+    -------
+    dict[str, Any]
+        JSON-serializable output with upcoming earnings
+
+    Examples
+    --------
+    >>> result = get_upcoming_earnings(symbols=["NVDA", "AAPL"])
+    >>> print(result["upcoming_earnings"])
+    [{'ticker': 'NVDA', 'name': 'NVIDIA Corporation', ...}]
+    """
+    logger.info(
+        "Getting upcoming earnings",
+        symbols=symbols,
+        days_ahead=days_ahead,
+    )
+
+    calendar = EarningsCalendar()
+    earnings = calendar.get_upcoming_earnings(
+        symbols=symbols,
+        days_ahead=days_ahead,
+    )
+
+    return calendar.to_json_output(earnings)
+
+
+__all__ = [
+    "EarningsCalendar",
+    "EarningsData",
+    "get_upcoming_earnings",
+]

--- a/tests/market_analysis/unit/analysis/test_earnings.py
+++ b/tests/market_analysis/unit/analysis/test_earnings.py
@@ -1,0 +1,373 @@
+"""Unit tests for earnings calendar module."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from market_analysis.analysis.earnings import (
+    EarningsCalendar,
+    EarningsData,
+    get_upcoming_earnings,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_earnings_dates() -> pd.DataFrame:
+    """Create mock earnings dates DataFrame as returned by yfinance."""
+    now = datetime.now(tz=timezone.utc)
+    dates = [
+        now + timedelta(days=3),  # 3 days from now
+        now + timedelta(days=10),  # 10 days from now
+        now + timedelta(days=20),  # 20 days from now (outside 2 weeks)
+        now - timedelta(days=5),  # 5 days ago (past)
+    ]
+
+    return pd.DataFrame(
+        {
+            "EPS Estimate": [0.85, 1.20, 0.95, 0.75],
+            "Reported EPS": [None, None, None, 0.78],
+            "Revenue Estimate": [38_500_000_000, 45_000_000_000, None, 35_000_000_000],
+        },
+        index=pd.DatetimeIndex(dates, name="Earnings Date"),
+    )
+
+
+@pytest.fixture
+def mock_ticker_info() -> dict:
+    """Create mock ticker info."""
+    return {
+        "shortName": "NVIDIA Corporation",
+        "symbol": "NVDA",
+        "sector": "Technology",
+    }
+
+
+@pytest.fixture
+def earnings_calendar() -> EarningsCalendar:
+    """Create EarningsCalendar instance."""
+    return EarningsCalendar()
+
+
+# =============================================================================
+# TestEarningsData
+# =============================================================================
+
+
+class TestEarningsData:
+    """Tests for EarningsData dataclass."""
+
+    def test_正常系_基本データで作成できる(self) -> None:
+        """EarningsDataが基本データで作成できることを確認。"""
+        data = EarningsData(
+            ticker="NVDA",
+            name="NVIDIA Corporation",
+            earnings_date=datetime(2026, 1, 28, tzinfo=timezone.utc),
+        )
+
+        assert data.ticker == "NVDA"
+        assert data.name == "NVIDIA Corporation"
+        assert data.earnings_date == datetime(2026, 1, 28, tzinfo=timezone.utc)
+        assert data.eps_estimate is None
+        assert data.revenue_estimate is None
+
+    def test_正常系_全データで作成できる(self) -> None:
+        """EarningsDataが全データで作成できることを確認。"""
+        data = EarningsData(
+            ticker="NVDA",
+            name="NVIDIA Corporation",
+            earnings_date=datetime(2026, 1, 28, tzinfo=timezone.utc),
+            eps_estimate=0.85,
+            revenue_estimate=38_500_000_000,
+        )
+
+        assert data.eps_estimate == 0.85
+        assert data.revenue_estimate == 38_500_000_000
+
+    def test_正常系_to_dict変換ができる(self) -> None:
+        """EarningsDataをdict形式に変換できることを確認。"""
+        data = EarningsData(
+            ticker="NVDA",
+            name="NVIDIA Corporation",
+            earnings_date=datetime(2026, 1, 28, tzinfo=timezone.utc),
+            eps_estimate=0.85,
+            revenue_estimate=38_500_000_000,
+        )
+
+        result = data.to_dict()
+
+        assert result["ticker"] == "NVDA"
+        assert result["name"] == "NVIDIA Corporation"
+        assert result["earnings_date"] == "2026-01-28"
+        assert result["eps_estimate"] == 0.85
+        assert result["revenue_estimate"] == 38_500_000_000
+
+
+# =============================================================================
+# TestEarningsCalendar
+# =============================================================================
+
+
+class TestEarningsCalendar:
+    """Tests for EarningsCalendar class."""
+
+    def test_正常系_デフォルトシンボルリストが存在する(
+        self,
+        earnings_calendar: EarningsCalendar,
+    ) -> None:
+        """デフォルトのシンボルリスト（Mag7 + セクター代表）が存在することを確認。"""
+        symbols = earnings_calendar.default_symbols
+
+        # Mag7 should be included
+        assert "AAPL" in symbols
+        assert "MSFT" in symbols
+        assert "GOOGL" in symbols
+        assert "AMZN" in symbols
+        assert "NVDA" in symbols
+        assert "META" in symbols
+        assert "TSLA" in symbols
+
+        # Should have more than just Mag7
+        assert len(symbols) > 7
+
+    @patch("yfinance.Ticker")
+    def test_正常系_単一銘柄の決算日を取得できる(
+        self,
+        mock_ticker_class: MagicMock,
+        earnings_calendar: EarningsCalendar,
+        mock_earnings_dates: pd.DataFrame,
+        mock_ticker_info: dict,
+    ) -> None:
+        """単一銘柄の決算日を取得できることを確認。"""
+        # Setup mock
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = mock_earnings_dates
+        mock_ticker.info = mock_ticker_info
+        mock_ticker_class.return_value = mock_ticker
+
+        result = earnings_calendar.get_earnings_for_symbol("NVDA")
+
+        assert result is not None
+        assert result.ticker == "NVDA"
+        mock_ticker.get_earnings_dates.assert_called_once()
+
+    @patch("yfinance.Ticker")
+    def test_正常系_今後2週間以内の決算をフィルタリングできる(
+        self,
+        mock_ticker_class: MagicMock,
+        earnings_calendar: EarningsCalendar,
+        mock_earnings_dates: pd.DataFrame,
+        mock_ticker_info: dict,
+    ) -> None:
+        """今後2週間以内の決算を正しくフィルタリングできることを確認。"""
+        # Setup mock
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = mock_earnings_dates
+        mock_ticker.info = mock_ticker_info
+        mock_ticker_class.return_value = mock_ticker
+
+        results = earnings_calendar.get_upcoming_earnings(
+            symbols=["NVDA"],
+            days_ahead=14,
+        )
+
+        # Should include at least 1 earnings within 14 days
+        # (get_earnings_for_symbol returns the nearest future date per symbol)
+        assert len(results) >= 1
+
+        # Verify dates are within range
+        now = datetime.now(tz=timezone.utc)
+        for result in results:
+            assert result.earnings_date > now
+            assert result.earnings_date <= now + timedelta(days=14)
+
+    @patch("yfinance.Ticker")
+    def test_正常系_EPS予想と売上予想を取得できる(
+        self,
+        mock_ticker_class: MagicMock,
+        earnings_calendar: EarningsCalendar,
+        mock_earnings_dates: pd.DataFrame,
+        mock_ticker_info: dict,
+    ) -> None:
+        """EPS予想と売上予想を取得できることを確認。"""
+        # Setup mock
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = mock_earnings_dates
+        mock_ticker.info = mock_ticker_info
+        mock_ticker_class.return_value = mock_ticker
+
+        result = earnings_calendar.get_earnings_for_symbol("NVDA")
+
+        assert result is not None
+        assert result.eps_estimate == 0.85
+        assert result.revenue_estimate == 38_500_000_000
+
+    @patch("yfinance.Ticker")
+    def test_正常系_複数銘柄の決算を取得できる(
+        self,
+        mock_ticker_class: MagicMock,
+        earnings_calendar: EarningsCalendar,
+        mock_earnings_dates: pd.DataFrame,
+    ) -> None:
+        """複数銘柄の決算を取得できることを確認。"""
+        # Setup mock
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = mock_earnings_dates
+        mock_ticker.info = {"shortName": "Test Corp", "symbol": "TEST"}
+        mock_ticker_class.return_value = mock_ticker
+
+        results = earnings_calendar.get_upcoming_earnings(
+            symbols=["AAPL", "MSFT", "GOOGL"],
+            days_ahead=14,
+        )
+
+        # Each symbol should have results (mock returns same data for all)
+        assert len(results) > 0
+
+    @patch("yfinance.Ticker")
+    def test_正常系_決算日で昇順ソートされる(
+        self,
+        mock_ticker_class: MagicMock,
+        earnings_calendar: EarningsCalendar,
+        mock_earnings_dates: pd.DataFrame,
+        mock_ticker_info: dict,
+    ) -> None:
+        """結果が決算日で昇順ソートされることを確認。"""
+        # Setup mock
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = mock_earnings_dates
+        mock_ticker.info = mock_ticker_info
+        mock_ticker_class.return_value = mock_ticker
+
+        results = earnings_calendar.get_upcoming_earnings(
+            symbols=["NVDA"],
+            days_ahead=14,
+        )
+
+        # Verify sorted order
+        for i in range(len(results) - 1):
+            assert results[i].earnings_date <= results[i + 1].earnings_date
+
+    @patch("yfinance.Ticker")
+    def test_異常系_APIエラー時は空リストを返す(
+        self,
+        mock_ticker_class: MagicMock,
+        earnings_calendar: EarningsCalendar,
+    ) -> None:
+        """APIエラー時は空リストを返すことを確認。"""
+        # Setup mock to raise exception
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.side_effect = Exception("API Error")
+        mock_ticker_class.return_value = mock_ticker
+
+        result = earnings_calendar.get_earnings_for_symbol("INVALID")
+
+        assert result is None
+
+    @patch("yfinance.Ticker")
+    def test_異常系_決算データがない銘柄はスキップ(
+        self,
+        mock_ticker_class: MagicMock,
+        earnings_calendar: EarningsCalendar,
+    ) -> None:
+        """決算データがない銘柄はスキップされることを確認。"""
+        # Setup mock to return empty DataFrame
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = pd.DataFrame()
+        mock_ticker.info = {"shortName": "Empty Corp"}
+        mock_ticker_class.return_value = mock_ticker
+
+        results = earnings_calendar.get_upcoming_earnings(
+            symbols=["EMPTY"],
+            days_ahead=14,
+        )
+
+        assert len(results) == 0
+
+    def test_正常系_JSON出力形式に変換できる(
+        self,
+        earnings_calendar: EarningsCalendar,
+    ) -> None:
+        """結果をJSON出力形式に変換できることを確認。"""
+        earnings_list = [
+            EarningsData(
+                ticker="NVDA",
+                name="NVIDIA Corporation",
+                earnings_date=datetime(2026, 1, 28, tzinfo=timezone.utc),
+                eps_estimate=0.85,
+                revenue_estimate=38_500_000_000,
+            ),
+            EarningsData(
+                ticker="AAPL",
+                name="Apple Inc.",
+                earnings_date=datetime(2026, 1, 30, tzinfo=timezone.utc),
+                eps_estimate=2.10,
+                revenue_estimate=124_000_000_000,
+            ),
+        ]
+
+        result = earnings_calendar.to_json_output(earnings_list)
+
+        assert "upcoming_earnings" in result
+        assert len(result["upcoming_earnings"]) == 2
+        assert result["upcoming_earnings"][0]["ticker"] == "NVDA"
+        assert result["upcoming_earnings"][1]["ticker"] == "AAPL"
+
+
+# =============================================================================
+# TestGetUpcomingEarnings (convenience function)
+# =============================================================================
+
+
+class TestGetUpcomingEarnings:
+    """Tests for get_upcoming_earnings convenience function."""
+
+    @patch("yfinance.Ticker")
+    def test_正常系_デフォルト設定で取得できる(
+        self,
+        mock_ticker_class: MagicMock,
+        mock_earnings_dates: pd.DataFrame,
+        mock_ticker_info: dict,
+    ) -> None:
+        """デフォルト設定で決算情報を取得できることを確認。"""
+        # Setup mock
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = mock_earnings_dates
+        mock_ticker.info = mock_ticker_info
+        mock_ticker_class.return_value = mock_ticker
+
+        result = get_upcoming_earnings(symbols=["NVDA"])
+
+        assert "upcoming_earnings" in result
+        assert len(result["upcoming_earnings"]) > 0
+
+    @patch("yfinance.Ticker")
+    def test_正常系_カスタム日数で取得できる(
+        self,
+        mock_ticker_class: MagicMock,
+        mock_earnings_dates: pd.DataFrame,
+        mock_ticker_info: dict,
+    ) -> None:
+        """カスタム日数指定で決算情報を取得できることを確認。"""
+        # Setup mock
+        mock_ticker = MagicMock()
+        mock_ticker.get_earnings_dates.return_value = mock_earnings_dates
+        mock_ticker.info = mock_ticker_info
+        mock_ticker_class.return_value = mock_ticker
+
+        result = get_upcoming_earnings(symbols=["NVDA"], days_ahead=7)
+
+        # With 7 days, only the 3-day-ahead earnings should be included
+        assert "upcoming_earnings" in result
+        # Verify all results are within 7 days
+        now = datetime.now(tz=timezone.utc)
+        for item in result["upcoming_earnings"]:
+            earnings_date = datetime.fromisoformat(item["earnings_date"])
+            if earnings_date.tzinfo is None:
+                earnings_date = earnings_date.replace(tzinfo=timezone.utc)
+            assert (earnings_date - now).days <= 7


### PR DESCRIPTION
## 概要

- 今後n日以内の決算発表銘柄を抽出するモジュールを新規作成
- `EarningsCalendar`クラスと`EarningsData`データクラスを実装
- yfinanceを使用して決算日、EPS予想、売上予想を取得

## 機能

- `yf.Ticker(symbol).get_earnings_dates(limit=100)` で決算日取得
- 今後2週間以内の決算発表銘柄をフィルタリング
- EPS予想・売上予想を取得（利用可能な場合）
- デフォルトでMag7 + セクター代表銘柄をサポート

## 出力形式

```json
{
  "upcoming_earnings": [
    {
      "ticker": "NVDA",
      "name": "NVIDIA Corporation",
      "earnings_date": "2026-01-28",
      "eps_estimate": 0.85,
      "revenue_estimate": 38500000000
    }
  ]
}
```

## テストプラン

- [x] `tests/market_analysis/unit/analysis/test_earnings.py` に14テストケースを作成
- [x] make check-all が成功することを確認

Fixes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)