### PR TITLE
feat(scripts): データ収集スクリプトを追加

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,13 @@
+"""Scripts package for finance project.
+
+このパッケージには、finance プロジェクトで使用するユーティリティスクリプトが含まれます。
+
+Modules
+-------
+market_report_data
+    市場レポートデータの収集スクリプト（騰落率、セクター分析、決算カレンダー）
+collect_finance_news
+    金融ニュース収集スクリプト
+check_project_sync
+    プロジェクト同期チェックスクリプト
+"""

--- a/scripts/market_report_data.py
+++ b/scripts/market_report_data.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Market Report Data Collection Script.
+
+騰落率・セクター分析・決算カレンダーの各モジュールを統合実行し、
+JSONファイルを出力するスクリプト。
+
+このスクリプトは以下の3つのモジュールからデータを収集します:
+
+1. **騰落率 (Returns)**: 主要指数、MAG7、セクターETF、グローバル指数の騰落率
+2. **セクター分析 (Sectors)**: セクター別のパフォーマンス分析
+3. **決算カレンダー (Earnings)**: 今後の決算発表予定
+
+出力ファイル
+-----------
+- returns.json: 騰落率データ
+- sectors.json: セクター分析データ
+- earnings.json: 決算カレンダーデータ
+
+Examples
+--------
+基本的な使用方法:
+
+    $ uv run python scripts/market_report_data.py
+
+出力ディレクトリを指定:
+
+    $ uv run python scripts/market_report_data.py --output .tmp/market-report-20260119/
+
+Notes
+-----
+- 各モジュールのエラーは独立して処理され、一つのモジュールが失敗しても他は続行
+- 出力ディレクトリは自動作成される
+- 終了コード 0 は少なくとも1つのファイル作成成功、1 は全て失敗
+
+See Also
+--------
+market_analysis.analysis.returns : 騰落率計算モジュール
+market_analysis.analysis.sector : セクター分析モジュール
+market_analysis.analysis.earnings : 決算カレンダーモジュール
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from finance.utils.logging_config import get_logger
+from market_analysis.analysis.earnings import get_upcoming_earnings
+from market_analysis.analysis.returns import generate_returns_report
+from market_analysis.analysis.sector import analyze_sector_performance
+
+logger = get_logger(__name__)
+
+
+def collect_returns_data() -> dict[str, Any]:
+    """Collect returns data using generate_returns_report.
+
+    Returns
+    -------
+    dict[str, Any]
+        Returns report containing indices, MAG7, sectors, and global indices data.
+
+    Examples
+    --------
+    >>> data = collect_returns_data()
+    >>> "as_of" in data
+    True
+    """
+    logger.debug("Collecting returns data")
+    result = generate_returns_report()
+    logger.info("Returns data collected", indices_count=len(result.get("indices", [])))
+    return result
+
+
+def collect_sector_data() -> dict[str, Any]:
+    """Collect sector analysis data using analyze_sector_performance.
+
+    Returns
+    -------
+    dict[str, Any]
+        Sector analysis result containing top_sectors and bottom_sectors.
+
+    Examples
+    --------
+    >>> data = collect_sector_data()
+    >>> "top_sectors" in data
+    True
+    """
+    logger.debug("Collecting sector data")
+    result = analyze_sector_performance()
+    data = result.to_dict()
+    logger.info(
+        "Sector data collected",
+        top_sectors_count=len(data.get("top_sectors", [])),
+        bottom_sectors_count=len(data.get("bottom_sectors", [])),
+    )
+    return data
+
+
+def collect_earnings_data() -> dict[str, Any]:
+    """Collect upcoming earnings data using get_upcoming_earnings.
+
+    Returns
+    -------
+    dict[str, Any]
+        Earnings calendar data containing upcoming earnings events.
+
+    Examples
+    --------
+    >>> data = collect_earnings_data()
+    >>> isinstance(data, dict)
+    True
+    """
+    logger.debug("Collecting earnings data")
+    result = get_upcoming_earnings()
+    logger.info(
+        "Earnings data collected",
+        earnings_count=len(result.get("upcoming_earnings", [])),
+    )
+    return result
+
+
+def save_all_reports(output_dir: Path) -> None:
+    """Collect all reports and save them as JSON files.
+
+    This function orchestrates the collection of returns, sector, and earnings
+    data, then saves each to a separate JSON file. If one module fails, the
+    others will still be processed.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory where JSON files will be saved.
+
+    Raises
+    ------
+    PermissionError
+        If the output directory cannot be created.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> save_all_reports(Path(".tmp/market-report"))  # doctest: +SKIP
+    """
+    logger.info("Starting report collection", output_dir=str(output_dir))
+
+    # Create output directory
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    success_count = 0
+    total_count = 3
+
+    # Collect returns data
+    try:
+        returns_data = collect_returns_data()
+        returns_file = output_dir / "returns.json"
+        with returns_file.open("w", encoding="utf-8") as f:
+            json.dump(returns_data, f, ensure_ascii=False, indent=2)
+        logger.info("Returns data saved", file=str(returns_file))
+        success_count += 1
+    except Exception as e:
+        logger.error("Failed to collect returns data", error=str(e), exc_info=True)
+
+    # Collect sector data
+    try:
+        sector_data = collect_sector_data()
+        sectors_file = output_dir / "sectors.json"
+        with sectors_file.open("w", encoding="utf-8") as f:
+            json.dump(sector_data, f, ensure_ascii=False, indent=2)
+        logger.info("Sector data saved", file=str(sectors_file))
+        success_count += 1
+    except Exception as e:
+        logger.error("Failed to collect sector data", error=str(e), exc_info=True)
+
+    # Collect earnings data
+    try:
+        earnings_data = collect_earnings_data()
+        earnings_file = output_dir / "earnings.json"
+        with earnings_file.open("w", encoding="utf-8") as f:
+            json.dump(earnings_data, f, ensure_ascii=False, indent=2)
+        logger.info("Earnings data saved", file=str(earnings_file))
+        success_count += 1
+    except Exception as e:
+        logger.error("Failed to collect earnings data", error=str(e), exc_info=True)
+
+    logger.info(
+        "Report collection completed",
+        success_count=success_count,
+        total_count=total_count,
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create command line argument parser.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Configured argument parser with --output option.
+
+    Examples
+    --------
+    >>> parser = create_parser()
+    >>> args = parser.parse_args(["--output", "/path/to/output"])
+    >>> args.output
+    '/path/to/output'
+    """
+    parser = argparse.ArgumentParser(
+        description="Collect market report data (returns, sectors, earnings)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # Default output directory with timestamp
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    default_output = f".tmp/market-report-{timestamp}"
+
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=default_output,
+        help=f"Output directory for JSON files (default: {default_output})",
+    )
+
+    return parser
+
+
+def main() -> int:
+    """Main entry point for the script.
+
+    Returns
+    -------
+    int
+        Exit code (0 for success, 1 for failure).
+
+    Examples
+    --------
+    >>> # Run with default arguments (requires mocking in tests)
+    >>> # exit_code = main()
+    """
+    logger.info("Market report data collection started")
+
+    parser = create_parser()
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+    logger.info("Output directory", path=str(output_dir))
+
+    try:
+        save_all_reports(output_dir)
+
+        # Check if at least one file was created
+        expected_files = ["returns.json", "sectors.json", "earnings.json"]
+        existing_files = [f for f in expected_files if (output_dir / f).exists()]
+
+        if not existing_files:
+            logger.error("No report files were created")
+            return 1
+
+        logger.info(
+            "Market report data collection completed successfully",
+            files_created=existing_files,
+        )
+        return 0
+
+    except PermissionError as e:
+        logger.error("Permission denied", error=str(e))
+        raise
+    except Exception as e:
+        logger.error("Unexpected error", error=str(e), exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_market_report_data.py
+++ b/tests/unit/test_market_report_data.py
@@ -1,0 +1,349 @@
+"""Unit tests for market_report_data.py script.
+
+scripts/market_report_data.py の単体テストを提供します。
+
+このテストモジュールは以下のコンポーネントをテストします:
+
+- collect_returns_data: 騰落率データ収集
+- collect_sector_data: セクター分析データ収集
+- collect_earnings_data: 決算カレンダーデータ収集
+- save_all_reports: 全レポートのJSON出力
+- create_parser: コマンドライン引数パーサー
+- main: エントリーポイント
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import LogCaptureFixture
+
+
+class TestCollectReturnsData:
+    """collect_returns_data 関数のテスト。"""
+
+    def test_正常系_returnsモジュールを呼び出して結果を取得できる(self) -> None:
+        """generate_returns_report を呼び出してデータを返すことを確認。"""
+        # Arrange
+        mock_returns_data = {
+            "as_of": "2026-01-19T12:00:00",
+            "indices": [{"ticker": "^GSPC", "1D": 0.01}],
+            "mag7": [],
+            "sectors": [],
+            "global_indices": [],
+        }
+
+        with patch(
+            "scripts.market_report_data.generate_returns_report",
+            return_value=mock_returns_data,
+        ) as mock_generate:
+            # Act
+            from scripts.market_report_data import collect_returns_data
+
+            result = collect_returns_data()
+
+            # Assert
+            mock_generate.assert_called_once()
+            assert result == mock_returns_data
+
+
+class TestCollectSectorData:
+    """collect_sector_data 関数のテスト。"""
+
+    def test_正常系_sectorモジュールを呼び出して結果を取得できる(self) -> None:
+        """analyze_sector_performance を呼び出してデータを返すことを確認。"""
+        # Arrange
+        mock_result = MagicMock()
+        mock_result.to_dict.return_value = {
+            "top_sectors": [{"name": "Technology", "return_1w": 0.05}],
+            "bottom_sectors": [{"name": "Energy", "return_1w": -0.02}],
+        }
+
+        with patch(
+            "scripts.market_report_data.analyze_sector_performance",
+            return_value=mock_result,
+        ) as mock_analyze:
+            # Act
+            from scripts.market_report_data import collect_sector_data
+
+            result = collect_sector_data()
+
+            # Assert
+            mock_analyze.assert_called_once()
+            assert "top_sectors" in result
+            assert "bottom_sectors" in result
+
+
+class TestCollectEarningsData:
+    """collect_earnings_data 関数のテスト。"""
+
+    def test_正常系_earningsモジュールを呼び出して結果を取得できる(self) -> None:
+        """get_upcoming_earnings を呼び出してデータを返すことを確認。"""
+        # Arrange
+        mock_earnings_data = {
+            "upcoming_earnings": [
+                {
+                    "ticker": "NVDA",
+                    "name": "NVIDIA",
+                    "earnings_date": "2026-01-28",
+                }
+            ]
+        }
+
+        with patch(
+            "scripts.market_report_data.get_upcoming_earnings",
+            return_value=mock_earnings_data,
+        ) as mock_get:
+            # Act
+            from scripts.market_report_data import collect_earnings_data
+
+            result = collect_earnings_data()
+
+            # Assert
+            mock_get.assert_called_once()
+            assert result == mock_earnings_data
+
+
+class TestOutputJsonFiles:
+    """save_all_reports 関数のJSON出力テスト。"""
+
+    def test_正常系_指定ディレクトリにJSONファイルを出力できる(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """3つのJSONファイル(returns, sectors, earnings)が作成されることを確認。"""
+        # Arrange
+        mock_returns = {"as_of": "2026-01-19T12:00:00", "indices": []}
+        mock_sectors = {"top_sectors": [], "bottom_sectors": []}
+        mock_earnings = {"upcoming_earnings": []}
+
+        with (
+            patch(
+                "scripts.market_report_data.collect_returns_data",
+                return_value=mock_returns,
+            ),
+            patch(
+                "scripts.market_report_data.collect_sector_data",
+                return_value=mock_sectors,
+            ),
+            patch(
+                "scripts.market_report_data.collect_earnings_data",
+                return_value=mock_earnings,
+            ),
+        ):
+            # Act
+            from scripts.market_report_data import save_all_reports
+
+            save_all_reports(output_dir=tmp_path)
+
+            # Assert
+            returns_file = tmp_path / "returns.json"
+            sectors_file = tmp_path / "sectors.json"
+            earnings_file = tmp_path / "earnings.json"
+
+            assert returns_file.exists(), "returns.json should be created"
+            assert sectors_file.exists(), "sectors.json should be created"
+            assert earnings_file.exists(), "earnings.json should be created"
+
+            # Verify content
+            with returns_file.open() as f:
+                returns_content = json.load(f)
+            assert returns_content == mock_returns
+
+            with sectors_file.open() as f:
+                sectors_content = json.load(f)
+            assert sectors_content == mock_sectors
+
+            with earnings_file.open() as f:
+                earnings_content = json.load(f)
+            assert earnings_content == mock_earnings
+
+
+class TestArgumentParser:
+    """create_parser 関数のテスト。"""
+
+    def test_正常系_outputオプションでディレクトリを指定できる(self) -> None:
+        """--output オプションで出力ディレクトリを指定できることを確認。"""
+        # Act
+        from scripts.market_report_data import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["--output", "/path/to/output"])
+
+        # Assert
+        assert args.output == "/path/to/output"
+
+    def test_正常系_outputオプションのデフォルト値が設定される(self) -> None:
+        """--output 未指定時にタイムスタンプ付きデフォルトパスが設定されることを確認。"""
+        # Act
+        from scripts.market_report_data import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([])
+
+        # Assert
+        # デフォルトはカレントディレクトリまたは指定のディレクトリ
+        assert args.output is not None
+
+
+class TestErrorHandling:
+    """save_all_reports のエラーハンドリングテスト。"""
+
+    def test_異常系_モジュールエラー時にログを出力して続行する(
+        self,
+        tmp_path: Path,
+        caplog: LogCaptureFixture,
+    ) -> None:
+        """一つのモジュールがエラーでも他のモジュールは実行され、エラーログが出力される。"""
+        # Arrange
+        mock_sectors = {"top_sectors": [], "bottom_sectors": []}
+        mock_earnings = {"upcoming_earnings": []}
+
+        with (
+            patch(
+                "scripts.market_report_data.collect_returns_data",
+                side_effect=Exception("Returns API error"),
+            ),
+            patch(
+                "scripts.market_report_data.collect_sector_data",
+                return_value=mock_sectors,
+            ),
+            patch(
+                "scripts.market_report_data.collect_earnings_data",
+                return_value=mock_earnings,
+            ),
+        ):
+            # Act
+            from scripts.market_report_data import save_all_reports
+
+            # エラーが発生しても例外を投げず続行することを確認
+            save_all_reports(output_dir=tmp_path)
+
+            # Assert
+            # returns.json は作成されない（または空）
+            # sectors.json と earnings.json は作成される
+            sectors_file = tmp_path / "sectors.json"
+            earnings_file = tmp_path / "earnings.json"
+
+            assert sectors_file.exists(), "sectors.json should be created despite error"
+            assert earnings_file.exists(), (
+                "earnings.json should be created despite error"
+            )
+
+            # エラーログが出力されていることを確認
+            assert any(
+                "Returns API error" in record.message
+                or "error" in record.message.lower()
+                for record in caplog.records
+            )
+
+    def test_異常系_出力ディレクトリが作成できない場合はエラー(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """PermissionError が発生した場合、例外が再スローされることを確認。"""
+        # Arrange
+        # 存在しない親ディレクトリを持つパスを指定
+        invalid_path = tmp_path / "nonexistent" / "deep" / "path"
+
+        with (
+            patch(
+                "scripts.market_report_data.collect_returns_data",
+                return_value={},
+            ),
+            patch(
+                "scripts.market_report_data.collect_sector_data",
+                return_value={},
+            ),
+            patch(
+                "scripts.market_report_data.collect_earnings_data",
+                return_value={},
+            ),
+            patch(
+                "pathlib.Path.mkdir", side_effect=PermissionError("Permission denied")
+            ),
+        ):
+            # Act & Assert
+            from scripts.market_report_data import save_all_reports
+
+            with pytest.raises(PermissionError, match="Permission denied"):
+                save_all_reports(output_dir=invalid_path)
+
+
+class TestMainFunction:
+    """main 関数のエントリーポイントテスト。"""
+
+    def test_正常系_main関数が全モジュールを実行して終了する(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """main 関数が全レポートを生成し、終了コード0を返すことを確認。"""
+        # Arrange
+        mock_returns = {"as_of": "2026-01-19T12:00:00", "indices": []}
+        mock_sectors = {"top_sectors": [], "bottom_sectors": []}
+        mock_earnings = {"upcoming_earnings": []}
+
+        with (
+            patch(
+                "scripts.market_report_data.collect_returns_data",
+                return_value=mock_returns,
+            ),
+            patch(
+                "scripts.market_report_data.collect_sector_data",
+                return_value=mock_sectors,
+            ),
+            patch(
+                "scripts.market_report_data.collect_earnings_data",
+                return_value=mock_earnings,
+            ),
+            patch("sys.argv", ["market_report_data.py", "--output", str(tmp_path)]),
+        ):
+            # Act
+            from scripts.market_report_data import main
+
+            exit_code = main()
+
+            # Assert
+            assert exit_code == 0
+
+            # ファイルが作成されていることを確認
+            assert (tmp_path / "returns.json").exists()
+            assert (tmp_path / "sectors.json").exists()
+            assert (tmp_path / "earnings.json").exists()
+
+    def test_異常系_main関数でエラー発生時は終了コード1を返す(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """全モジュールが失敗した場合、終了コード1を返すことを確認。"""
+        # Arrange
+        with (
+            patch(
+                "scripts.market_report_data.collect_returns_data",
+                side_effect=Exception("Returns error"),
+            ),
+            patch(
+                "scripts.market_report_data.collect_sector_data",
+                side_effect=Exception("Sector error"),
+            ),
+            patch(
+                "scripts.market_report_data.collect_earnings_data",
+                side_effect=Exception("Earnings error"),
+            ),
+            patch("sys.argv", ["market_report_data.py", "--output", str(tmp_path)]),
+        ):
+            # Act
+            from scripts.market_report_data import main
+
+            exit_code = main()
+
+            # Assert
+            # 全モジュールがエラーの場合は終了コード 1
+            assert exit_code == 1


### PR DESCRIPTION
## 概要

騰落率・セクター分析・決算カレンダーの各モジュールを統合実行するスクリプトを追加しました。

- `scripts/market_report_data.py` を新規作成
- JSON形式で `.tmp/market-report-{timestamp}/` に出力

## 変更内容

- `collect_returns_data()`: 騰落率データ収集
- `collect_sector_data()`: セクター分析データ収集
- `collect_earnings_data()`: 決算カレンダーデータ収集
- `save_all_reports()`: JSON出力
- `--output` オプションで出力先を指定可能

## テストプラン

- [x] `make check-all` が成功することを確認
- [x] 10個のユニットテストが全てパス
- [x] 型チェック（pyright）が成功

Fixes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)