### PR TITLE
[フェーズ0] エージェントへのスキル参照パターンを仕様書に追記

### DIFF
--- a/docs/project/project-18/project.md
+++ b/docs/project/project-18/project.md
@@ -12,7 +12,7 @@
 
 | フェーズ | 内容 | ステータス |
 |---------|------|----------|
-| フェーズ 0 | 基盤整備（Project作成、テンプレート、仕様書） | Todo |
+| フェーズ 0 | 基盤整備（Project作成、テンプレート、仕様書） | Done |
 | フェーズ 1 | レポジトリ管理スキル（7スキル作成） | Todo |
 | フェーズ 2 | コーディングスキル（3スキル作成） | Todo |
 | フェーズ 3 | 金融分析スキル（後続） | Backlog |
@@ -29,7 +29,7 @@
 | 0.1 | GitHub Project「System Update」の作成 | なし | Done | - |
 | 0.2 | スキル標準構造テンプレートの作成 | なし | Done | [#598](https://github.com/YH-05/finance/issues/598) |
 | 0.3 | スキルプリロード仕様書の作成 | 0.2 | Done | [#599](https://github.com/YH-05/finance/issues/599) |
-| 0.4 | エージェントへのスキル参照パターンの確定 | 0.3 | Todo | [#600](https://github.com/YH-05/finance/issues/600) |
+| 0.4 | エージェントへのスキル参照パターンの確定 | 0.3 | Done | [#600](https://github.com/YH-05/finance/issues/600) |
 
 ---
 


### PR DESCRIPTION
## 概要
- スキルプリロード仕様書にエージェントへのスキル参照パターンを追加
- 複数スキル参照時の順序・優先度ルールを明記
- スキルとエージェントの責務分担ガイドラインを追加
- 既存エージェントへの適用例を4つ提示

## 変更内容

### docs/skill-preload-spec.md
- **エージェントフロントマターでの `skills:` 記述パターン**: 4つのパターン（単一スキル、複数スキル、専門+共通、スキルなし）を追加
- **複数スキル参照時の順序・優先度**: 汎用→特化、依存関係順、参照頻度順の原則を定義
- **スキルとエージェントの責務分担ガイドライン**: 知識（スキル）vs 実行（エージェント）の責務分担を明確化
- **既存エージェントへの適用例**: feature-implementer, test-writer, quality-checker, テストエージェント群への適用例を追加

### docs/project/project-18/project.md
- タスク 0.4 のステータスを Done に更新
- フェーズ 0 全体のステータスを Done に更新

## テストプラン
- [ ] make check-all が成功することを確認

Fixes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)