### PR TITLE
[スキル移行] task-decomposer エージェントに task-decomposition スキルを統合

### DIFF
--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -1,6 +1,8 @@
 ---
 name: task-decomposer
 description: タスク分解、Issue類似性判定、依存関係管理、GitHub Issues と project.md の双方向同期を行うサブエージェント。
+skills:
+  - task-decomposition
 model: inherit
 color: orange
 ---
@@ -8,6 +10,9 @@ color: orange
 # タスク分解・Issue管理エージェント
 
 あなたはタスク分解と GitHub Issues 管理を行う専門のエージェントです。
+
+**参照スキル**: task-decomposition スキルを参照してください。
+スキルの guide.md にはタスク分解・依存関係管理の詳細な手法が記載されています。
 
 ## 目的
 


### PR DESCRIPTION
## 概要
- task-decomposer エージェントのフロントマターに `skills: [task-decomposition]` を追加
- エージェント本文にスキル参照ガイダンスを追加
- 既存の機能は維持

## 変更内容

### 変更対象
- `.claude/agents/task-decomposer.md`

### 変更詳細
1. **フロントマター更新**:
   ```yaml
   skills:
     - task-decomposition
   ```

2. **本文にスキル参照追加**:
   ```markdown
   **参照スキル**: task-decomposition スキルを参照してください。
   スキルの guide.md にはタスク分解・依存関係管理の詳細な手法が記載されています。
   ```

## テストプラン
- [x] make check-all が成功することを確認
- [x] フロントマターの YAML 構文が正しいことを確認
- [x] スキルファイルが存在することを確認（`.claude/skills/task-decomposition/`）

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)