### PR TITLE
[フェーズ2] error-handling スキルの作成

### DIFF
--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -3,6 +3,8 @@ name: code-simplifier
 description: コードの複雑性を削減し、可読性・保守性を向上させる専門エージェント。最近変更されたコードを対象に整理・リファクタリングする。
 model: inherit
 color: green
+skills:
+  - error-handling
 ---
 
 # コード簡素化エージェント

--- a/.claude/agents/feature-implementer.md
+++ b/.claude/agents/feature-implementer.md
@@ -3,6 +3,8 @@ name: feature-implementer
 description: TDDループを自動実行するサブエージェント。GitHub Issue のチェックボックスを更新しながら Red→Green→Refactor サイクルを繰り返す。
 model: inherit
 color: cyan
+skills:
+  - error-handling
 ---
 
 # 機能実装エージェント

--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: error-handling
+description: |
+  Python エラーハンドリングパターンのナレッジベースを提供するスキル。
+  シンプル/リッチパターンの選択ガイド、リトライ戦略、ロギング統合を提供。
+  エラー設計時、例外クラス作成時、エラーハンドリング実装時にプロアクティブに使用。
+allowed-tools: Read
+---
+
+# Error Handling
+
+Python エラーハンドリングパターンのナレッジベースを提供するスキルです。
+
+## 目的
+
+このスキルは以下を提供します：
+
+- **パターン選択ガイド**: シンプル/リッチパターンの使い分け
+- **例外階層設計**: ドメイン固有の例外クラス設計
+- **リトライ戦略**: 指数バックオフ、フォールバック
+- **ロギング統合**: structlog との連携パターン
+
+## いつ使用するか
+
+### プロアクティブ使用（自動で検討）
+
+以下の状況では、ユーザーが明示的に要求しなくても使用を検討：
+
+1. **新しいパッケージ・モジュールの作成**
+   - `exceptions.py` または `errors.py` の作成時
+   - 例外クラスの設計時
+
+2. **エラーハンドリングの実装**
+   - try/except ブロックの実装時
+   - エラーメッセージの設計時
+   - リトライロジックの実装時
+
+3. **外部 API 連携**
+   - HTTP クライアントの実装時
+   - レート制限への対応時
+   - タイムアウト処理の実装時
+
+### 明示的な使用（ユーザー要求）
+
+- 「エラーハンドリングのパターンを教えて」
+- 「例外クラスを設計したい」
+- 「リトライ処理を実装したい」
+
+## パターン選択ガイド
+
+### 判断基準
+
+| 条件 | 推奨パターン |
+|------|-------------|
+| 内部ライブラリ、シンプルな例外 | シンプルパターン |
+| 外部 API 連携、詳細情報必要 | リッチパターン |
+| エラーのシリアライズ必要 | リッチパターン |
+| CLI ツール | シンプルパターン |
+| REST API サーバー | リッチパターン |
+
+### シンプルパターン（RSS 方式）
+
+**特徴**:
+- 継承のみで実装、追加フィールドなし
+- メッセージは `raise` 時に文字列で渡す
+- Docstring で Parameters を明示（IDE ヒント用）
+
+**使用例**:
+```python
+# 例外定義
+class RSSError(Exception):
+    """RSS パッケージの基底例外"""
+    pass
+
+class FeedNotFoundError(RSSError):
+    """フィードが見つからない場合の例外"""
+    pass
+
+# 使用
+raise FeedNotFoundError(f"Feed '{feed_id}' not found")
+```
+
+**適用場面**:
+- 内部ライブラリ
+- エラー情報のシリアライズが不要
+- シンプルなエラー処理で十分
+
+### リッチパターン（Market Analysis 方式）
+
+**特徴**:
+- エラーコード（Enum）による分類
+- 詳細情報を保持する `details` フィールド
+- `cause` による例外チェーン
+- `to_dict()` でシリアライズ可能
+
+**使用例**:
+```python
+# 例外定義
+class MarketAnalysisError(Exception):
+    def __init__(
+        self,
+        message: str,
+        code: ErrorCode = ErrorCode.UNKNOWN,
+        details: dict[str, Any] | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.details = details or {}
+        self.cause = cause
+
+# 使用
+raise DataFetchError(
+    "Failed to fetch data",
+    symbol="AAPL",
+    source="yfinance",
+    code=ErrorCode.API_ERROR,
+    cause=original_exception,
+)
+```
+
+**適用場面**:
+- 外部 API との連携
+- エラーの分類・集計が必要
+- REST API でエラーレスポンスを返す
+- 詳細なデバッグ情報が必要
+
+## 例外階層の基本構造
+
+```
+PackageError (基底例外)
+├── ValidationError (入力検証エラー)
+├── DataError (データ関連エラー)
+│   ├── NotFoundError (データが見つからない)
+│   └── FetchError (データ取得失敗)
+├── NetworkError (ネットワークエラー)
+│   ├── TimeoutError (タイムアウト)
+│   └── RateLimitError (レート制限)
+└── ConfigurationError (設定エラー)
+```
+
+## リトライ戦略
+
+### 基本パターン
+
+```python
+import time
+from typing import TypeVar, Callable
+
+T = TypeVar("T")
+
+def retry_with_backoff(
+    func: Callable[[], T],
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> T:
+    """指数バックオフでリトライ"""
+    for attempt in range(max_retries):
+        try:
+            return func()
+        except exceptions as e:
+            if attempt == max_retries - 1:
+                raise
+            delay = min(base_delay * (2 ** attempt), max_delay)
+            logger.warning(
+                "Retry attempt",
+                attempt=attempt + 1,
+                delay=delay,
+                error=str(e),
+            )
+            time.sleep(delay)
+    raise RuntimeError("Unreachable")
+```
+
+### フォールバックパターン
+
+```python
+def fetch_with_fallback(symbol: str) -> DataFrame:
+    """プライマリ失敗時にフォールバック"""
+    try:
+        return primary_source.fetch(symbol)
+    except DataFetchError as e:
+        logger.warning("Primary failed, trying fallback", error=str(e))
+        return fallback_source.fetch(symbol)
+```
+
+## リソース
+
+このスキルには以下のリソースが含まれています：
+
+### ./guide.md
+
+エラーハンドリングの詳細設計原則：
+
+- 例外階層の設計パターン
+- エラーメッセージのベストプラクティス
+- エラーコードの設計
+- コンテキスト情報の収集
+
+### ./examples/simple-pattern.md
+
+シンプルパターンの完全実装例：
+
+- RSS パッケージの exceptions.py
+- 使用例とテスト例
+
+### ./examples/rich-pattern.md
+
+リッチパターンの完全実装例：
+
+- Market Analysis パッケージの errors.py
+- ErrorCode Enum の設計
+- to_dict() によるシリアライズ
+
+### ./examples/retry-patterns.md
+
+リトライ・フォールバックパターン：
+
+- 指数バックオフ実装
+- サーキットブレーカー
+- フォールバック戦略
+
+### ./examples/logging-integration.md
+
+ロギング統合パターン：
+
+- structlog との連携
+- エラーコンテキストの収集
+- トレーサビリティ確保
+
+## 使用例
+
+### 例1: 新規パッケージの例外設計
+
+**状況**: 新しいパッケージに例外クラスを作成したい
+
+**処理**:
+1. パターン選択ガイドを確認
+2. パッケージの用途に基づきパターンを選択
+3. 例外階層を設計
+4. exceptions.py / errors.py を実装
+
+**期待される出力**:
+```python
+# src/my_package/exceptions.py
+class MyPackageError(Exception):
+    """Base exception for my_package"""
+    pass
+
+class ValidationError(MyPackageError):
+    """Input validation error"""
+    pass
+
+class DataNotFoundError(MyPackageError):
+    """Requested data not found"""
+    pass
+```
+
+---
+
+### 例2: リトライ処理の実装
+
+**状況**: 外部 API 呼び出しにリトライ処理を追加したい
+
+**処理**:
+1. retry-patterns.md を参照
+2. 指数バックオフパターンを選択
+3. 適切なリトライ回数・遅延を設定
+4. ロギングを統合
+
+**期待される出力**:
+```python
+result = retry_with_backoff(
+    lambda: api_client.fetch(symbol),
+    max_retries=3,
+    base_delay=1.0,
+    exceptions=(NetworkError, RateLimitError),
+)
+```
+
+---
+
+### 例3: エラーハンドリングのレビュー
+
+**状況**: 既存のエラーハンドリングを改善したい
+
+**処理**:
+1. 現在の実装を分析
+2. パターン選択ガイドで適切なパターンを確認
+3. 改善点を特定
+4. リファクタリングを提案
+
+**期待される出力**:
+```markdown
+## 現状分析
+- 生の Exception を catch している
+- エラーメッセージが不明瞭
+- リトライ処理がない
+
+## 改善提案
+1. ドメイン固有の例外クラスを作成
+2. エラーメッセージにコンテキストを追加
+3. リトライ処理を実装
+```
+
+## 品質基準
+
+### 必須（MUST）
+
+- [ ] 例外クラスには適切な Docstring がある
+- [ ] エラーメッセージにはコンテキスト情報が含まれる
+- [ ] 基底例外クラスが定義されている
+- [ ] except Exception: は使用しない（具体的な例外を catch）
+
+### 推奨（SHOULD）
+
+- リトライ対象の例外は明示的に指定する
+- エラー発生時はログを出力する
+- from e を使用して例外チェーンを保持する
+- エラーコードを使用して分類する（リッチパターンの場合）
+
+## 参照実装
+
+| パッケージ | ファイル | パターン |
+|-----------|----------|----------|
+| rss | `src/rss/exceptions.py` | シンプル |
+| market_analysis | `src/market_analysis/errors.py` | リッチ |
+
+## 関連スキル
+
+- **development-guidelines**: 開発ガイドライン（エラーハンドリングセクション）
+
+## 参考資料
+
+- `CLAUDE.md`: プロジェクト全体のガイドライン
+- `.claude/rules/common-instructions.md`: ロギング・エラーハンドリングの共通指示

--- a/.claude/skills/error-handling/examples/logging-integration.md
+++ b/.claude/skills/error-handling/examples/logging-integration.md
@@ -1,0 +1,365 @@
+# ロギング統合パターン
+
+structlog と例外処理を統合するパターンです。
+
+## 基本原則
+
+1. **すべてのエラーはログに記録する**
+2. **構造化されたコンテキストを含める**
+3. **ログレベルを適切に使い分ける**
+4. **トレーサビリティを確保する**
+
+## ログレベルの使い分け
+
+| レベル | 用途 | 例 |
+|-------|------|-----|
+| DEBUG | 詳細なデバッグ情報 | 処理開始、中間状態 |
+| INFO | 正常な処理の記録 | 処理完了、成功 |
+| WARNING | 問題だが継続可能 | リトライ成功、フォールバック使用 |
+| ERROR | エラー発生 | 処理失敗、例外発生 |
+| CRITICAL | 致命的エラー | システム停止、データ損失 |
+
+## structlog の基本設定
+
+```python
+from finance.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+```
+
+## エラーハンドリングとロギングの統合
+
+### 基本パターン
+
+```python
+def process_data(data: list[dict]) -> list[dict]:
+    """データを処理する
+
+    Parameters
+    ----------
+    data : list[dict]
+        処理対象のデータ
+
+    Returns
+    -------
+    list[dict]
+        処理結果
+    """
+    logger.debug("Processing started", item_count=len(data))
+
+    try:
+        result = transform(data)
+        logger.info(
+            "Processing completed",
+            input_count=len(data),
+            output_count=len(result),
+        )
+        return result
+    except ValidationError as e:
+        logger.warning(
+            "Validation failed",
+            error=str(e),
+            field=e.field,
+            value=e.value,
+        )
+        raise
+    except DataError as e:
+        logger.error(
+            "Data processing failed",
+            error=str(e),
+            error_code=e.code.value if hasattr(e, "code") else None,
+            exc_info=True,  # スタックトレースを含める
+        )
+        raise
+```
+
+### 例外属性のログ出力
+
+```python
+def fetch_stock_data(symbol: str) -> DataFrame:
+    """株価データを取得する"""
+    logger.debug("Fetching stock data", symbol=symbol)
+
+    try:
+        data = api_client.fetch(symbol)
+        logger.info(
+            "Stock data fetched",
+            symbol=symbol,
+            rows=len(data),
+        )
+        return data
+    except DataFetchError as e:
+        # 例外の属性をログに含める
+        logger.error(
+            "Stock data fetch failed",
+            symbol=symbol,
+            source=e.source,
+            error_code=e.code.value,
+            details=e.details,
+            exc_info=True,
+        )
+        raise
+    except RateLimitError as e:
+        logger.warning(
+            "Rate limit exceeded",
+            symbol=symbol,
+            retry_after=e.retry_after,
+            source=e.source,
+        )
+        raise
+```
+
+## コンテキスト情報の収集
+
+### bind でコンテキストを追加
+
+```python
+def process_order(order_id: str, user_id: str) -> Order:
+    """注文を処理する"""
+    # コンテキストをバインド
+    log = logger.bind(
+        order_id=order_id,
+        user_id=user_id,
+    )
+
+    log.info("Processing order started")
+
+    try:
+        order = validate_order(order_id)
+        log.debug("Order validated", status=order.status)
+
+        result = execute_order(order)
+        log.info("Order processed", result=result.status)
+
+        return result
+    except ValidationError as e:
+        log.warning("Order validation failed", error=str(e))
+        raise
+    except OrderError as e:
+        log.error(
+            "Order processing failed",
+            error=str(e),
+            exc_info=True,
+        )
+        raise
+```
+
+### リクエスト ID によるトレース
+
+```python
+import uuid
+
+
+def with_request_id(func):
+    """リクエスト ID を付与するデコレータ"""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        request_id = str(uuid.uuid4())
+        log = logger.bind(request_id=request_id)
+
+        log.info("Request started")
+        try:
+            result = func(*args, **kwargs)
+            log.info("Request completed")
+            return result
+        except Exception as e:
+            log.error(
+                "Request failed",
+                error=str(e),
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
+            raise
+
+    return wrapper
+
+
+@with_request_id
+def handle_api_request(data: dict) -> Response:
+    """API リクエストを処理"""
+    # request_id は自動的にログに含まれる
+    logger.debug("Processing request", data_keys=list(data.keys()))
+    # ...
+```
+
+## エラーレポート用のログ
+
+### 構造化されたエラーログ
+
+```python
+def log_error_report(
+    error: Exception,
+    context: dict[str, Any] | None = None,
+) -> None:
+    """エラーレポートをログに出力
+
+    Parameters
+    ----------
+    error : Exception
+        発生した例外
+    context : dict[str, Any] | None
+        追加のコンテキスト情報
+    """
+    error_data = {
+        "error_type": type(error).__name__,
+        "error_message": str(error),
+    }
+
+    # リッチパターンの例外の場合
+    if hasattr(error, "code"):
+        error_data["error_code"] = error.code.value
+    if hasattr(error, "details"):
+        error_data["error_details"] = error.details
+    if hasattr(error, "cause") and error.cause:
+        error_data["cause_type"] = type(error.cause).__name__
+        error_data["cause_message"] = str(error.cause)
+
+    # コンテキストをマージ
+    if context:
+        error_data.update(context)
+
+    logger.error(
+        "Error occurred",
+        **error_data,
+        exc_info=True,
+    )
+```
+
+### 使用例
+
+```python
+try:
+    result = process_complex_operation(data)
+except PackageError as e:
+    log_error_report(
+        e,
+        context={
+            "operation": "process_complex_operation",
+            "data_size": len(data),
+            "user_id": current_user.id,
+        },
+    )
+    raise
+```
+
+## 非同期処理でのロギング
+
+```python
+import asyncio
+
+
+async def fetch_multiple(symbols: list[str]) -> dict[str, DataFrame]:
+    """複数のシンボルを並列取得"""
+    logger.info("Starting parallel fetch", symbol_count=len(symbols))
+
+    results = {}
+    errors = []
+
+    async def fetch_one(symbol: str) -> tuple[str, DataFrame | None]:
+        log = logger.bind(symbol=symbol)
+        try:
+            data = await async_fetch(symbol)
+            log.debug("Fetch succeeded", rows=len(data))
+            return symbol, data
+        except DataFetchError as e:
+            log.warning("Fetch failed", error=str(e))
+            errors.append((symbol, e))
+            return symbol, None
+
+    tasks = [fetch_one(s) for s in symbols]
+    fetched = await asyncio.gather(*tasks)
+
+    for symbol, data in fetched:
+        if data is not None:
+            results[symbol] = data
+
+    logger.info(
+        "Parallel fetch completed",
+        success_count=len(results),
+        error_count=len(errors),
+    )
+
+    if errors:
+        logger.warning(
+            "Some fetches failed",
+            failed_symbols=[s for s, _ in errors],
+        )
+
+    return results
+```
+
+## ログフォーマットの例
+
+### 開発環境（text フォーマット）
+
+```
+2026-01-21 10:30:45.123 | INFO     | fetch_stock_data | Stock data fetched | symbol=AAPL rows=252
+2026-01-21 10:30:45.456 | ERROR    | fetch_stock_data | Stock data fetch failed | symbol=INVALID error_code=DATA_NOT_FOUND
+Traceback (most recent call last):
+  ...
+DataFetchError: [DATA_NOT_FOUND] Symbol 'INVALID' not found
+```
+
+### 本番環境（JSON フォーマット）
+
+```json
+{
+  "timestamp": "2026-01-21T10:30:45.123456Z",
+  "level": "info",
+  "logger": "market_analysis.fetcher",
+  "message": "Stock data fetched",
+  "symbol": "AAPL",
+  "rows": 252,
+  "request_id": "abc123"
+}
+```
+
+## ベストプラクティス
+
+### DO（推奨）
+
+```python
+# 1. 構造化されたコンテキストを含める
+logger.error(
+    "Processing failed",
+    symbol=symbol,
+    error_code=e.code.value,
+    attempt=attempt,
+)
+
+# 2. exc_info=True でスタックトレースを含める
+logger.error("Unexpected error", exc_info=True)
+
+# 3. 適切なログレベルを使用
+logger.warning("Using fallback")  # 問題だが継続可能
+logger.error("Operation failed")  # エラー発生
+
+# 4. 成功時もログを出力
+logger.info("Operation completed", result_count=len(results))
+```
+
+### DON'T（非推奨）
+
+```python
+# 1. print を使用しない
+print(f"Error: {e}")  # 避ける
+
+# 2. 文字列フォーマットを使用しない
+logger.error(f"Error: {error}")  # 避ける
+logger.error("Error", error=error)  # 推奨
+
+# 3. 機密情報をログに含めない
+logger.error("Auth failed", api_key=api_key)  # 絶対に避ける
+
+# 4. 過度なログを避ける
+for item in large_list:
+    logger.debug("Processing item", item=item)  # ループ内は避ける
+```
+
+## 参照実装
+
+このプロジェクトでの参照実装：
+
+- `src/finance/utils/logging_config.py`: ロギング設定
+- `src/market_analysis/core/fetcher.py`: データ取得のログ
+- `.claude/rules/common-instructions.md`: ロギングの共通指示

--- a/.claude/skills/error-handling/examples/retry-patterns.md
+++ b/.claude/skills/error-handling/examples/retry-patterns.md
@@ -1,0 +1,496 @@
+# リトライ・フォールバックパターン
+
+外部 API 呼び出しやネットワーク処理での信頼性を向上させるパターンです。
+
+## パターン一覧
+
+| パターン | 用途 |
+|---------|------|
+| 指数バックオフ | 一時的な障害からの復帰 |
+| 固定遅延リトライ | シンプルなリトライ |
+| フォールバック | 代替手段への切り替え |
+| サーキットブレーカー | 障害の連鎖防止 |
+
+## 指数バックオフ
+
+### 基本実装
+
+```python
+import time
+import random
+from typing import TypeVar, Callable
+from finance.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+def retry_with_backoff(
+    func: Callable[[], T],
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    jitter: bool = True,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> T:
+    """指数バックオフでリトライする
+
+    Parameters
+    ----------
+    func : Callable[[], T]
+        実行する関数
+    max_retries : int
+        最大リトライ回数
+    base_delay : float
+        基本遅延時間（秒）
+    max_delay : float
+        最大遅延時間（秒）
+    jitter : bool
+        ジッターを追加するか（同時リトライの分散用）
+    exceptions : tuple[type[Exception], ...]
+        リトライ対象の例外
+
+    Returns
+    -------
+    T
+        関数の戻り値
+
+    Raises
+    ------
+    Exception
+        最大リトライ回数を超えた場合
+
+    Examples
+    --------
+    >>> result = retry_with_backoff(
+    ...     lambda: api_client.fetch("AAPL"),
+    ...     max_retries=3,
+    ...     exceptions=(NetworkError, RateLimitError),
+    ... )
+    """
+    last_exception: Exception | None = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except exceptions as e:
+            last_exception = e
+
+            if attempt == max_retries:
+                logger.error(
+                    "Max retries exceeded",
+                    attempt=attempt + 1,
+                    max_retries=max_retries,
+                    error=str(e),
+                )
+                raise
+
+            # 指数バックオフ計算
+            delay = min(base_delay * (2 ** attempt), max_delay)
+
+            # ジッター追加（0.5〜1.5倍の範囲）
+            if jitter:
+                delay = delay * (0.5 + random.random())
+
+            logger.warning(
+                "Retry attempt",
+                attempt=attempt + 1,
+                delay=round(delay, 2),
+                error=str(e),
+            )
+            time.sleep(delay)
+
+    # 到達しないはずだが型チェックのため
+    if last_exception:
+        raise last_exception
+    raise RuntimeError("Unexpected state in retry loop")
+```
+
+### デコレータ版
+
+```python
+from functools import wraps
+from typing import ParamSpec
+
+P = ParamSpec("P")
+
+
+def with_retry(
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """リトライデコレータ
+
+    Examples
+    --------
+    >>> @with_retry(max_retries=3, exceptions=(NetworkError,))
+    ... def fetch_data(symbol: str) -> DataFrame:
+    ...     return api_client.fetch(symbol)
+    """
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            return retry_with_backoff(
+                lambda: func(*args, **kwargs),
+                max_retries=max_retries,
+                base_delay=base_delay,
+                exceptions=exceptions,
+            )
+        return wrapper
+    return decorator
+
+
+# 使用例
+@with_retry(max_retries=3, exceptions=(DataFetchError,))
+def fetch_stock_data(symbol: str) -> DataFrame:
+    """リトライ付きデータ取得"""
+    return yfinance_client.download(symbol)
+```
+
+## 固定遅延リトライ
+
+シンプルなケースで使用：
+
+```python
+def retry_with_fixed_delay(
+    func: Callable[[], T],
+    max_retries: int = 3,
+    delay: float = 1.0,
+    exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> T:
+    """固定遅延でリトライする
+
+    Parameters
+    ----------
+    func : Callable[[], T]
+        実行する関数
+    max_retries : int
+        最大リトライ回数
+    delay : float
+        リトライ間隔（秒）
+    exceptions : tuple[type[Exception], ...]
+        リトライ対象の例外
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except exceptions as e:
+            if attempt == max_retries:
+                raise
+            logger.warning(
+                "Retry with fixed delay",
+                attempt=attempt + 1,
+                delay=delay,
+            )
+            time.sleep(delay)
+
+    raise RuntimeError("Unreachable")
+```
+
+## フォールバック
+
+### 基本パターン
+
+```python
+def fetch_with_fallback(
+    symbol: str,
+    primary: DataSource,
+    fallback: DataSource,
+) -> DataFrame:
+    """プライマリ失敗時にフォールバックを使用
+
+    Parameters
+    ----------
+    symbol : str
+        取得するシンボル
+    primary : DataSource
+        プライマリデータソース
+    fallback : DataSource
+        フォールバックデータソース
+
+    Returns
+    -------
+    DataFrame
+        取得したデータ
+    """
+    try:
+        logger.debug("Fetching from primary", source=primary.name)
+        return primary.fetch(symbol)
+    except DataFetchError as e:
+        logger.warning(
+            "Primary failed, trying fallback",
+            primary=primary.name,
+            fallback=fallback.name,
+            error=str(e),
+        )
+        return fallback.fetch(symbol)
+```
+
+### 複数フォールバック
+
+```python
+def fetch_with_multiple_fallbacks(
+    symbol: str,
+    sources: list[DataSource],
+) -> DataFrame:
+    """複数のソースを順番に試行
+
+    Parameters
+    ----------
+    symbol : str
+        取得するシンボル
+    sources : list[DataSource]
+        データソースのリスト（優先順）
+
+    Returns
+    -------
+    DataFrame
+        取得したデータ
+
+    Raises
+    ------
+    DataFetchError
+        すべてのソースが失敗した場合
+    """
+    errors: list[Exception] = []
+
+    for source in sources:
+        try:
+            logger.debug("Trying source", source=source.name)
+            return source.fetch(symbol)
+        except DataFetchError as e:
+            logger.warning(
+                "Source failed",
+                source=source.name,
+                error=str(e),
+            )
+            errors.append(e)
+
+    raise DataFetchError(
+        f"All {len(sources)} sources failed for {symbol}",
+        symbol=symbol,
+        details={"errors": [str(e) for e in errors]},
+    )
+```
+
+## サーキットブレーカー
+
+連続した障害を検出し、一時的にリクエストを遮断：
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"      # 正常
+    OPEN = "open"          # 遮断中
+    HALF_OPEN = "half_open"  # 試行中
+
+
+@dataclass
+class CircuitBreaker:
+    """サーキットブレーカー
+
+    Parameters
+    ----------
+    failure_threshold : int
+        オープンにする失敗回数
+    recovery_timeout : float
+        回復までの秒数
+    half_open_max_calls : int
+        ハーフオープン時の最大試行回数
+    """
+
+    failure_threshold: int = 5
+    recovery_timeout: float = 60.0
+    half_open_max_calls: int = 1
+
+    state: CircuitState = field(default=CircuitState.CLOSED)
+    failure_count: int = field(default=0)
+    last_failure_time: datetime | None = field(default=None)
+    half_open_calls: int = field(default=0)
+
+    def call(self, func: Callable[[], T]) -> T:
+        """サーキットブレーカー経由で関数を呼び出す"""
+        if not self._can_execute():
+            raise CircuitOpenError(
+                "Circuit is open",
+                recovery_in=self._time_until_recovery(),
+            )
+
+        try:
+            result = func()
+            self._on_success()
+            return result
+        except Exception as e:
+            self._on_failure()
+            raise
+
+    def _can_execute(self) -> bool:
+        """実行可能かどうかを判定"""
+        if self.state == CircuitState.CLOSED:
+            return True
+
+        if self.state == CircuitState.OPEN:
+            if self._should_try_recovery():
+                self.state = CircuitState.HALF_OPEN
+                self.half_open_calls = 0
+                return True
+            return False
+
+        # HALF_OPEN
+        return self.half_open_calls < self.half_open_max_calls
+
+    def _should_try_recovery(self) -> bool:
+        """回復を試みるべきかどうか"""
+        if self.last_failure_time is None:
+            return True
+        elapsed = datetime.now() - self.last_failure_time
+        return elapsed > timedelta(seconds=self.recovery_timeout)
+
+    def _time_until_recovery(self) -> float:
+        """回復までの残り時間"""
+        if self.last_failure_time is None:
+            return 0.0
+        elapsed = datetime.now() - self.last_failure_time
+        remaining = self.recovery_timeout - elapsed.total_seconds()
+        return max(0.0, remaining)
+
+    def _on_success(self) -> None:
+        """成功時の処理"""
+        self.failure_count = 0
+        self.state = CircuitState.CLOSED
+        logger.info("Circuit closed", state=self.state.value)
+
+    def _on_failure(self) -> None:
+        """失敗時の処理"""
+        self.failure_count += 1
+        self.last_failure_time = datetime.now()
+
+        if self.state == CircuitState.HALF_OPEN:
+            self.state = CircuitState.OPEN
+            logger.warning(
+                "Circuit re-opened",
+                failure_count=self.failure_count,
+            )
+        elif self.failure_count >= self.failure_threshold:
+            self.state = CircuitState.OPEN
+            logger.warning(
+                "Circuit opened",
+                failure_count=self.failure_count,
+                threshold=self.failure_threshold,
+            )
+
+
+class CircuitOpenError(Exception):
+    """サーキットがオープン状態の場合の例外"""
+
+    def __init__(self, message: str, recovery_in: float) -> None:
+        super().__init__(message)
+        self.recovery_in = recovery_in
+```
+
+### サーキットブレーカーの使用例
+
+```python
+# グローバルなサーキットブレーカー
+yfinance_circuit = CircuitBreaker(
+    failure_threshold=5,
+    recovery_timeout=60.0,
+)
+
+
+def fetch_stock_data(symbol: str) -> DataFrame:
+    """サーキットブレーカー付きデータ取得"""
+    try:
+        return yfinance_circuit.call(
+            lambda: yfinance_client.download(symbol)
+        )
+    except CircuitOpenError as e:
+        logger.warning(
+            "Circuit is open, using cache",
+            recovery_in=e.recovery_in,
+        )
+        return cache.get(symbol)
+```
+
+## ベストプラクティス
+
+### リトライ対象の例外を明示
+
+```python
+# 良い例：具体的な例外を指定
+RETRYABLE_EXCEPTIONS = (
+    ConnectionError,
+    TimeoutError,
+    RateLimitError,
+)
+
+retry_with_backoff(
+    func,
+    exceptions=RETRYABLE_EXCEPTIONS,
+)
+
+# 悪い例：すべての例外をリトライ
+retry_with_backoff(
+    func,
+    exceptions=(Exception,),  # 避ける
+)
+```
+
+### リトライしてはいけない例外
+
+以下の例外はリトライしても解決しない：
+
+- `ValidationError`: 入力が不正
+- `AuthenticationError`: 認証情報が無効
+- `NotFoundError`: リソースが存在しない
+- `PermissionDeniedError`: 権限がない
+
+```python
+# リトライ不可の例外を除外
+def is_retryable(e: Exception) -> bool:
+    """リトライ可能な例外かどうか判定"""
+    non_retryable = (
+        ValidationError,
+        AuthenticationError,
+        NotFoundError,
+        PermissionDeniedError,
+    )
+    return not isinstance(e, non_retryable)
+```
+
+### ログの重要性
+
+```python
+def retry_with_logging(func: Callable[[], T]) -> T:
+    """ログ付きリトライ"""
+    for attempt in range(max_retries + 1):
+        try:
+            result = func()
+            if attempt > 0:
+                logger.info(
+                    "Retry succeeded",
+                    attempt=attempt + 1,
+                )
+            return result
+        except Exception as e:
+            logger.warning(
+                "Attempt failed",
+                attempt=attempt + 1,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            # ...
+```
+
+## 参照実装
+
+このプロジェクトでの参照実装：
+
+- `src/market_analysis/utils/retry.py`: リトライユーティリティ
+- `src/rss/core/http_client.py`: HTTP クライアントのリトライ

--- a/.claude/skills/error-handling/examples/rich-pattern.md
+++ b/.claude/skills/error-handling/examples/rich-pattern.md
@@ -1,0 +1,443 @@
+# リッチパターン（Market Analysis 方式）
+
+外部 API 連携や詳細なエラー情報が必要な場合のパターンです。
+
+## 特徴
+
+- **エラーコード（Enum）による分類**: プログラム的な判定が可能
+- **details フィールド**: 構造化されたコンテキスト情報
+- **cause による例外チェーン**: 元の例外を保持
+- **to_dict() でシリアライズ**: JSON レスポンスに変換可能
+
+## いつ使うか
+
+- 外部 API との連携
+- REST API でエラーレスポンスを返す
+- エラーの統計・分析が必要
+- 詳細なデバッグ情報が必要
+
+## 実装例
+
+### errors.py
+
+```python
+"""Custom exception classes for the package.
+
+This module provides a hierarchy of exception classes for handling
+various error conditions with structured error information.
+"""
+
+from enum import Enum
+from typing import Any
+
+
+class ErrorCode(str, Enum):
+    """Error codes for categorizing exceptions.
+
+    str を継承することで JSON シリアライズが容易になります。
+    """
+
+    # 汎用
+    UNKNOWN = "UNKNOWN"
+
+    # ネットワーク関連
+    NETWORK_ERROR = "NETWORK_ERROR"
+    TIMEOUT = "TIMEOUT"
+    CONNECTION_ERROR = "CONNECTION_ERROR"
+
+    # API 関連
+    API_ERROR = "API_ERROR"
+    RATE_LIMIT = "RATE_LIMIT"
+    AUTH_FAILED = "AUTH_FAILED"
+
+    # データ関連
+    DATA_NOT_FOUND = "DATA_NOT_FOUND"
+    DATA_INVALID = "DATA_INVALID"
+
+    # バリデーション関連
+    INVALID_PARAMETER = "INVALID_PARAMETER"
+    INVALID_FORMAT = "INVALID_FORMAT"
+
+
+class PackageError(Exception):
+    """Base exception for all package errors.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message
+    code : ErrorCode
+        Error code for programmatic handling
+    details : dict[str, Any] | None
+        Additional context about the error
+    cause : Exception | None
+        The underlying exception that caused this error
+
+    Examples
+    --------
+    >>> try:
+    ...     raise PackageError(
+    ...         "Failed to process data",
+    ...         code=ErrorCode.DATA_INVALID,
+    ...         details={"field": "date"},
+    ...     )
+    ... except PackageError as e:
+    ...     print(e.code)
+    DATA_INVALID
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: ErrorCode = ErrorCode.UNKNOWN,
+        details: dict[str, Any] | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.details = details or {}
+        self.cause = cause
+
+    def __str__(self) -> str:
+        """Return a formatted error message."""
+        parts = [f"[{self.code.value}] {self.message}"]
+
+        if self.details:
+            details_str = ", ".join(
+                f"{k}={v!r}" for k, v in self.details.items()
+            )
+            parts.append(f"Details: {details_str}")
+
+        if self.cause:
+            parts.append(
+                f"Caused by: {type(self.cause).__name__}: {self.cause}"
+            )
+
+        return " | ".join(parts)
+
+    def __repr__(self) -> str:
+        """Return a developer-friendly representation."""
+        return (
+            f"{self.__class__.__name__}("
+            f"message={self.message!r}, "
+            f"code={self.code!r}, "
+            f"details={self.details!r})"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert exception to dictionary for serialization.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary representation of the error
+        """
+        result: dict[str, Any] = {
+            "error_type": self.__class__.__name__,
+            "code": self.code.value,
+            "message": self.message,
+            "details": self.details,
+        }
+
+        if self.cause:
+            result["cause"] = {
+                "type": type(self.cause).__name__,
+                "message": str(self.cause),
+            }
+
+        return result
+
+
+class DataFetchError(PackageError):
+    """Exception raised when data fetching fails.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message
+    symbol : str | None
+        The symbol that failed to fetch
+    source : str | None
+        The data source that was used
+    code : ErrorCode
+        Error code (defaults to API_ERROR)
+    details : dict[str, Any] | None
+        Additional context
+    cause : Exception | None
+        The underlying exception
+    """
+
+    def __init__(
+        self,
+        message: str,
+        symbol: str | None = None,
+        source: str | None = None,
+        code: ErrorCode = ErrorCode.API_ERROR,
+        details: dict[str, Any] | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        details = details or {}
+        if symbol:
+            details["symbol"] = symbol
+        if source:
+            details["source"] = source
+
+        super().__init__(message, code=code, details=details, cause=cause)
+        self.symbol = symbol
+        self.source = source
+
+
+class ValidationError(PackageError):
+    """Exception raised when input validation fails.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message
+    field : str | None
+        The field that failed validation
+    value : Any
+        The invalid value
+    code : ErrorCode
+        Error code (defaults to INVALID_PARAMETER)
+    details : dict[str, Any] | None
+        Additional context
+    cause : Exception | None
+        The underlying exception
+    """
+
+    def __init__(
+        self,
+        message: str,
+        field: str | None = None,
+        value: Any = None,
+        code: ErrorCode = ErrorCode.INVALID_PARAMETER,
+        details: dict[str, Any] | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        details = details or {}
+        if field:
+            details["field"] = field
+        if value is not None:
+            details["value"] = repr(value)
+
+        super().__init__(message, code=code, details=details, cause=cause)
+        self.field = field
+        self.value = value
+
+
+class RateLimitError(DataFetchError):
+    """Exception raised when API rate limit is exceeded.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message
+    retry_after : int | None
+        Seconds to wait before retrying
+    source : str | None
+        The data source
+    """
+
+    def __init__(
+        self,
+        message: str,
+        retry_after: int | None = None,
+        source: str | None = None,
+        details: dict[str, Any] | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        details = details or {}
+        if retry_after:
+            details["retry_after_seconds"] = retry_after
+
+        super().__init__(
+            message,
+            symbol=None,
+            source=source,
+            code=ErrorCode.RATE_LIMIT,
+            details=details,
+            cause=cause,
+        )
+        self.retry_after = retry_after
+
+
+__all__ = [
+    "ErrorCode",
+    "PackageError",
+    "DataFetchError",
+    "ValidationError",
+    "RateLimitError",
+]
+```
+
+### 使用例
+
+```python
+from my_package.errors import (
+    DataFetchError,
+    ValidationError,
+    RateLimitError,
+    ErrorCode,
+)
+
+
+def fetch_stock_data(symbol: str) -> DataFrame:
+    """株価データを取得する
+
+    Raises
+    ------
+    ValidationError
+        symbol が不正な場合
+    DataFetchError
+        データ取得に失敗した場合
+    RateLimitError
+        レート制限に達した場合
+    """
+    if not symbol or not symbol.isalpha():
+        raise ValidationError(
+            f"Invalid symbol format: {symbol}",
+            field="symbol",
+            value=symbol,
+            code=ErrorCode.INVALID_FORMAT,
+        )
+
+    try:
+        return api_client.fetch(symbol)
+    except RateLimitExceeded as e:
+        raise RateLimitError(
+            f"Rate limit exceeded for {symbol}",
+            retry_after=e.retry_after,
+            source="yfinance",
+            cause=e,
+        ) from e
+    except APIError as e:
+        raise DataFetchError(
+            f"Failed to fetch data for {symbol}",
+            symbol=symbol,
+            source="yfinance",
+            code=ErrorCode.API_ERROR,
+            cause=e,
+        ) from e
+```
+
+### REST API でのエラーレスポンス
+
+```python
+from fastapi import FastAPI, HTTPException
+from my_package.errors import PackageError
+
+app = FastAPI()
+
+
+@app.exception_handler(PackageError)
+async def package_error_handler(request, exc: PackageError):
+    """パッケージ例外を JSON レスポンスに変換"""
+    return JSONResponse(
+        status_code=get_status_code(exc.code),
+        content=exc.to_dict(),
+    )
+
+
+def get_status_code(code: ErrorCode) -> int:
+    """ErrorCode から HTTP ステータスコードを決定"""
+    mapping = {
+        ErrorCode.INVALID_PARAMETER: 400,
+        ErrorCode.INVALID_FORMAT: 400,
+        ErrorCode.AUTH_FAILED: 401,
+        ErrorCode.DATA_NOT_FOUND: 404,
+        ErrorCode.RATE_LIMIT: 429,
+        ErrorCode.API_ERROR: 502,
+        ErrorCode.TIMEOUT: 504,
+    }
+    return mapping.get(code, 500)
+```
+
+### エラーレスポンス例
+
+```json
+{
+    "error_type": "DataFetchError",
+    "code": "API_ERROR",
+    "message": "Failed to fetch data for AAPL",
+    "details": {
+        "symbol": "AAPL",
+        "source": "yfinance"
+    },
+    "cause": {
+        "type": "ConnectionError",
+        "message": "Connection refused"
+    }
+}
+```
+
+## テスト例
+
+```python
+import pytest
+from my_package.errors import (
+    DataFetchError,
+    ValidationError,
+    ErrorCode,
+)
+
+
+class TestDataFetchError:
+    def test_正常系_エラーコードが設定される(self):
+        error = DataFetchError(
+            "Failed to fetch",
+            symbol="AAPL",
+            source="yfinance",
+            code=ErrorCode.NETWORK_ERROR,
+        )
+
+        assert error.code == ErrorCode.NETWORK_ERROR
+        assert error.symbol == "AAPL"
+        assert error.source == "yfinance"
+
+    def test_正常系_to_dictでシリアライズできる(self):
+        error = DataFetchError(
+            "Failed to fetch",
+            symbol="AAPL",
+        )
+
+        result = error.to_dict()
+
+        assert result["error_type"] == "DataFetchError"
+        assert result["code"] == "API_ERROR"
+        assert result["details"]["symbol"] == "AAPL"
+
+    def test_正常系_causeが保持される(self):
+        original = ValueError("Original error")
+        error = DataFetchError(
+            "Wrapped error",
+            cause=original,
+        )
+
+        assert error.cause is original
+        assert "ValueError" in error.to_dict()["cause"]["type"]
+```
+
+## 参照実装
+
+このプロジェクトでの参照実装：
+
+- `src/market_analysis/errors.py`: Market Analysis パッケージの例外定義
+
+## リッチパターンの利点
+
+1. **プログラム的な分類**: ErrorCode で条件分岐が可能
+2. **構造化された情報**: details で任意のコンテキストを保持
+3. **シリアライズ対応**: to_dict() で JSON 変換が容易
+4. **例外チェーン**: cause で元の例外を保持
+5. **統一された出力**: __str__ で一貫したフォーマット
+
+## いつシンプルパターンに戻すべきか
+
+以下の条件が当てはまる場合は、シンプルパターンで十分：
+
+- [ ] エラーのシリアライズが不要
+- [ ] エラーコードによる分類が不要
+- [ ] 詳細なコンテキスト情報が不要
+- [ ] 内部ライブラリとしてのみ使用

--- a/.claude/skills/error-handling/examples/simple-pattern.md
+++ b/.claude/skills/error-handling/examples/simple-pattern.md
@@ -1,0 +1,259 @@
+# シンプルパターン（RSS 方式）
+
+内部ライブラリ向けのシンプルなエラーハンドリングパターンです。
+
+## 特徴
+
+- **継承のみで実装**: 追加フィールドなし
+- **メッセージは raise 時に渡す**: Docstring で Parameters を明示
+- **軽量**: コンテキスト最小限
+
+## いつ使うか
+
+- 内部ライブラリ
+- エラー情報のシリアライズが不要
+- シンプルなエラー処理で十分
+- CLI ツール
+
+## 実装例
+
+### exceptions.py
+
+```python
+"""Custom exceptions for the package."""
+
+
+class PackageError(Exception):
+    """Base exception for all package errors.
+
+    This is the base class for all custom exceptions raised by this package.
+    All package-specific exceptions should inherit from this class.
+
+    Examples
+    --------
+    >>> try:
+    ...     raise PackageError("An error occurred")
+    ... except PackageError as e:
+    ...     print(f"Caught error: {e}")
+    Caught error: An error occurred
+    """
+
+    pass
+
+
+class ValidationError(PackageError):
+    """Exception raised when input validation fails.
+
+    Parameters
+    ----------
+    message : str
+        Description of the validation error
+
+    Examples
+    --------
+    >>> raise ValidationError("Expected positive integer, got -1")
+    Traceback (most recent call last):
+        ...
+    ValidationError: Expected positive integer, got -1
+    """
+
+    pass
+
+
+class NotFoundError(PackageError):
+    """Exception raised when a resource is not found.
+
+    Parameters
+    ----------
+    resource_type : str
+        The type of resource that was not found
+    resource_id : str
+        The identifier of the resource
+
+    Examples
+    --------
+    >>> raise NotFoundError("User with ID '123' not found")
+    Traceback (most recent call last):
+        ...
+    NotFoundError: User with ID '123' not found
+    """
+
+    pass
+
+
+class FetchError(PackageError):
+    """Exception raised when data fetching fails.
+
+    Parameters
+    ----------
+    source : str
+        The source that failed
+    reason : str
+        The reason for failure
+
+    Examples
+    --------
+    >>> raise FetchError("Failed to fetch from API: Connection timeout")
+    Traceback (most recent call last):
+        ...
+    FetchError: Failed to fetch from API: Connection timeout
+    """
+
+    pass
+
+
+class ConfigurationError(PackageError):
+    """Exception raised when configuration is invalid.
+
+    Parameters
+    ----------
+    config_key : str
+        The configuration key that is invalid
+    reason : str
+        The reason why it's invalid
+
+    Examples
+    --------
+    >>> raise ConfigurationError("Missing required config 'API_KEY'")
+    Traceback (most recent call last):
+        ...
+    ConfigurationError: Missing required config 'API_KEY'
+    """
+
+    pass
+```
+
+### 使用例
+
+```python
+from my_package.exceptions import (
+    NotFoundError,
+    ValidationError,
+    FetchError,
+)
+
+
+def get_user(user_id: str) -> User:
+    """ユーザーを取得する
+
+    Raises
+    ------
+    ValidationError
+        user_id が空の場合
+    NotFoundError
+        ユーザーが存在しない場合
+    """
+    if not user_id:
+        raise ValidationError("user_id cannot be empty")
+
+    user = database.find_user(user_id)
+    if user is None:
+        raise NotFoundError(f"User with ID '{user_id}' not found")
+
+    return user
+
+
+def fetch_data(source: str) -> Data:
+    """外部ソースからデータを取得する
+
+    Raises
+    ------
+    FetchError
+        データ取得に失敗した場合
+    """
+    try:
+        return external_api.get(source)
+    except ConnectionError as e:
+        raise FetchError(
+            f"Failed to fetch from {source}: {e}"
+        ) from e
+```
+
+### エラーハンドリング
+
+```python
+def process_user_request(user_id: str) -> Response:
+    try:
+        user = get_user(user_id)
+        return Response(success=True, data=user)
+
+    except ValidationError as e:
+        logger.warning("Validation failed", error=str(e))
+        return Response(success=False, error="Invalid input")
+
+    except NotFoundError as e:
+        logger.info("User not found", user_id=user_id)
+        return Response(success=False, error="User not found")
+
+    except FetchError as e:
+        logger.error("Fetch failed", error=str(e))
+        return Response(success=False, error="Service unavailable")
+```
+
+## テスト例
+
+```python
+import pytest
+from my_package.exceptions import NotFoundError, ValidationError
+
+
+class TestGetUser:
+    def test_正常系_有効なIDでユーザーを取得できる(self):
+        user = get_user("valid-id")
+        assert user.id == "valid-id"
+
+    def test_異常系_空のIDでValidationError(self):
+        with pytest.raises(ValidationError) as exc_info:
+            get_user("")
+
+        assert "cannot be empty" in str(exc_info.value)
+
+    def test_異常系_存在しないIDでNotFoundError(self):
+        with pytest.raises(NotFoundError) as exc_info:
+            get_user("nonexistent-id")
+
+        assert "nonexistent-id" in str(exc_info.value)
+```
+
+## 参照実装
+
+このプロジェクトでの参照実装：
+
+- `src/rss/exceptions.py`: RSS パッケージの例外定義
+
+```python
+# 実際の rss パッケージの例外
+class RSSError(Exception):
+    """Base exception for all RSS package errors."""
+    pass
+
+class FeedNotFoundError(RSSError):
+    """Exception raised when a feed is not found."""
+    pass
+
+class FeedFetchError(RSSError):
+    """Exception raised when fetching a feed fails."""
+    pass
+
+class InvalidURLError(RSSError):
+    """Exception raised when a URL is invalid."""
+    pass
+```
+
+## シンプルパターンの利点
+
+1. **低オーバーヘッド**: 追加の属性やメソッドがないため軽量
+2. **理解しやすい**: 標準の Python 例外と同じ使い方
+3. **メンテナンスが容易**: コードが少ないため変更が簡単
+4. **Docstring で十分**: Parameters を Docstring で説明
+5. **柔軟なメッセージ**: raise 時に自由にメッセージを構成
+
+## いつリッチパターンに移行すべきか
+
+以下の条件が複数該当する場合は、リッチパターンへの移行を検討：
+
+- [ ] エラーをプログラム的に分類する必要がある（エラーコード）
+- [ ] エラーを JSON 等にシリアライズして返す必要がある
+- [ ] エラーの詳細情報を構造化して保持したい
+- [ ] エラーの統計・分析を行いたい
+- [ ] 外部 API との連携でエラーレスポンスを返す

--- a/.claude/skills/error-handling/guide.md
+++ b/.claude/skills/error-handling/guide.md
@@ -1,0 +1,341 @@
+# Error Handling 詳細ガイド
+
+## 例外階層の設計原則
+
+### 基底例外クラスの設計
+
+すべてのパッケージは固有の基底例外クラスを持つべきです。
+
+```python
+class PackageError(Exception):
+    """パッケージ固有の基底例外
+
+    このクラスを継承することで：
+    - パッケージのすべての例外を一括で catch 可能
+    - 外部から見た明確な境界を提供
+    - 例外の分類とハンドリングが容易に
+    """
+    pass
+```
+
+### 例外の分類
+
+例外は以下のカテゴリに分類することを推奨します：
+
+| カテゴリ | 説明 | 例 |
+|---------|------|-----|
+| Validation | 入力検証エラー | 不正なパラメータ、フォーマットエラー |
+| Data | データ関連エラー | データ未発見、データ破損 |
+| Network | ネットワークエラー | 接続失敗、タイムアウト |
+| Configuration | 設定エラー | 設定ファイル不正、環境変数未設定 |
+| Authorization | 認証・認可エラー | 認証失敗、権限不足 |
+
+### 例外階層の深さ
+
+**推奨**: 2〜3 階層まで
+
+```
+# 推奨
+PackageError
+├── DataError
+│   ├── NotFoundError
+│   └── FetchError
+└── NetworkError
+
+# 非推奨（深すぎる）
+PackageError
+└── DataError
+    └── FetchError
+        └── HTTPFetchError
+            └── HTTP500Error
+                └── InternalServerError
+```
+
+## エラーメッセージのベストプラクティス
+
+### 良いエラーメッセージの要素
+
+1. **何が起きたか**（What happened）
+2. **なぜ問題なのか**（Why it's a problem）
+3. **どう解決するか**（How to fix it）
+
+```python
+# 悪い例
+raise ValueError("Invalid input")
+
+# 良い例
+raise ValueError(
+    f"Expected positive integer for 'count', got {count}. "
+    f"Provide a value greater than 0."
+)
+```
+
+### コンテキスト情報の含め方
+
+```python
+# 悪い例
+raise FetchError("Failed to fetch data")
+
+# 良い例
+raise FetchError(
+    f"Failed to fetch price data for symbol '{symbol}' "
+    f"from {source}: {original_error}"
+)
+```
+
+### 機密情報の除外
+
+エラーメッセージに以下を含めないこと：
+
+- パスワード、API キー
+- 内部システムパス（本番環境）
+- スタックトレースの詳細（エンドユーザー向け）
+- 顧客の個人情報
+
+```python
+# 悪い例
+raise AuthError(f"Failed to authenticate with API key: {api_key}")
+
+# 良い例
+raise AuthError(
+    "Failed to authenticate. Check that your API key is valid."
+)
+```
+
+## エラーコードの設計
+
+### ErrorCode Enum の設計
+
+```python
+from enum import Enum
+
+class ErrorCode(str, Enum):
+    """エラーコードの列挙型
+
+    命名規則:
+    - UPPER_SNAKE_CASE
+    - カテゴリ_詳細 の形式
+
+    値:
+    - str 継承により JSON シリアライズが容易
+    """
+
+    # 汎用
+    UNKNOWN = "UNKNOWN"
+
+    # ネットワーク関連
+    NETWORK_ERROR = "NETWORK_ERROR"
+    NETWORK_TIMEOUT = "NETWORK_TIMEOUT"
+    NETWORK_CONNECTION_REFUSED = "NETWORK_CONNECTION_REFUSED"
+
+    # API 関連
+    API_ERROR = "API_ERROR"
+    API_RATE_LIMIT = "API_RATE_LIMIT"
+    API_AUTH_FAILED = "API_AUTH_FAILED"
+
+    # データ関連
+    DATA_NOT_FOUND = "DATA_NOT_FOUND"
+    DATA_INVALID = "DATA_INVALID"
+    DATA_CORRUPTED = "DATA_CORRUPTED"
+
+    # バリデーション関連
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    VALIDATION_MISSING_FIELD = "VALIDATION_MISSING_FIELD"
+    VALIDATION_INVALID_FORMAT = "VALIDATION_INVALID_FORMAT"
+```
+
+### エラーコードの使い分け
+
+```python
+try:
+    response = api_client.fetch(symbol)
+except HTTPError as e:
+    if e.status_code == 429:
+        code = ErrorCode.API_RATE_LIMIT
+    elif e.status_code == 401:
+        code = ErrorCode.API_AUTH_FAILED
+    elif e.status_code >= 500:
+        code = ErrorCode.API_ERROR
+    else:
+        code = ErrorCode.UNKNOWN
+
+    raise DataFetchError(
+        f"Failed to fetch data for {symbol}",
+        code=code,
+        cause=e,
+    )
+```
+
+## 例外チェーンの活用
+
+### from e の使用
+
+```python
+try:
+    data = external_api.fetch(symbol)
+except HTTPError as e:
+    # 例外チェーンを保持
+    raise DataFetchError(
+        f"Failed to fetch data for {symbol}",
+        cause=e,
+    ) from e
+```
+
+### スタックトレースの可読性
+
+```python
+# 例外チェーンがある場合のスタックトレース例
+Traceback (most recent call last):
+  File "api_client.py", line 50, in fetch
+    response = requests.get(url)
+  ...
+requests.exceptions.ConnectionError: Connection refused
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "service.py", line 100, in get_data
+    return api_client.fetch(symbol)
+  ...
+DataFetchError: Failed to fetch data for AAPL
+```
+
+## コンテキスト情報の収集
+
+### details フィールドの活用
+
+```python
+class DataFetchError(MarketAnalysisError):
+    def __init__(
+        self,
+        message: str,
+        symbol: str | None = None,
+        source: str | None = None,
+        **kwargs,
+    ) -> None:
+        details = kwargs.pop("details", {}) or {}
+        if symbol:
+            details["symbol"] = symbol
+        if source:
+            details["source"] = source
+
+        super().__init__(message, details=details, **kwargs)
+```
+
+### to_dict() によるシリアライズ
+
+```python
+def to_dict(self) -> dict[str, Any]:
+    """例外を辞書に変換（API レスポンス用）"""
+    result = {
+        "error_type": self.__class__.__name__,
+        "code": self.code.value,
+        "message": self.message,
+        "details": self.details,
+    }
+
+    if self.cause:
+        result["cause"] = {
+            "type": type(self.cause).__name__,
+            "message": str(self.cause),
+        }
+
+    return result
+```
+
+## ハンドリングパターン
+
+### 特定の例外を catch
+
+```python
+# 悪い例
+try:
+    result = process_data(data)
+except Exception:
+    logger.error("Something went wrong")
+    raise
+
+# 良い例
+try:
+    result = process_data(data)
+except ValidationError as e:
+    logger.warning("Validation failed", error=str(e), field=e.field)
+    raise
+except DataFetchError as e:
+    logger.error("Data fetch failed", error=str(e), symbol=e.symbol)
+    raise
+```
+
+### 例外の変換
+
+```python
+def public_api_method(symbol: str) -> DataFrame:
+    """外部向け API メソッド
+
+    内部例外を外部向け例外に変換
+    """
+    try:
+        return internal_fetch(symbol)
+    except InternalDatabaseError as e:
+        # 内部の詳細を隠蔽
+        raise DataError("Data is temporarily unavailable") from e
+    except InternalAPIError as e:
+        raise DataFetchError(
+            f"Failed to fetch data for {symbol}",
+            symbol=symbol,
+        ) from e
+```
+
+### finally の活用
+
+```python
+def process_with_cleanup(resource: Resource) -> Result:
+    """リソースのクリーンアップを保証"""
+    try:
+        return resource.process()
+    except ProcessingError as e:
+        logger.error("Processing failed", error=str(e))
+        raise
+    finally:
+        # 成功・失敗に関わらず実行
+        resource.cleanup()
+```
+
+## テストでの例外検証
+
+### pytest.raises の使用
+
+```python
+import pytest
+
+def test_raises_validation_error_for_invalid_input():
+    with pytest.raises(ValidationError) as exc_info:
+        process_data(invalid_data)
+
+    assert "expected positive integer" in str(exc_info.value)
+    assert exc_info.value.field == "count"
+
+def test_raises_with_correct_error_code():
+    with pytest.raises(DataFetchError) as exc_info:
+        fetch_data("INVALID_SYMBOL")
+
+    assert exc_info.value.code == ErrorCode.DATA_NOT_FOUND
+```
+
+### 例外の属性検証
+
+```python
+def test_exception_contains_context():
+    with pytest.raises(DataFetchError) as exc_info:
+        fetch_data("AAPL")
+
+    error = exc_info.value
+    assert error.symbol == "AAPL"
+    assert error.source == "yfinance"
+    assert error.details["symbol"] == "AAPL"
+```
+
+## 参考リンク
+
+- [Python 公式ドキュメント - 例外](https://docs.python.org/3/library/exceptions.html)
+- [PEP 3134 - Exception Chaining](https://peps.python.org/pep-3134/)


### PR DESCRIPTION
## 概要

Python エラーハンドリングパターンのナレッジベースを提供する `error-handling` スキルを作成しました。

- シンプル/リッチパターンの選択ガイド
- 例外階層の設計原則
- リトライ・フォールバック戦略
- ロギング統合パターン

## 追加ファイル

```
.claude/skills/error-handling/
├── SKILL.md                           # パターン選択ガイド、概要
├── guide.md                           # 詳細設計原則
└── examples/
    ├── simple-pattern.md              # シンプルパターン（RSS方式）
    ├── rich-pattern.md                # リッチパターン（Market Analysis方式）
    ├── retry-patterns.md              # リトライ・フォールバック
    └── logging-integration.md         # ロギング統合パターン
```

## 変更ファイル

- `.claude/agents/feature-implementer.md`: `skills: [error-handling]` を追加
- `.claude/agents/code-simplifier.md`: `skills: [error-handling]` を追加

## パターン選択ガイド

| 条件 | 推奨パターン |
|------|-------------|
| 内部ライブラリ、シンプルな例外 | シンプルパターン（RSS方式） |
| 外部API連携、詳細情報必要 | リッチパターン（Market Analysis方式） |
| エラーのシリアライズ必要 | リッチパターン |

## テストプラン

- [x] スキルディレクトリ構造の確認
- [x] フロントマターの検証（name, description, allowed-tools）
- [x] 対象エージェントへのスキル参照追加の確認

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)