### PR TITLE
feat(skill): finance-news-workflow templates/ を追加

### DIFF
--- a/.claude/skills/finance-news-workflow/templates/issue-template.md
+++ b/.claude/skills/finance-news-workflow/templates/issue-template.md
@@ -1,0 +1,183 @@
+# Issue作成テンプレート
+
+GitHub Issue作成時のフォーマット定義。
+
+## Issueタイトル形式
+
+```
+[{{theme_ja}}] {{japanese_title}}
+```
+
+### テーマ名プレフィックス
+
+| テーマキー | プレフィックス | GitHub Status |
+|-----------|--------------|---------------|
+| `index` | `[株価指数]` | Index |
+| `stock` | `[個別銘柄]` | Stock |
+| `sector` | `[セクター]` | Sector |
+| `macro` | `[マクロ経済]` | Macro Economics |
+| `ai` | `[AI]` | AI |
+| `finance` | `[金融]` | Finance |
+
+### タイトル翻訳ルール
+
+- 英語タイトルは日本語に翻訳
+- 企業名・固有名詞は原則そのまま（例: Apple, Fed, S&P 500）
+- 専門用語は日本語訳を使用（例: earnings → 決算）
+
+## Issue本文テンプレート
+
+```markdown
+{{summary}}
+
+### 情報源URL
+
+{{url}}
+
+### 公開日
+
+{{published_date}}
+
+### 収集日時
+
+{{collected_at}}
+
+### カテゴリ
+
+{{category}}
+
+### フィード/情報源名
+
+{{feed_source}}
+
+### 備考・メモ
+
+{{notes}}
+
+---
+
+**自動収集**: このIssueは `/collect-finance-news` コマンドによって自動作成されました。
+```
+
+## プレースホルダー一覧
+
+| プレースホルダー | 説明 | 例 | 必須 |
+|-----------------|------|-----|------|
+| `{{theme_ja}}` | テーマ名（日本語） | `株価指数` | ✅ |
+| `{{japanese_title}}` | 記事タイトル（日本語） | `S&P 500が最高値更新` | ✅ |
+| `{{summary}}` | 日本語要約（4セクション構成） | - | ✅ |
+| `{{url}}` | 元記事のURL | `https://cnbc.com/...` | ✅ |
+| `{{published_date}}` | 公開日時（JST形式） | `2026-01-15 10:00(JST)` | ✅ |
+| `{{collected_at}}` | 収集日時（JST形式） | `2026-01-15 14:30(JST)` | ✅ |
+| `{{category}}` | カテゴリ表記 | `Index（株価指数）` | ✅ |
+| `{{feed_source}}` | フィード名 | `CNBC - Markets` | ✅ |
+| `{{notes}}` | 備考・メモ | テーマ、AI判定理由 | ❌ |
+
+## 要約フォーマット（4セクション構成）
+
+`{{summary}}` には以下の構造で要約を記載：
+
+```markdown
+### 概要
+- [主要事実を箇条書きで3行程度]
+- [数値データがあれば含める]
+- [関連企業があれば含める]
+
+### 背景
+[この出来事の背景・経緯を記載。記事に記載がなければ「[記載なし]」]
+
+### 市場への影響
+[株式・為替・債券等への影響を記載。記事に記載がなければ「[記載なし]」]
+
+### 今後の見通し
+[今後予想される展開・注目点を記載。記事に記載がなければ「[記載なし]」]
+```
+
+### 各セクションの記載ルール
+
+| セクション | 内容 | 記載なしの例 |
+|-----------|------|-------------|
+| 概要 | 主要事実、数値データ | （常に何か記載できるはず） |
+| 背景 | 経緯、原因、これまでの流れ | 速報で背景説明がない場合 |
+| 市場への影響 | 株価・為替・債券への影響 | 影響の言及がない場合 |
+| 今後の見通し | 予想、アナリスト見解 | 将来予測の言及がない場合 |
+
+## ラベル設定
+
+### 必須ラベル
+
+- `news`: 全ニュースIssueに付与
+
+### オプションラベル（将来拡張用）
+
+| ラベル | 条件 |
+|--------|------|
+| `urgent` | 速報性が高い記事 |
+| `earnings` | 決算関連 |
+| `fed` | Fed/金融政策関連 |
+
+## URL設定の重要ルール
+
+> **絶対に守ること**: `{{url}}`には**RSSから取得したオリジナルのlink**をそのまま使用すること。
+>
+> - ✅ 正しい: RSSの`link`フィールドの値をそのまま使用
+> - ❌ 間違い: WebFetchのリダイレクト先URL
+> - ❌ 間違い: URLを推測・生成する
+> - ❌ 間違い: URLを短縮・変換する
+
+## Issue作成手順
+
+```bash
+# Step 1: テンプレート読み込み（frontmatter除外）
+template=$(cat .github/ISSUE_TEMPLATE/news-article.md | tail -n +7)
+
+# Step 2: 収集日時を取得
+collected_at=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+
+# Step 3: プレースホルダーを置換
+body="${template//\{\{summary\}\}/$japanese_summary}"
+body="${body//\{\{url\}\}/$link}"
+body="${body//\{\{published_date\}\}/$published_jst(JST)}"
+body="${body//\{\{collected_at\}\}/$collected_at(JST)}"
+body="${body//\{\{category\}\}/$category}"
+body="${body//\{\{feed_source\}\}/$source}"
+body="${body//\{\{notes\}\}/$notes}"
+
+# Step 4: Issue作成
+issue_url=$(gh issue create \
+    --repo YH-05/finance \
+    --title "[${theme_ja}] ${japanese_title}" \
+    --body "$body" \
+    --label "news")
+
+# Step 5: Issue番号を抽出
+issue_number=$(echo "$issue_url" | grep -oE '[0-9]+$')
+
+# Step 6: Issueをclose（ニュースIssueはclosed状態で保存）
+gh issue close "$issue_number" --repo YH-05/finance
+```
+
+## GitHub Project設定
+
+Issue作成後、以下を設定：
+
+1. **Project追加**: `gh project item-add 15 --owner YH-05 --url {issue_url}`
+2. **Status設定**: テーマに対応するStatusを設定
+3. **公開日時設定**: `YYYY-MM-DD` 形式で日付を設定
+
+### Status Option ID一覧
+
+| テーマ | Status名 | Option ID |
+|--------|----------|-----------|
+| index | Index | `3925acc3` |
+| stock | Stock | `f762022e` |
+| sector | Sector | `48762504` |
+| macro | Macro Economics | `730034a5` |
+| ai | AI | `6fbb43d0` |
+| finance | Finance | `ac4a91b1` |
+
+## 参照
+
+- **GitHub Issueテンプレート**: `.github/ISSUE_TEMPLATE/news-article.md`
+- **共通処理ガイド**: `.claude/agents/finance_news_collector/common-processing-guide.md`
+- **テーマ設定**: `data/config/finance-news-themes.json`

--- a/.claude/skills/finance-news-workflow/templates/summary-template.md
+++ b/.claude/skills/finance-news-workflow/templates/summary-template.md
@@ -1,0 +1,292 @@
+# 収集結果サマリーテンプレート
+
+ニュース収集完了時に表示するサマリーフォーマット。
+
+## 全体サマリー
+
+```markdown
+================================================================================
+            /collect-finance-news 完了
+================================================================================
+
+## 収集結果サマリー
+
+| 項目 | 件数 |
+|------|------|
+| 処理記事数 | {{total_processed}} |
+| 期間外スキップ | {{date_filtered}} |
+| テーママッチ | {{total_matched}} |
+| 重複スキップ | {{total_duplicates}} |
+| 新規投稿 | {{total_created}} |
+| 投稿失敗 | {{total_failed}} |
+
+## テーマ別統計
+
+| テーマ | 処理 | マッチ | 重複 | 投稿 | 失敗 |
+|--------|------|--------|------|------|------|
+{{#themes}}
+| {{theme_ja}} | {{processed}} | {{matched}} | {{duplicates}} | {{created}} | {{failed}} |
+{{/themes}}
+
+## 作成されたIssue
+
+{{#created_issues}}
+- [#{{issue_number}}]({{issue_url}}) {{title}}
+  - テーマ: {{theme_ja}}
+  - 公開日: {{published_date}}
+  - ソース: {{feed_source}}
+{{/created_issues}}
+
+## エラー・スキップ情報
+
+{{#has_errors}}
+### エラー一覧
+
+{{#errors}}
+- **{{title}}**: {{error_message}}
+  - URL: {{url}}
+{{/errors}}
+{{/has_errors}}
+
+{{#has_skipped}}
+### スキップされた記事
+
+#### 期間外
+{{#date_skipped}}
+- {{title}} (公開: {{published_date}})
+{{/date_skipped}}
+
+#### 重複
+{{#duplicates}}
+- {{title}} → 既存Issue: #{{existing_issue_number}}
+{{/duplicates}}
+
+#### テーマ不一致
+{{#theme_mismatch}}
+- {{title}} (判定: {{判定結果}})
+{{/theme_mismatch}}
+{{/has_skipped}}
+
+## 実行パラメータ
+
+- **期間**: {{since}}
+- **対象テーマ**: {{themes}}
+- **取得上限**: {{limit}}件
+- **dry-run**: {{dry_run}}
+
+---
+
+**次回実行**: `/collect-finance-news` または `/collect-finance-news --since 1d`
+```
+
+## プレースホルダー一覧
+
+### 統計情報
+
+| プレースホルダー | 説明 | 型 |
+|-----------------|------|-----|
+| `{{total_processed}}` | 処理した記事総数 | int |
+| `{{date_filtered}}` | 期間外でスキップした件数 | int |
+| `{{total_matched}}` | テーマにマッチした件数 | int |
+| `{{total_duplicates}}` | 重複でスキップした件数 | int |
+| `{{total_created}}` | 新規作成したIssue数 | int |
+| `{{total_failed}}` | 作成失敗した件数 | int |
+
+### テーマ別統計
+
+| プレースホルダー | 説明 |
+|-----------------|------|
+| `{{themes}}` | テーマ別統計の配列 |
+| `{{theme_ja}}` | テーマ名（日本語） |
+| `{{processed}}` | そのテーマで処理した件数 |
+| `{{matched}}` | テーマにマッチした件数 |
+| `{{duplicates}}` | 重複件数 |
+| `{{created}}` | 作成したIssue数 |
+| `{{failed}}` | 失敗件数 |
+
+### 作成Issue一覧
+
+| プレースホルダー | 説明 |
+|-----------------|------|
+| `{{created_issues}}` | 作成したIssueの配列 |
+| `{{issue_number}}` | Issue番号 |
+| `{{issue_url}}` | IssueのURL |
+| `{{title}}` | 記事タイトル |
+| `{{published_date}}` | 公開日時 |
+| `{{feed_source}}` | フィード名 |
+
+### エラー・スキップ情報
+
+| プレースホルダー | 説明 |
+|-----------------|------|
+| `{{has_errors}}` | エラーがあるかどうか（boolean） |
+| `{{errors}}` | エラー一覧の配列 |
+| `{{error_message}}` | エラーメッセージ |
+| `{{has_skipped}}` | スキップがあるかどうか（boolean） |
+| `{{date_skipped}}` | 期間外でスキップした記事の配列 |
+| `{{duplicates}}` | 重複でスキップした記事の配列 |
+| `{{existing_issue_number}}` | 重複先のIssue番号 |
+| `{{theme_mismatch}}` | テーマ不一致でスキップした記事の配列 |
+| `{{判定結果}}` | AI判定の結果 |
+
+### 実行パラメータ
+
+| プレースホルダー | 説明 | デフォルト |
+|-----------------|------|-----------|
+| `{{since}}` | 期間指定 | `1d` |
+| `{{themes}}` | 対象テーマ | `all` |
+| `{{limit}}` | 取得上限 | `50` |
+| `{{dry_run}}` | dry-runモード | `false` |
+
+## テーマ別サマリー
+
+各テーマエージェントが出力するサマリー形式：
+
+```markdown
+## {{theme_name}} ニュース収集完了
+
+### 処理統計
+- **処理記事数**: {{processed}}件
+- **テーママッチ**: {{matched}}件（AI判断）
+- **重複**: {{duplicates}}件
+- **新規投稿**: {{created}}件
+- **投稿失敗**: {{failed}}件
+
+### 投稿されたニュース
+
+{{#created_issues}}
+1. **{{title}}** [#{{issue_number}}]
+   - ソース: {{feed_source}}
+   - 公開日時: {{published_jst}}
+   - AI判定理由: {{判定理由}}
+   - URL: https://github.com/YH-05/finance/issues/{{issue_number}}
+{{/created_issues}}
+```
+
+## dry-runモード出力
+
+`--dry-run` オプション使用時の出力形式：
+
+```markdown
+================================================================================
+            /collect-finance-news (dry-run) 完了
+================================================================================
+
+## dry-run結果
+
+**注意**: 以下は投稿されずにシミュレーションされた結果です。
+
+### 投稿予定のニュース
+
+{{#would_create}}
+1. **[{{theme_ja}}] {{japanese_title}}**
+   - 元タイトル: {{original_title}}
+   - URL: {{url}}
+   - ソース: {{feed_source}}
+   - 公開日: {{published_date}}
+{{/would_create}}
+
+### スキップ予定
+
+- 期間外: {{date_filtered}}件
+- 重複: {{total_duplicates}}件
+- テーマ不一致: {{theme_mismatch_count}}件
+
+---
+
+**実際に投稿するには**: `/collect-finance-news` を実行してください
+```
+
+## エラーサマリー
+
+収集中にエラーが発生した場合の追加出力：
+
+```markdown
+## ⚠️ エラーサマリー
+
+### 発生したエラー
+
+| タイプ | 件数 | 詳細 |
+|--------|------|------|
+| MCP接続エラー | {{mcp_errors}} | RSS MCPへの接続失敗 |
+| Issue作成エラー | {{issue_create_errors}} | GitHub API呼び出し失敗 |
+| 日時設定エラー | {{date_field_errors}} | Project日時フィールド設定失敗 |
+| その他 | {{other_errors}} | - |
+
+### 推奨アクション
+
+{{#has_mcp_errors}}
+- MCPサーバーの状態を確認: `.mcp.json` の設定を確認
+{{/has_mcp_errors}}
+
+{{#has_rate_limit}}
+- GitHub API レート制限: 1時間待機後に再実行
+{{/has_rate_limit}}
+
+{{#has_network_errors}}
+- ネットワーク接続を確認し、再実行
+{{/has_network_errors}}
+```
+
+## 出力例
+
+### 正常完了時
+
+```markdown
+================================================================================
+            /collect-finance-news 完了
+================================================================================
+
+## 収集結果サマリー
+
+| 項目 | 件数 |
+|------|------|
+| 処理記事数 | 45 |
+| 期間外スキップ | 12 |
+| テーママッチ | 18 |
+| 重複スキップ | 5 |
+| 新規投稿 | 13 |
+| 投稿失敗 | 0 |
+
+## テーマ別統計
+
+| テーマ | 処理 | マッチ | 重複 | 投稿 | 失敗 |
+|--------|------|--------|------|------|------|
+| 株価指数 | 8 | 4 | 1 | 3 | 0 |
+| 個別銘柄 | 10 | 5 | 2 | 3 | 0 |
+| セクター | 7 | 2 | 0 | 2 | 0 |
+| マクロ経済 | 12 | 4 | 1 | 3 | 0 |
+| AI | 5 | 2 | 1 | 1 | 0 |
+| 金融 | 3 | 1 | 0 | 1 | 0 |
+
+## 作成されたIssue
+
+- [#345](https://github.com/YH-05/finance/issues/345) S&P 500が最高値を更新、テック株がけん引
+  - テーマ: 株価指数
+  - 公開日: 2026-01-22 09:30
+  - ソース: CNBC - Markets
+
+- [#346](https://github.com/YH-05/finance/issues/346) Fed議長、3月利下げを示唆
+  - テーマ: マクロ経済
+  - 公開日: 2026-01-22 10:15
+  - ソース: CNBC - Economy
+
+...
+
+## 実行パラメータ
+
+- **期間**: 1d
+- **対象テーマ**: all
+- **取得上限**: 50件
+- **dry-run**: false
+
+---
+
+**次回実行**: `/collect-finance-news` または `/collect-finance-news --since 1d`
+```
+
+## 参照
+
+- **スキル定義**: `.claude/skills/finance-news-workflow/SKILL.md`
+- **Issue作成テンプレート**: `./issue-template.md`
+- **共通処理ガイド**: `.claude/agents/finance_news_collector/common-processing-guide.md`


### PR DESCRIPTION
## 概要

- finance-news-workflow スキルの templates/ ディレクトリを作成
- Issue作成テンプレートと結果サマリーテンプレートを追加

## 変更内容

### templates/issue-template.md
- Issueタイトル形式（`[テーマ名] タイトル`）の定義
- Issue本文テンプレートと変数プレースホルダー
- 4セクション構成の要約フォーマット
- URL設定ルールとラベル設定

### templates/summary-template.md
- 全体サマリーフォーマット
- テーマ別統計テーブル
- 作成Issue一覧
- エラー・スキップ情報
- dry-runモード出力

## テストプラン

- [x] make check-all が成功することを確認
- [x] 変数プレースホルダーが正しく定義されていることを確認
- [x] 既存の収集フローで使用されているフォーマットを踏襲していることを確認

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)