### PR TITLE
[スキル移行] finance-news-orchestrator, collector エージェント更新

### DIFF
--- a/.claude/agents/finance-news-collector.md
+++ b/.claude/agents/finance-news-collector.md
@@ -8,6 +8,9 @@ color: green
 depends_on: []
 phase: 1
 priority: high
+skills:
+  - finance-news-workflow
+  - rss-integration
 archived: true
 ---
 

--- a/.claude/agents/finance-news-orchestrator.md
+++ b/.claude/agents/finance-news-orchestrator.md
@@ -8,6 +8,9 @@ color: purple
 depends_on: []
 phase: 1
 priority: high
+skills:
+  - finance-news-workflow
+  - rss-integration
 tools:
   - Read
   - Write


### PR DESCRIPTION
## 概要
- finance-news-orchestrator.md に skills フィールドを追加
- finance-news-collector.md に skills フィールドを追加

## 変更内容
| ファイル | 追加内容 |
|---------|---------|
| `.claude/agents/finance-news-orchestrator.md` | `skills: [finance-news-workflow, rss-integration]` |
| `.claude/agents/finance-news-collector.md` | `skills: [finance-news-workflow, rss-integration]` |

既存の `description`, `tools` フィールドは維持しています。

## テストプラン
- [x] 各エージェントに skills フィールドが正しく追加されていることを確認
- [x] 既存のフロントマターフィールドが維持されていることを確認

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)