### PR TITLE
feat(agent): 6つのテーマ別エージェントにスキル参照を追加

### DIFF
--- a/.claude/agents/finance-news-ai.md
+++ b/.claude/agents/finance-news-ai.md
@@ -8,6 +8,8 @@ color: cyan
 depends_on: [finance-news-orchestrator]
 phase: 2
 priority: high
+skills:
+  - finance-news-workflow
 tools:
   - Read
   - Bash

--- a/.claude/agents/finance-news-finance.md
+++ b/.claude/agents/finance-news-finance.md
@@ -8,6 +8,8 @@ color: red
 depends_on: [finance-news-orchestrator]
 phase: 2
 priority: high
+skills:
+  - finance-news-workflow
 tools:
   - Read
   - Bash

--- a/.claude/agents/finance-news-index.md
+++ b/.claude/agents/finance-news-index.md
@@ -8,6 +8,8 @@ color: blue
 depends_on: [finance-news-orchestrator]
 phase: 2
 priority: high
+skills:
+  - finance-news-workflow
 tools:
   - Read
   - Bash

--- a/.claude/agents/finance-news-macro.md
+++ b/.claude/agents/finance-news-macro.md
@@ -8,6 +8,8 @@ color: red
 depends_on: [finance-news-orchestrator]
 phase: 2
 priority: high
+skills:
+  - finance-news-workflow
 tools:
   - Read
   - Bash

--- a/.claude/agents/finance-news-sector.md
+++ b/.claude/agents/finance-news-sector.md
@@ -8,6 +8,8 @@ color: orange
 depends_on: [finance-news-orchestrator]
 phase: 2
 priority: high
+skills:
+  - finance-news-workflow
 tools:
   - Read
   - Bash

--- a/.claude/agents/finance-news-stock.md
+++ b/.claude/agents/finance-news-stock.md
@@ -8,6 +8,8 @@ color: green
 depends_on: [finance-news-orchestrator]
 phase: 2
 priority: high
+skills:
+  - finance-news-workflow
 tools:
   - Read
   - Bash


### PR DESCRIPTION
## 概要
- 6つのテーマ別 finance-news エージェントに `skills: [finance-news-workflow]` を追加

## 変更ファイル
1. `.claude/agents/finance-news-index.md` - Indexテーマ
2. `.claude/agents/finance-news-stock.md` - Stockテーマ
3. `.claude/agents/finance-news-sector.md` - Sectorテーマ
4. `.claude/agents/finance-news-macro.md` - Macroテーマ
5. `.claude/agents/finance-news-ai.md` - AIテーマ
6. `.claude/agents/finance-news-finance.md` - Financeテーマ

## 変更内容
各エージェントのフロントマターに `skills:` フィールドを追加:
```yaml
skills:
  - finance-news-workflow
```

既存の `description`, `tools` 設定は維持。

## テストプラン
- [x] make check-all が成功することを確認
- [x] 6つすべてのエージェントに skills フィールドが追加されていることを確認
- [x] 既存の description, tools が維持されていることを確認

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)