### PR TITLE
feat(rss): ニュースカテゴリ分類ロジックを実装

### DIFF
--- a/src/rss/services/__init__.py
+++ b/src/rss/services/__init__.py
@@ -4,5 +4,18 @@ from .batch_scheduler import BatchScheduler
 from .feed_fetcher import FeedFetcher
 from .feed_manager import FeedManager
 from .feed_reader import FeedReader
+from .news_categorizer import (
+    CategorizationResult,
+    NewsCategorizer,
+    NewsCategory,
+)
 
-__all__ = ["BatchScheduler", "FeedFetcher", "FeedManager", "FeedReader"]
+__all__ = [
+    "BatchScheduler",
+    "CategorizationResult",
+    "FeedFetcher",
+    "FeedManager",
+    "FeedReader",
+    "NewsCategorizer",
+    "NewsCategory",
+]

--- a/src/rss/services/news_categorizer.py
+++ b/src/rss/services/news_categorizer.py
@@ -1,0 +1,399 @@
+"""News categorizer module for classifying financial news articles.
+
+This module provides functionality to automatically categorize financial news
+based on keywords matching in title and content.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+# Logger lazy initialization to avoid circular imports
+def _get_logger() -> Any:
+    try:
+        from ..utils.logging_config import get_logger
+
+        return get_logger(__name__, module="news_categorizer")
+    except ImportError:
+        import logging
+
+        return logging.getLogger(__name__)
+
+
+logger: Any = _get_logger()
+
+
+class NewsCategory(str, Enum):
+    """News category types.
+
+    Attributes
+    ----------
+    INDEX : str
+        Stock index related news (S&P 500, NASDAQ, Dow Jones, etc.)
+    MAG7 : str
+        Magnificent 7 company related news (Apple, Microsoft, etc.)
+    SECTOR : str
+        Sector analysis related news (technology, energy, etc.)
+    MACRO : str
+        Macroeconomic related news (Fed, interest rates, etc.)
+    THEME : str
+        Investment theme related news (AI, semiconductor, EV, etc.)
+    OTHER : str
+        News that does not fit into above categories
+    """
+
+    INDEX = "index"
+    MAG7 = "mag7"
+    SECTOR = "sector"
+    MACRO = "macro"
+    THEME = "theme"
+    OTHER = "other"
+
+
+@dataclass
+class CategorizationResult:
+    """Result of news categorization.
+
+    Attributes
+    ----------
+    category : NewsCategory
+        Determined category for the news item
+    confidence : float
+        Confidence score between 0.0 and 1.0
+    matched_keywords : list[str]
+        List of keywords that matched during categorization
+    """
+
+    category: NewsCategory
+    confidence: float
+    matched_keywords: list[str]
+
+
+# Keyword definitions for each category
+# Priority order: INDEX > MAG7 > MACRO > SECTOR > THEME > OTHER
+
+INDEX_KEYWORDS: list[str] = [
+    # US indices
+    "s&p 500",
+    "s&p500",
+    "sp500",
+    "nasdaq",
+    "dow jones",
+    "djia",
+    "russell 2000",
+    "russell2000",
+    "vix",
+    # Japanese indices
+    "日経平均",
+    "日経225",
+    "nikkei",
+    "topix",
+    # European indices
+    "ftse",
+    "dax",
+    "stoxx",
+    "cac 40",
+    # Index-related terms
+    "stock index",
+    "株価指数",
+    "指数",
+]
+
+MAG7_KEYWORDS: list[str] = [
+    # Apple
+    "apple",
+    "aapl",
+    "iphone",
+    "アップル",
+    # Microsoft
+    "microsoft",
+    "msft",
+    "azure",
+    "マイクロソフト",
+    # Google/Alphabet
+    "google",
+    "googl",
+    "goog",
+    "alphabet",
+    "グーグル",
+    # Amazon
+    "amazon",
+    "amzn",
+    "aws",
+    "アマゾン",
+    # NVIDIA
+    "nvidia",
+    "nvda",
+    "エヌビディア",
+    # Meta
+    "meta platforms",
+    "meta",
+    "facebook",
+    "メタ",
+    # Tesla
+    "tesla",
+    "tsla",
+    "テスラ",
+]
+
+MACRO_KEYWORDS: list[str] = [
+    # Central banks
+    "fed",
+    "federal reserve",
+    "fomc",
+    "boj",
+    "ecb",
+    "日銀",
+    "中央銀行",
+    # Interest rates
+    "interest rate",
+    "金利",
+    "利上げ",
+    "利下げ",
+    "rate cut",
+    "rate hike",
+    # Inflation
+    "inflation",
+    "cpi",
+    "インフレ",
+    "物価",
+    # GDP and economy
+    "gdp",
+    "economic growth",
+    "recession",
+    "景気",
+    # Employment
+    "employment",
+    "unemployment",
+    "payroll",
+    "non-farm",
+    "nonfarm",
+    "jobless",
+    "雇用",
+    "失業率",
+    # Bond market
+    "treasury",
+    "yield",
+    "国債",
+    "債券",
+]
+
+SECTOR_KEYWORDS: list[str] = [
+    # Sector names
+    "technology sector",
+    "tech sector",
+    "energy sector",
+    "healthcare sector",
+    "healthcare stocks",
+    "financial sector",
+    "financials",
+    "consumer discretionary",
+    "consumer staples",
+    "industrials",
+    "materials",
+    "utilities",
+    "real estate",
+    "pharmaceutical",
+    # Sector-related terms
+    "sector rotation",
+    "sector performance",
+    "セクター",
+    "業種",
+]
+
+THEME_KEYWORDS: list[str] = [
+    # AI
+    "artificial intelligence",
+    "ai investment",
+    "ai stocks",
+    "generative ai",
+    "人工知能",
+    "生成ai",
+    # Semiconductor
+    "semiconductor",
+    "chip",
+    "半導体",
+    # EV
+    "electric vehicle",
+    "ev",
+    "電気自動車",
+    # Renewable energy
+    "renewable energy",
+    "clean energy",
+    "solar",
+    "wind power",
+    "再生可能エネルギー",
+    "クリーンエネルギー",
+    # Other themes
+    "blockchain",
+    "cryptocurrency",
+    "quantum computing",
+    "space economy",
+    "cybersecurity",
+]
+
+
+class NewsCategorizer:
+    """Categorizer for financial news articles.
+
+    This class categorizes news articles into predefined categories
+    based on keyword matching in title and content.
+
+    The priority order for categories when multiple matches occur is:
+    INDEX > MAG7 > MACRO > SECTOR > THEME > OTHER
+
+    Examples
+    --------
+    >>> categorizer = NewsCategorizer()
+    >>> result = categorizer.categorize(
+    ...     title="S&P 500 hits record high",
+    ...     content="The index continued its rally..."
+    ... )
+    >>> result.category
+    <NewsCategory.INDEX: 'index'>
+    """
+
+    def __init__(self) -> None:
+        """Initialize the NewsCategorizer with keyword sets."""
+        logger.debug("Initializing NewsCategorizer")
+        # Store keywords as sets for O(1) lookup, lowercased
+        self._index_keywords = {kw.lower() for kw in INDEX_KEYWORDS}
+        self._mag7_keywords = {kw.lower() for kw in MAG7_KEYWORDS}
+        self._macro_keywords = {kw.lower() for kw in MACRO_KEYWORDS}
+        self._sector_keywords = {kw.lower() for kw in SECTOR_KEYWORDS}
+        self._theme_keywords = {kw.lower() for kw in THEME_KEYWORDS}
+
+        # Categories in priority order
+        self._categories_in_order: list[tuple[NewsCategory, set[str]]] = [
+            (NewsCategory.INDEX, self._index_keywords),
+            (NewsCategory.MAG7, self._mag7_keywords),
+            (NewsCategory.MACRO, self._macro_keywords),
+            (NewsCategory.SECTOR, self._sector_keywords),
+            (NewsCategory.THEME, self._theme_keywords),
+        ]
+        logger.info(
+            "NewsCategorizer initialized",
+            index_keywords=len(self._index_keywords),
+            mag7_keywords=len(self._mag7_keywords),
+            macro_keywords=len(self._macro_keywords),
+            sector_keywords=len(self._sector_keywords),
+            theme_keywords=len(self._theme_keywords),
+        )
+
+    def categorize(
+        self,
+        title: str,
+        content: str | None = None,
+    ) -> CategorizationResult:
+        """Categorize a single news article.
+
+        Parameters
+        ----------
+        title : str
+            News article title
+        content : str | None
+            News article content (optional)
+
+        Returns
+        -------
+        CategorizationResult
+            Categorization result with category, confidence, and matched keywords
+        """
+        logger.debug(
+            "Categorizing news",
+            title_length=len(title),
+            content_length=len(content) if content else 0,
+        )
+
+        # Combine and lowercase text for matching
+        text = (title + " " + (content or "")).lower()
+
+        # Try each category in priority order
+        for category, keywords in self._categories_in_order:
+            matched = self._find_matched_keywords(text, keywords)
+            if matched:
+                # Calculate confidence based on number of matches
+                confidence = min(len(matched) * 0.25, 1.0)
+                logger.debug(
+                    "Category matched",
+                    category=category.value,
+                    matched_count=len(matched),
+                    confidence=confidence,
+                )
+                return CategorizationResult(
+                    category=category,
+                    confidence=confidence,
+                    matched_keywords=matched,
+                )
+
+        # No match found, return OTHER
+        logger.debug("No category matched, returning OTHER")
+        return CategorizationResult(
+            category=NewsCategory.OTHER,
+            confidence=0.0,
+            matched_keywords=[],
+        )
+
+    def categorize_batch(
+        self,
+        news_items: list[dict[str, str]],
+    ) -> list[CategorizationResult]:
+        """Categorize multiple news articles.
+
+        Parameters
+        ----------
+        news_items : list[dict[str, str]]
+            List of news items with 'title' and optional 'content' keys
+
+        Returns
+        -------
+        list[CategorizationResult]
+            List of categorization results
+        """
+        logger.debug("Batch categorization started", item_count=len(news_items))
+        results = []
+        for item in news_items:
+            result = self.categorize(
+                title=item.get("title", ""),
+                content=item.get("content"),
+            )
+            results.append(result)
+
+        # Log summary
+        category_counts = {}
+        for r in results:
+            category_counts[r.category.value] = (
+                category_counts.get(r.category.value, 0) + 1
+            )
+        logger.info(
+            "Batch categorization completed",
+            total_items=len(news_items),
+            category_distribution=category_counts,
+        )
+        return results
+
+    def _find_matched_keywords(
+        self,
+        text: str,
+        keywords: set[str],
+    ) -> list[str]:
+        """Find all keywords that match in the text.
+
+        Parameters
+        ----------
+        text : str
+            Text to search in (already lowercased)
+        keywords : set[str]
+            Set of keywords to search for (already lowercased)
+
+        Returns
+        -------
+        list[str]
+            List of matched keywords
+        """
+        matched = []
+        for keyword in keywords:
+            if keyword in text:
+                matched.append(keyword)
+        return matched

--- a/tests/rss/property/test_news_categorizer_property.py
+++ b/tests/rss/property/test_news_categorizer_property.py
@@ -1,0 +1,105 @@
+"""Property-based tests for news categorizer module."""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from rss.services.news_categorizer import (
+    CategorizationResult,
+    NewsCategorizer,
+    NewsCategory,
+)
+
+
+class TestNewsCategorizer:
+    """Property-based tests for NewsCategorizer."""
+
+    @given(
+        title=st.text(min_size=0, max_size=500),
+        content=st.text(min_size=0, max_size=2000),
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_任意の入力に対して有効なカテゴリを返す(
+        self,
+        title: str,
+        content: str,
+    ) -> None:
+        """Any input should return a valid NewsCategory."""
+        categorizer = NewsCategorizer()
+        result = categorizer.categorize(title=title, content=content)
+
+        # Result should be a CategorizationResult
+        assert isinstance(result, CategorizationResult)
+        # Category should be a valid NewsCategory
+        assert result.category in NewsCategory
+        # Confidence should be between 0 and 1
+        assert 0.0 <= result.confidence <= 1.0
+        # matched_keywords should be a list
+        assert isinstance(result.matched_keywords, list)
+
+    @given(
+        items=st.lists(
+            st.fixed_dictionaries(
+                {
+                    "title": st.text(min_size=0, max_size=200),
+                    "content": st.text(min_size=0, max_size=500),
+                }
+            ),
+            min_size=0,
+            max_size=50,
+        )
+    )
+    @settings(max_examples=50)
+    def test_プロパティ_バッチ処理が入力数と同じ結果を返す(
+        self,
+        items: list[dict[str, str]],
+    ) -> None:
+        """Batch categorization should return same number of results as inputs."""
+        categorizer = NewsCategorizer()
+        results = categorizer.categorize_batch(items)
+
+        assert len(results) == len(items)
+        for result in results:
+            assert isinstance(result, CategorizationResult)
+            assert result.category in NewsCategory
+
+    @given(
+        title=st.text(min_size=1, max_size=200),
+        content=st.text(min_size=0, max_size=500),
+    )
+    @settings(max_examples=50)
+    def test_プロパティ_大文字小文字変換しても結果が同じ(
+        self,
+        title: str,
+        content: str,
+    ) -> None:
+        """Case conversion should not change the category result."""
+        categorizer = NewsCategorizer()
+        result_original = categorizer.categorize(title=title, content=content)
+        result_upper = categorizer.categorize(
+            title=title.upper(), content=content.upper()
+        )
+        result_lower = categorizer.categorize(
+            title=title.lower(), content=content.lower()
+        )
+
+        assert result_original.category == result_upper.category
+        assert result_original.category == result_lower.category
+
+    @given(
+        title=st.text(min_size=0, max_size=200),
+        content=st.text(min_size=0, max_size=500),
+    )
+    @settings(max_examples=50)
+    def test_プロパティ_同じ入力で同じ結果を返す_冪等性(
+        self,
+        title: str,
+        content: str,
+    ) -> None:
+        """Same input should always produce same output (idempotency)."""
+        categorizer = NewsCategorizer()
+        result1 = categorizer.categorize(title=title, content=content)
+        result2 = categorizer.categorize(title=title, content=content)
+
+        assert result1.category == result2.category
+        assert result1.confidence == result2.confidence
+        assert result1.matched_keywords == result2.matched_keywords

--- a/tests/rss/unit/services/test_news_categorizer.py
+++ b/tests/rss/unit/services/test_news_categorizer.py
@@ -1,0 +1,443 @@
+"""Tests for news categorizer module."""
+
+import time
+
+import pytest
+
+from rss.services.news_categorizer import (
+    CategorizationResult,
+    NewsCategorizer,
+    NewsCategory,
+)
+
+
+class TestNewsCategory:
+    """Tests for NewsCategory enum."""
+
+    def test_正常系_全カテゴリが定義されている(self) -> None:
+        expected_categories = {"index", "mag7", "sector", "macro", "theme", "other"}
+        actual_categories = {c.value for c in NewsCategory}
+        assert actual_categories == expected_categories
+
+
+class TestNewsCategorizer:
+    """Tests for NewsCategorizer class."""
+
+    @pytest.fixture
+    def categorizer(self) -> NewsCategorizer:
+        """Create a NewsCategorizer instance."""
+        return NewsCategorizer()
+
+    # === Index Category Tests ===
+    class TestIndexCategory:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_SP500関連ニュースがindex判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="S&P 500 hits record high amid tech rally",
+                content="The S&P 500 index reached a new all-time high...",
+            )
+            assert result.category == NewsCategory.INDEX
+
+        def test_正常系_NASDAQ関連ニュースがindex判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="NASDAQ Composite surges 2%",
+                content="Technology stocks led the gains...",
+            )
+            assert result.category == NewsCategory.INDEX
+
+        def test_正常系_日経平均関連ニュースがindex判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="日経平均が4万円突破",
+                content="日経平均株価が史上最高値を更新...",
+            )
+            assert result.category == NewsCategory.INDEX
+
+        def test_正常系_DowJones関連ニュースがindex判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Dow Jones Industrial Average drops 500 points",
+                content="The Dow fell sharply...",
+            )
+            assert result.category == NewsCategory.INDEX
+
+    # === MAG7 Category Tests ===
+    class TestMAG7Category:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_Apple関連ニュースがmag7判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Apple announces new iPhone",
+                content="Apple Inc. unveiled its latest smartphone...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+        def test_正常系_NVIDIA関連ニュースがmag7判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="NVIDIA reports record quarterly earnings",
+                content="NVIDIA Corporation announced...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+        def test_正常系_Microsoft関連ニュースがmag7判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Microsoft Azure growth exceeds expectations",
+                content="Microsoft Corp. reported strong cloud revenue...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+        def test_正常系_Tesla関連ニュースがmag7判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Tesla delivers record number of vehicles",
+                content="Tesla Inc. announced quarterly delivery...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+        def test_正常系_Amazon関連ニュースがmag7判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Amazon Web Services announces new AI tools",
+                content="Amazon.com Inc.'s cloud division...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+        def test_正常系_Google関連ニュースがmag7判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Google launches new AI model",
+                content="Alphabet Inc.'s Google division...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+        def test_正常系_Meta関連ニュースがmag7判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Meta unveils new VR headset",
+                content="Meta Platforms Inc. announced...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+    # === Macro Category Tests ===
+    class TestMacroCategory:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_Fed関連ニュースがmacro判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Fed holds interest rates steady",
+                content="The Federal Reserve announced...",
+            )
+            assert result.category == NewsCategory.MACRO
+
+        def test_正常系_inflation関連ニュースがmacro判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Inflation data exceeds expectations",
+                content="Consumer prices rose more than expected...",
+            )
+            assert result.category == NewsCategory.MACRO
+
+        def test_正常系_GDP関連ニュースがmacro判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="US GDP grows 3% in Q3",
+                content="The economy expanded at a stronger pace...",
+            )
+            assert result.category == NewsCategory.MACRO
+
+        def test_正常系_雇用統計関連ニュースがmacro判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Non-farm payrolls beat expectations",
+                content="The US economy added 250,000 jobs...",
+            )
+            assert result.category == NewsCategory.MACRO
+
+        def test_正常系_金利関連ニュースがmacro判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Interest rate decision looms",
+                content="Markets await the central bank's policy...",
+            )
+            assert result.category == NewsCategory.MACRO
+
+    # === Sector Category Tests ===
+    class TestSectorCategory:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_technology_sector関連ニュースがsector判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Technology sector leads market gains",
+                content="Tech stocks outperformed...",
+            )
+            assert result.category == NewsCategory.SECTOR
+
+        def test_正常系_energy_sector関連ニュースがsector判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Energy sector rallies on oil prices",
+                content="Oil and gas companies gained...",
+            )
+            assert result.category == NewsCategory.SECTOR
+
+        def test_正常系_healthcare_sector関連ニュースがsector判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Healthcare stocks surge",
+                content="Pharmaceutical companies led gains...",
+            )
+            assert result.category == NewsCategory.SECTOR
+
+        def test_正常系_financials_sector関連ニュースがsector判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Financial sector outperforms",
+                content="Banks reported strong earnings...",
+            )
+            assert result.category == NewsCategory.SECTOR
+
+    # === Theme Category Tests ===
+    class TestThemeCategory:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_AI投資テーマがtheme判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="AI investment boom continues",
+                content="Artificial intelligence stocks surge...",
+            )
+            assert result.category == NewsCategory.THEME
+
+        def test_正常系_semiconductor投資テーマがtheme判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Semiconductor demand drives growth",
+                content="Chip makers benefit from AI demand...",
+            )
+            assert result.category == NewsCategory.THEME
+
+        def test_正常系_EV投資テーマがtheme判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Electric vehicle sales accelerate",
+                content="EV adoption continues to grow...",
+            )
+            assert result.category == NewsCategory.THEME
+
+        def test_正常系_renewable_energy投資テーマがtheme判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Renewable energy investments surge",
+                content="Solar and wind power capacity grows...",
+            )
+            assert result.category == NewsCategory.THEME
+
+    # === Other Category Tests ===
+    class TestOtherCategory:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_該当なしニュースがother判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Local weather update",
+                content="Sunny skies expected tomorrow...",
+            )
+            assert result.category == NewsCategory.OTHER
+
+    # === Priority Tests ===
+    class TestPriority:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_複数カテゴリマッチ時に優先度順で判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            # S&P 500 (index) + Apple (MAG7) -> index が優先
+            result = categorizer.categorize(
+                title="S&P 500 rises as Apple reports earnings",
+                content="The index gained as Apple announced...",
+            )
+            # 優先度: index > mag7 > macro > sector > theme > other
+            assert result.category == NewsCategory.INDEX
+
+        def test_正常系_MAG7とMacroが競合時MAG7が優先(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            # Apple (MAG7) + Fed (macro) -> MAG7 が優先
+            result = categorizer.categorize(
+                title="Apple stock rises after Fed decision",
+                content="Apple shares gained...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+    # === Confidence Score Tests ===
+    class TestConfidenceScore:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_高い信頼度スコアを返す(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="S&P 500 S&P500 index hits record",
+                content="The S&P 500 benchmark index reached...",
+            )
+            assert result.confidence >= 0.5
+
+        def test_正常系_信頼度スコアが0から1の範囲(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="Random news article",
+                content="Some content here...",
+            )
+            assert 0.0 <= result.confidence <= 1.0
+
+    # === Matched Keywords Tests ===
+    class TestMatchedKeywords:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_マッチしたキーワードを返す(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="S&P 500 hits record high",
+                content="The index continued its rally...",
+            )
+            assert len(result.matched_keywords) > 0
+            assert any("s&p 500" in kw.lower() for kw in result.matched_keywords)
+
+    # === Batch Categorization Tests ===
+    class TestBatchCategorization:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_複数ニュースを一括分類(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            news_items = [
+                {"title": "S&P 500 rises", "content": "Index gains..."},
+                {"title": "Apple reports earnings", "content": "Tech giant..."},
+                {"title": "Fed holds rates", "content": "Central bank..."},
+            ]
+            results = categorizer.categorize_batch(news_items)
+            assert len(results) == 3
+            assert results[0].category == NewsCategory.INDEX
+            assert results[1].category == NewsCategory.MAG7
+            assert results[2].category == NewsCategory.MACRO
+
+    # === Performance Tests ===
+    class TestPerformance:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_100件秒以上の処理速度(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            """100件/秒以上の処理速度を確認."""
+            news_items = [
+                {"title": f"News item {i}", "content": f"Content {i}"}
+                for i in range(100)
+            ]
+            start_time = time.perf_counter()
+            categorizer.categorize_batch(news_items)
+            elapsed = time.perf_counter() - start_time
+
+            # 100件を1秒以内に処理できること
+            assert elapsed < 1.0, f"Processing took {elapsed:.2f}s, expected < 1.0s"
+
+    # === Edge Cases ===
+    class TestEdgeCases:
+        @pytest.fixture
+        def categorizer(self) -> NewsCategorizer:
+            return NewsCategorizer()
+
+        def test_正常系_空タイトルでother判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(title="", content="Some content")
+            assert result.category == NewsCategory.OTHER
+
+        def test_正常系_空コンテンツでタイトルのみで判定(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(title="S&P 500 hits record", content="")
+            assert result.category == NewsCategory.INDEX
+
+        def test_正常系_両方空でother判定(self, categorizer: NewsCategorizer) -> None:
+            result = categorizer.categorize(title="", content="")
+            assert result.category == NewsCategory.OTHER
+
+        def test_正常系_大文字小文字を区別しない(
+            self, categorizer: NewsCategorizer
+        ) -> None:
+            result = categorizer.categorize(
+                title="APPLE REPORTS EARNINGS",
+                content="apple inc announced...",
+            )
+            assert result.category == NewsCategory.MAG7
+
+
+class TestCategorizationResult:
+    """Tests for CategorizationResult dataclass."""
+
+    def test_正常系_結果が正しく作成される(self) -> None:
+        result = CategorizationResult(
+            category=NewsCategory.INDEX,
+            confidence=0.85,
+            matched_keywords=["S&P 500", "index"],
+        )
+        assert result.category == NewsCategory.INDEX
+        assert result.confidence == 0.85
+        assert result.matched_keywords == ["S&P 500", "index"]


### PR DESCRIPTION
## 概要

- ニュースタイトル・本文からカテゴリを自動判定するロジックを追加
- キーワードマッチングにより高速・シンプルな分類を実現
- 6カテゴリ（index, mag7, sector, macro, theme, other）に対応

## 変更内容

### 新規追加
- `src/rss/services/news_categorizer.py`
  - `NewsCategory` enum（6カテゴリ）
  - `CategorizationResult` データクラス
  - `NewsCategorizer` クラス（キーワードベース分類）
  
### テスト
- `tests/rss/unit/services/test_news_categorizer.py`（38件の単体テスト）
- `tests/rss/property/test_news_categorizer_property.py`（4件のプロパティテスト）

## カテゴリ定義

| カテゴリ | 説明 | キーワード例 |
|---------|------|-------------|
| index | 株価指数関連 | S&P 500, NASDAQ, 日経平均 |
| mag7 | Magnificent 7 | Apple, NVIDIA, Microsoft |
| macro | マクロ経済 | Fed, inflation, GDP |
| sector | セクター | technology, energy |
| theme | 投資テーマ | AI, semiconductor, EV |
| other | その他 | 上記以外 |

## 優先度順

複数カテゴリにマッチする場合の判定順序:
```
index > mag7 > macro > sector > theme > other
```

## テストプラン

- [x] make check-all が成功することを確認
- [x] 全38件の単体テストがパス
- [x] 全4件のプロパティテストがパス
- [x] 処理速度: 100件/秒以上

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)