### PR TITLE
[Phase1] marketパッケージ: cacheモジュール移植

### DIFF
--- a/src/market/__init__.py
+++ b/src/market/__init__.py
@@ -31,7 +31,7 @@ ExportError
     Exception for export operations
 """
 
-from .errors import ErrorCode, ExportError, MarketError
+from .errors import CacheError, ErrorCode, ExportError, MarketError
 from .export import DataExporter
 from .types import (
     AgentOutput,
@@ -45,6 +45,7 @@ __all__ = [
     "AgentOutput",
     "AgentOutputMetadata",
     "AnalysisResult",
+    "CacheError",
     "DataExporter",
     "DataSource",
     "ErrorCode",

--- a/src/market/cache/__init__.py
+++ b/src/market/cache/__init__.py
@@ -1,0 +1,54 @@
+"""Cache module for the market package.
+
+This module provides caching functionality for market data including:
+- CacheConfig: Configuration for cache behavior
+- SQLiteCache: SQLite-based cache with TTL support
+- generate_cache_key: Generate unique cache keys for market data
+- get_cache/reset_cache: Global cache instance management
+- create_persistent_cache: Create file-based persistent cache
+
+Public API
+----------
+CacheConfig
+    Configuration dataclass for cache behavior (frozen/immutable)
+SQLiteCache
+    SQLite-based cache with TTL support and thread-safe operations
+generate_cache_key
+    Generate unique cache keys for market data
+get_cache
+    Get or create the global cache instance
+reset_cache
+    Reset the global cache instance
+create_persistent_cache
+    Create a persistent file-based cache
+DEFAULT_CACHE_CONFIG
+    Default in-memory cache configuration
+DEFAULT_CACHE_DB_PATH
+    Default path for persistent cache database
+PERSISTENT_CACHE_CONFIG
+    Default persistent cache configuration
+"""
+
+from .cache import (
+    DEFAULT_CACHE_CONFIG,
+    DEFAULT_CACHE_DB_PATH,
+    PERSISTENT_CACHE_CONFIG,
+    SQLiteCache,
+    create_persistent_cache,
+    generate_cache_key,
+    get_cache,
+    reset_cache,
+)
+from .types import CacheConfig
+
+__all__ = [
+    "DEFAULT_CACHE_CONFIG",
+    "DEFAULT_CACHE_DB_PATH",
+    "PERSISTENT_CACHE_CONFIG",
+    "CacheConfig",
+    "SQLiteCache",
+    "create_persistent_cache",
+    "generate_cache_key",
+    "get_cache",
+    "reset_cache",
+]

--- a/src/market/cache/cache.py
+++ b/src/market/cache/cache.py
@@ -1,0 +1,650 @@
+"""SQLite-based caching for market data.
+
+This module provides a persistent cache implementation using SQLite
+for storing fetched market data with TTL (time-to-live) support.
+"""
+
+import hashlib
+import json
+import pickle  # nosec B403
+import sqlite3
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from market.errors import CacheError
+from market.utils import get_logger
+
+from .types import CacheConfig
+
+logger = get_logger(__name__)
+
+# Default cache database path (relative to project root)
+# cache.py is at src/market/cache/cache.py
+DEFAULT_CACHE_DB_PATH = (
+    Path(__file__).parent.parent.parent.parent / "data" / "cache" / "market_data.db"
+)
+
+# Default cache configuration (in-memory by default for backwards compatibility)
+DEFAULT_CACHE_CONFIG = CacheConfig(
+    enabled=True,
+    ttl_seconds=3600,  # 1 hour
+    max_entries=1000,
+    db_path=None,  # In-memory by default
+)
+
+# Persistent cache configuration with file-based storage
+PERSISTENT_CACHE_CONFIG = CacheConfig(
+    enabled=True,
+    ttl_seconds=86400,  # 24 hours
+    max_entries=10000,
+    db_path=str(DEFAULT_CACHE_DB_PATH),
+)
+
+
+def generate_cache_key(
+    symbol: str,
+    start_date: datetime | str | None = None,
+    end_date: datetime | str | None = None,
+    interval: str = "1d",
+    source: str = "yfinance",
+) -> str:
+    """Generate a unique cache key for market data.
+
+    Parameters
+    ----------
+    symbol : str
+        Ticker symbol
+    start_date : datetime | str | None
+        Start date
+    end_date : datetime | str | None
+        End date
+    interval : str
+        Data interval
+    source : str
+        Data source
+
+    Returns
+    -------
+    str
+        A unique cache key
+
+    Examples
+    --------
+    >>> key = generate_cache_key("AAPL", "2024-01-01", "2024-12-31")
+    >>> len(key)
+    64
+    """
+    parts = [
+        symbol.upper(),
+        str(start_date) if start_date else "none",
+        str(end_date) if end_date else "none",
+        interval,
+        source,
+    ]
+    key_str = ":".join(parts)
+    return hashlib.sha256(key_str.encode()).hexdigest()
+
+
+class SQLiteCache:
+    """SQLite-based cache for market data.
+
+    Provides persistent caching with TTL support, automatic cleanup
+    of expired entries, and thread-safe operations.
+
+    Parameters
+    ----------
+    config : CacheConfig | None
+        Cache configuration. Uses DEFAULT_CACHE_CONFIG if not specified.
+
+    Attributes
+    ----------
+    config : CacheConfig
+        The cache configuration
+    db_path : str
+        Path to the SQLite database (":memory:" for in-memory)
+
+    Examples
+    --------
+    >>> cache = SQLiteCache()
+    >>> cache.set("key1", {"price": 150.0}, ttl=3600)
+    >>> cache.get("key1")
+    {'price': 150.0}
+    """
+
+    def __init__(self, config: CacheConfig | None = None) -> None:
+        self.config = config or DEFAULT_CACHE_CONFIG
+        self.db_path = self.config.db_path or ":memory:"
+        self._local = threading.local()
+        self._lock = threading.Lock()
+
+        logger.debug(
+            "Initializing SQLite cache",
+            db_path=self.db_path,
+            ttl_seconds=self.config.ttl_seconds,
+            max_entries=self.config.max_entries,
+        )
+
+        self._init_db()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get a thread-local database connection."""
+        if not hasattr(self._local, "connection") or self._local.connection is None:
+            if self.db_path != ":memory:":
+                Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+
+            self._local.connection = sqlite3.connect(
+                self.db_path,
+                check_same_thread=False,
+                timeout=30.0,
+            )
+            self._local.connection.row_factory = sqlite3.Row
+
+        return self._local.connection
+
+    @contextmanager
+    def _transaction(self) -> Generator[sqlite3.Connection, None, None]:
+        """Context manager for database transactions.
+
+        Yields
+        ------
+        sqlite3.Connection
+            The database connection with an active transaction.
+
+        Raises
+        ------
+        CacheError
+            If the transaction fails.
+        """
+        conn = self._get_connection()
+        try:
+            yield conn
+            conn.commit()
+        except sqlite3.Error as e:
+            conn.rollback()
+            raise CacheError(
+                f"Database transaction failed: {e}",
+                operation="transaction",
+                cause=e,
+            ) from e
+
+    def _init_db(self) -> None:
+        """Initialize the database schema."""
+        with self._transaction() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS cache (
+                    key TEXT PRIMARY KEY,
+                    value BLOB NOT NULL,
+                    value_type TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    metadata TEXT
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_expires_at
+                ON cache (expires_at)
+            """)
+
+        logger.debug("Cache database initialized")
+
+    def get(self, key: str) -> Any | None:
+        """Get a value from the cache.
+
+        Parameters
+        ----------
+        key : str
+            The cache key
+
+        Returns
+        -------
+        Any | None
+            The cached value, or None if not found or expired
+
+        Examples
+        --------
+        >>> cache.get("nonexistent_key")
+        None
+        """
+        logger.debug("Cache get", key=key[:16] + "...")
+
+        try:
+            with self._transaction() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT value, value_type, expires_at
+                    FROM cache
+                    WHERE key = ?
+                    """,
+                    (key,),
+                )
+                row = cursor.fetchone()
+
+                if row is None:
+                    logger.debug("Cache miss", key=key[:16] + "...")
+                    return None
+
+                expires_at = datetime.fromisoformat(row["expires_at"])
+                if expires_at < datetime.now(UTC):
+                    logger.debug("Cache expired", key=key[:16] + "...")
+                    # Delete expired entry
+                    conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+                    return None
+
+                value = self._deserialize(row["value"], row["value_type"])
+                logger.debug("Cache hit", key=key[:16] + "...")
+                return value
+
+        except CacheError:
+            raise
+        except Exception as e:
+            logger.error("Cache get failed", key=key[:16] + "...", error=str(e))
+            raise CacheError(
+                f"Failed to get cache entry: {e}",
+                operation="get",
+                key=key,
+                cause=e,
+            ) from e
+
+    def set(
+        self,
+        key: str,
+        value: Any,
+        ttl: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Set a value in the cache.
+
+        Parameters
+        ----------
+        key : str
+            The cache key
+        value : Any
+            The value to cache
+        ttl : int | None
+            Time-to-live in seconds. Uses config.ttl_seconds if not specified.
+        metadata : dict[str, Any] | None
+            Optional metadata to store with the entry
+
+        Examples
+        --------
+        >>> cache.set("key1", {"data": [1, 2, 3]}, ttl=7200)
+        """
+        if ttl is None:
+            ttl = self.config.ttl_seconds
+
+        logger.debug(
+            "Cache set",
+            key=key[:16] + "...",
+            ttl_seconds=ttl,
+            value_type=type(value).__name__,
+        )
+
+        try:
+            now = datetime.now(UTC)
+            expires_at = now + timedelta(seconds=ttl)
+            serialized, value_type = self._serialize(value)
+            metadata_json = json.dumps(metadata) if metadata else None
+
+            with self._lock, self._transaction() as conn:
+                # Check entry count and cleanup if needed
+                cursor = conn.execute("SELECT COUNT(*) as count FROM cache")
+                count = cursor.fetchone()["count"]
+
+                if count >= self.config.max_entries:
+                    logger.debug(
+                        "Max entries reached, cleaning up",
+                        current=count,
+                        max=self.config.max_entries,
+                    )
+                    self._cleanup_oldest(conn, count - self.config.max_entries + 1)
+
+                # Insert or replace the entry
+                conn.execute(
+                    """
+                        INSERT OR REPLACE INTO cache
+                        (key, value, value_type, created_at, expires_at, metadata)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                    (
+                        key,
+                        serialized,
+                        value_type,
+                        now.isoformat(),
+                        expires_at.isoformat(),
+                        metadata_json,
+                    ),
+                )
+
+            logger.debug("Cache entry stored", key=key[:16] + "...")
+
+        except CacheError:
+            raise
+        except Exception as e:
+            logger.error("Cache set failed", key=key[:16] + "...", error=str(e))
+            raise CacheError(
+                f"Failed to set cache entry: {e}",
+                operation="set",
+                key=key,
+                cause=e,
+            ) from e
+
+    def delete(self, key: str) -> bool:
+        """Delete an entry from the cache.
+
+        Parameters
+        ----------
+        key : str
+            The cache key
+
+        Returns
+        -------
+        bool
+            True if an entry was deleted, False otherwise
+
+        Examples
+        --------
+        >>> cache.delete("key1")
+        True
+        """
+        logger.debug("Cache delete", key=key[:16] + "...")
+
+        try:
+            with self._transaction() as conn:
+                cursor = conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+                deleted = cursor.rowcount > 0
+
+            if deleted:
+                logger.debug("Cache entry deleted", key=key[:16] + "...")
+            else:
+                logger.debug("Cache entry not found", key=key[:16] + "...")
+
+            return deleted
+
+        except Exception as e:
+            logger.error("Cache delete failed", key=key[:16] + "...", error=str(e))
+            raise CacheError(
+                f"Failed to delete cache entry: {e}",
+                operation="delete",
+                key=key,
+                cause=e,
+            ) from e
+
+    def clear(self) -> int:
+        """Clear all entries from the cache.
+
+        Returns
+        -------
+        int
+            Number of entries cleared
+
+        Examples
+        --------
+        >>> cache.clear()
+        5
+        """
+        logger.info("Clearing cache")
+
+        try:
+            with self._lock, self._transaction() as conn:
+                cursor = conn.execute("SELECT COUNT(*) as count FROM cache")
+                count = cursor.fetchone()["count"]
+                conn.execute("DELETE FROM cache")
+
+            logger.info("Cache cleared", entries_removed=count)
+            return count
+
+        except Exception as e:
+            logger.error("Cache clear failed", error=str(e))
+            raise CacheError(
+                f"Failed to clear cache: {e}",
+                operation="clear",
+                cause=e,
+            ) from e
+
+    def cleanup_expired(self) -> int:
+        """Remove all expired entries from the cache.
+
+        Returns
+        -------
+        int
+            Number of entries removed
+
+        Examples
+        --------
+        >>> cache.cleanup_expired()
+        3
+        """
+        logger.debug("Cleaning up expired cache entries")
+
+        try:
+            now = datetime.now(UTC).isoformat()
+
+            with self._lock, self._transaction() as conn:
+                cursor = conn.execute(
+                    "SELECT COUNT(*) as count FROM cache WHERE expires_at < ?",
+                    (now,),
+                )
+                expired_count = cursor.fetchone()["count"]
+
+                if expired_count > 0:
+                    conn.execute(
+                        "DELETE FROM cache WHERE expires_at < ?",
+                        (now,),
+                    )
+
+            logger.debug("Expired entries cleaned up", count=expired_count)
+            return expired_count
+
+        except Exception as e:
+            logger.error("Cache cleanup failed", error=str(e))
+            raise CacheError(
+                f"Failed to cleanup expired entries: {e}",
+                operation="cleanup_expired",
+                cause=e,
+            ) from e
+
+    def _cleanup_oldest(self, conn: sqlite3.Connection, count: int) -> None:
+        """Remove the oldest entries to make room for new ones."""
+        conn.execute(
+            """
+            DELETE FROM cache
+            WHERE key IN (
+                SELECT key FROM cache
+                ORDER BY created_at ASC
+                LIMIT ?
+            )
+            """,
+            (count,),
+        )
+
+    def _serialize(self, value: Any) -> tuple[bytes, str]:
+        """Serialize a value for storage."""
+        if isinstance(value, pd.DataFrame):
+            return pickle.dumps(value), "dataframe"
+        elif isinstance(value, pd.Series):
+            return pickle.dumps(value), "series"
+        elif isinstance(value, (dict, list)):
+            return json.dumps(value).encode(), "json"
+        else:
+            return pickle.dumps(value), "pickle"
+
+    def _deserialize(self, data: bytes, value_type: str) -> Any:
+        """Deserialize a stored value."""
+        if value_type in ("dataframe", "series", "pickle"):
+            return pickle.loads(data)  # nosec B301
+        elif value_type == "json":
+            return json.loads(data.decode())
+        else:
+            return pickle.loads(data)  # nosec B301
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get cache statistics.
+
+        Returns
+        -------
+        dict[str, Any]
+            Cache statistics including entry count, size, etc.
+
+        Examples
+        --------
+        >>> cache.get_stats()
+        {'total_entries': 10, 'expired_entries': 2, ...}
+        """
+        try:
+            now = datetime.now(UTC).isoformat()
+
+            with self._transaction() as conn:
+                cursor = conn.execute("SELECT COUNT(*) as count FROM cache")
+                total = cursor.fetchone()["count"]
+
+                cursor = conn.execute(
+                    "SELECT COUNT(*) as count FROM cache WHERE expires_at < ?",
+                    (now,),
+                )
+                expired = cursor.fetchone()["count"]
+
+            return {
+                "total_entries": total,
+                "expired_entries": expired,
+                "active_entries": total - expired,
+                "max_entries": self.config.max_entries,
+                "ttl_seconds": self.config.ttl_seconds,
+                "db_path": self.db_path,
+            }
+
+        except Exception as e:
+            logger.error("Failed to get cache stats", error=str(e))
+            return {"error": str(e)}
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if hasattr(self._local, "connection") and self._local.connection:
+            self._local.connection.close()
+            self._local.connection = None
+            logger.debug("Cache connection closed")
+
+    def __enter__(self) -> "SQLiteCache":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        return f"SQLiteCache(db_path={self.db_path!r}, ttl={self.config.ttl_seconds}s)"
+
+
+# Global cache instance (lazy initialization)
+_global_cache: SQLiteCache | None = None
+_global_cache_lock = threading.Lock()
+
+
+def get_cache(config: CacheConfig | None = None) -> SQLiteCache:
+    """Get or create the global cache instance.
+
+    Parameters
+    ----------
+    config : CacheConfig | None
+        Cache configuration. Only used on first call.
+
+    Returns
+    -------
+    SQLiteCache
+        The global cache instance
+
+    Examples
+    --------
+    >>> cache = get_cache()
+    >>> cache.set("key", "value")
+    """
+    global _global_cache
+
+    with _global_cache_lock:
+        if _global_cache is None:
+            _global_cache = SQLiteCache(config)
+            logger.info("Global cache initialized")
+
+    return _global_cache
+
+
+def reset_cache() -> None:
+    """Reset the global cache instance.
+
+    This closes the existing cache and allows a new one to be created.
+    """
+    global _global_cache
+
+    with _global_cache_lock:
+        if _global_cache is not None:
+            _global_cache.close()
+            _global_cache = None
+            logger.info("Global cache reset")
+
+
+def create_persistent_cache(
+    db_path: str | Path | None = None,
+    ttl_seconds: int = 86400,
+    max_entries: int = 10000,
+) -> SQLiteCache:
+    """Create a persistent file-based cache.
+
+    This is a convenience function for creating a cache with file-based
+    storage for persistent data retention across sessions.
+
+    Parameters
+    ----------
+    db_path : str | Path | None
+        Path to the SQLite database file.
+        If None, uses the default path: data/cache/market_data.db
+    ttl_seconds : int
+        Time-to-live for cache entries in seconds (default: 86400 = 24 hours)
+    max_entries : int
+        Maximum number of cache entries (default: 10000)
+
+    Returns
+    -------
+    SQLiteCache
+        A configured cache instance with file-based storage
+
+    Examples
+    --------
+    >>> cache = create_persistent_cache()
+    >>> cache.set("AAPL_data", df)
+
+    >>> cache = create_persistent_cache(db_path="/custom/path/cache.db")
+    """
+    if db_path is None:
+        db_path = DEFAULT_CACHE_DB_PATH
+
+    config = CacheConfig(
+        enabled=True,
+        ttl_seconds=ttl_seconds,
+        max_entries=max_entries,
+        db_path=str(db_path),
+    )
+
+    logger.info(
+        "Creating persistent cache",
+        db_path=str(db_path),
+        ttl_seconds=ttl_seconds,
+        max_entries=max_entries,
+    )
+
+    return SQLiteCache(config)
+
+
+__all__ = [
+    "DEFAULT_CACHE_CONFIG",
+    "DEFAULT_CACHE_DB_PATH",
+    "PERSISTENT_CACHE_CONFIG",
+    "SQLiteCache",
+    "create_persistent_cache",
+    "generate_cache_key",
+    "get_cache",
+    "reset_cache",
+]

--- a/src/market/cache/types.py
+++ b/src/market/cache/types.py
@@ -1,0 +1,73 @@
+"""Type definitions for the market.cache package.
+
+This module provides type definitions for cache operations including:
+- Cache configuration dataclass
+"""
+
+from dataclasses import dataclass
+
+__all__ = [
+    "CacheConfig",
+]
+
+
+@dataclass(frozen=True)
+class CacheConfig:
+    """Configuration for cache behavior.
+
+    This is an immutable configuration dataclass that defines how caching
+    should behave in the market package.
+
+    Parameters
+    ----------
+    enabled : bool
+        Whether caching is enabled (default: True)
+    ttl_seconds : int
+        Time-to-live for cache entries in seconds (default: 3600).
+        Must be a positive integer.
+    max_entries : int
+        Maximum number of cache entries (default: 1000).
+        Must be a positive integer.
+    db_path : str | None
+        Path to SQLite database file (default: None, uses in-memory).
+        When None, an in-memory SQLite database is used.
+
+    Examples
+    --------
+    >>> config = CacheConfig(ttl_seconds=7200, max_entries=500)
+    >>> config.ttl_seconds
+    7200
+
+    >>> # In-memory cache (default)
+    >>> config = CacheConfig()
+    >>> config.db_path is None
+    True
+
+    >>> # Persistent cache
+    >>> config = CacheConfig(db_path="/path/to/cache.db")
+    >>> config.db_path
+    '/path/to/cache.db'
+
+    Notes
+    -----
+    This dataclass is frozen (immutable) to ensure thread-safety and
+    prevent accidental modification of cache configuration during runtime.
+    """
+
+    enabled: bool = True
+    ttl_seconds: int = 3600
+    max_entries: int = 1000
+    db_path: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate configuration values after initialization.
+
+        Raises
+        ------
+        ValueError
+            If ttl_seconds or max_entries is not positive
+        """
+        if self.ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be positive, got {self.ttl_seconds}")
+        if self.max_entries <= 0:
+            raise ValueError(f"max_entries must be positive, got {self.max_entries}")

--- a/src/market/errors.py
+++ b/src/market/errors.py
@@ -29,6 +29,7 @@ class ErrorCode(str, Enum):
     UNKNOWN = "UNKNOWN"
     EXPORT_ERROR = "EXPORT_ERROR"
     INVALID_PARAMETER = "INVALID_PARAMETER"
+    CACHE_ERROR = "CACHE_ERROR"
 
 
 class MarketError(Exception):
@@ -181,7 +182,58 @@ class ExportError(MarketError):
         self.path = path
 
 
+class CacheError(MarketError):
+    """Exception raised when cache operations fail.
+
+    This exception is raised for errors during cache read, write,
+    or management operations.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message
+    operation : str | None
+        The cache operation that failed (e.g., "get", "set", "delete")
+    key : str | None
+        The cache key involved in the operation
+    code : ErrorCode
+        Error code (defaults to CACHE_ERROR)
+    details : dict[str, Any] | None
+        Additional context
+    cause : Exception | None
+        The underlying exception
+
+    Examples
+    --------
+    >>> raise CacheError(
+    ...     "Failed to write cache entry",
+    ...     operation="set",
+    ...     key="AAPL_data",
+    ... )
+    """
+
+    def __init__(
+        self,
+        message: str,
+        operation: str | None = None,
+        key: str | None = None,
+        code: ErrorCode = ErrorCode.CACHE_ERROR,
+        details: dict[str, Any] | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        details = details or {}
+        if operation:
+            details["operation"] = operation
+        if key:
+            details["key"] = key
+
+        super().__init__(message, code=code, details=details, cause=cause)
+        self.operation = operation
+        self.key = key
+
+
 __all__ = [
+    "CacheError",
     "ErrorCode",
     "ExportError",
     "MarketError",

--- a/tests/market/unit/cache/__init__.py
+++ b/tests/market/unit/cache/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for market.cache module."""

--- a/tests/market/unit/cache/test_cache.py
+++ b/tests/market/unit/cache/test_cache.py
@@ -1,0 +1,276 @@
+"""Tests for market.cache module.
+
+このモジュールは市場データ用のSQLiteベースキャッシュ機能をテストします。
+
+テスト対象:
+- generate_cache_key: キャッシュキーの生成
+- SQLiteCache: SQLiteベースのキャッシュクラス
+- get_cache/reset_cache: グローバルキャッシュ管理
+- create_persistent_cache: 永続キャッシュの作成
+"""
+
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from market.cache import (
+    DEFAULT_CACHE_DB_PATH,
+    PERSISTENT_CACHE_CONFIG,
+    CacheConfig,
+    SQLiteCache,
+    create_persistent_cache,
+    generate_cache_key,
+    get_cache,
+    reset_cache,
+)
+
+
+class TestGenerateCacheKey:
+    """generate_cache_key関数のテスト。
+
+    キャッシュキー生成の一貫性、一意性、形式を検証します。
+    """
+
+    def test_正常系_同じ入力で一貫したキー生成(self) -> None:
+        """同じパラメータで呼び出すと同じキーが生成されることを確認。"""
+        key1 = generate_cache_key("AAPL", "2024-01-01", "2024-12-31")
+        key2 = generate_cache_key("AAPL", "2024-01-01", "2024-12-31")
+        assert key1 == key2
+
+    def test_正常系_異なるシンボルで異なるキー生成(self) -> None:
+        """異なるシンボルでは異なるキーが生成されることを確認。"""
+        key1 = generate_cache_key("AAPL", "2024-01-01", "2024-12-31")
+        key2 = generate_cache_key("GOOGL", "2024-01-01", "2024-12-31")
+        assert key1 != key2
+
+    def test_正常系_キー長が64文字のSHA256ハッシュ(self) -> None:
+        """生成されたキーがSHA256ハッシュ（64文字）であることを確認。"""
+        key = generate_cache_key("AAPL")
+        assert len(key) == 64
+
+
+class TestSQLiteCache:
+    """SQLiteCacheクラスのテスト。
+
+    SQLiteベースのキャッシュの基本操作、TTL処理、エントリ管理を検証します。
+    """
+
+    @pytest.fixture
+    def cache(self) -> Generator[SQLiteCache, None, None]:
+        """テスト用のインメモリキャッシュインスタンスを作成。"""
+        config = CacheConfig(
+            enabled=True,
+            ttl_seconds=3600,
+            max_entries=100,
+            db_path=None,  # In-memory
+        )
+        cache_instance = SQLiteCache(config)
+        yield cache_instance
+        cache_instance.close()
+
+    # =========================================================================
+    # 基本操作テスト
+    # =========================================================================
+
+    def test_正常系_存在しないキーでNone返却(self, cache: SQLiteCache) -> None:
+        """存在しないキーに対してgetがNoneを返すことを確認。"""
+        assert cache.get("nonexistent") is None
+
+    def test_正常系_setとgetの基本操作(self, cache: SQLiteCache) -> None:
+        """setした値をgetで取得できることを確認。"""
+        cache.set("key1", {"price": 150.0})
+        result = cache.get("key1")
+        assert result == {"price": 150.0}
+
+    def test_正常系_リストのシリアライズとデシリアライズ(
+        self, cache: SQLiteCache
+    ) -> None:
+        """リスト値の保存と取得が正しく動作することを確認。"""
+        cache.set("key1", [1, 2, 3])
+        result = cache.get("key1")
+        assert result == [1, 2, 3]
+
+    def test_正常系_DataFrameのシリアライズとデシリアライズ(
+        self, cache: SQLiteCache
+    ) -> None:
+        """DataFrameの保存と取得が正しく動作することを確認。"""
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        cache.set("df_key", df)
+        result = cache.get("df_key")
+        pd.testing.assert_frame_equal(result, df)
+
+    # =========================================================================
+    # TTL（有効期限）テスト
+    # =========================================================================
+
+    def test_正常系_TTL期限切れでNone返却(self) -> None:
+        """TTL期限切れ後にgetがNoneを返すことを確認。"""
+        config = CacheConfig(ttl_seconds=1)  # 1秒のTTL
+        with SQLiteCache(config) as cache:
+            cache.set("key1", "value1")
+            assert cache.get("key1") == "value1"
+
+            time.sleep(1.1)  # 期限切れを待つ
+            assert cache.get("key1") is None
+
+    # =========================================================================
+    # 削除操作テスト
+    # =========================================================================
+
+    def test_正常系_deleteでエントリ削除(self, cache: SQLiteCache) -> None:
+        """deleteでエントリが削除されることを確認。"""
+        cache.set("key1", "value1")
+        assert cache.get("key1") == "value1"
+
+        deleted = cache.delete("key1")
+        assert deleted is True
+        assert cache.get("key1") is None
+
+    def test_正常系_存在しないキーのdeleteでFalse(self, cache: SQLiteCache) -> None:
+        """存在しないキーに対するdeleteがFalseを返すことを確認。"""
+        deleted = cache.delete("nonexistent")
+        assert deleted is False
+
+    def test_正常系_clearで全エントリ削除(self, cache: SQLiteCache) -> None:
+        """clearで全エントリが削除されることを確認。"""
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+
+        count = cache.clear()
+        assert count == 2
+        assert cache.get("key1") is None
+        assert cache.get("key2") is None
+
+    def test_正常系_cleanup_expiredで期限切れエントリのみ削除(self) -> None:
+        """cleanup_expiredが期限切れエントリのみを削除することを確認。"""
+        config = CacheConfig(ttl_seconds=1)
+        with SQLiteCache(config) as cache:
+            cache.set("key1", "value1")
+            time.sleep(1.1)  # key1を期限切れにする
+            cache.set("key2", "value2", ttl=3600)  # key2は長いTTL
+
+            removed = cache.cleanup_expired()
+            assert removed == 1
+            assert cache.get("key1") is None
+            assert cache.get("key2") == "value2"
+
+    # =========================================================================
+    # エントリ制限テスト
+    # =========================================================================
+
+    def test_正常系_max_entries超過で古いエントリ削除(self) -> None:
+        """max_entries超過時に古いエントリが削除されることを確認。"""
+        config = CacheConfig(max_entries=3)
+        with SQLiteCache(config) as cache:
+            cache.set("key1", "value1")
+            cache.set("key2", "value2")
+            cache.set("key3", "value3")
+            cache.set("key4", "value4")  # クリーンアップをトリガー
+
+            stats = cache.get_stats()
+            assert stats["total_entries"] <= 3
+
+    # =========================================================================
+    # 統計情報テスト
+    # =========================================================================
+
+    def test_正常系_get_statsで正しい統計情報返却(self, cache: SQLiteCache) -> None:
+        """get_statsが正しい統計情報を返すことを確認。"""
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+
+        stats = cache.get_stats()
+        assert stats["total_entries"] == 2
+        assert stats["active_entries"] == 2
+        assert stats["expired_entries"] == 0
+        assert "max_entries" in stats
+
+    # =========================================================================
+    # コンテキストマネージャテスト
+    # =========================================================================
+
+    def test_正常系_コンテキストマネージャとして動作(self) -> None:
+        """withステートメントでキャッシュが正常に動作することを確認。"""
+        with SQLiteCache() as cache:
+            cache.set("key", "value")
+            assert cache.get("key") == "value"
+
+
+class TestGlobalCache:
+    """グローバルキャッシュ関数のテスト。
+
+    get_cacheとreset_cacheのシングルトンパターンを検証します。
+    """
+
+    def teardown_method(self) -> None:
+        """各テスト後にグローバルキャッシュをリセット。"""
+        reset_cache()
+
+    def test_正常系_get_cacheでシングルトン取得(self) -> None:
+        """get_cacheが同じインスタンスを返すことを確認。"""
+        cache1 = get_cache()
+        cache2 = get_cache()
+        assert cache1 is cache2
+
+    def test_正常系_reset_cacheで新インスタンス作成(self) -> None:
+        """reset_cache後に新しいインスタンスが作成されることを確認。"""
+        cache1 = get_cache()
+        cache1.set("key", "value")
+
+        reset_cache()
+        cache2 = get_cache()
+
+        assert cache1 is not cache2
+        assert cache2.get("key") is None
+
+
+class TestPersistentCache:
+    """永続キャッシュ機能のテスト。
+
+    ファイルベースの永続キャッシュ作成と設定を検証します。
+    """
+
+    def test_正常系_create_persistent_cacheでファイルベースキャッシュ作成(
+        self, tmp_path: Path
+    ) -> None:
+        """create_persistent_cacheがファイルベースのキャッシュを作成することを確認。"""
+        cache = create_persistent_cache(db_path=tmp_path / "test_cache.db")
+
+        cache.set("key1", "value1")
+        assert cache.get("key1") == "value1"
+        cache.close()
+
+    def test_正常系_カスタムTTL設定(self, tmp_path: Path) -> None:
+        """create_persistent_cacheでカスタムTTLを設定できることを確認。"""
+        cache = create_persistent_cache(
+            db_path=tmp_path / "test_cache.db",
+            ttl_seconds=7200,
+        )
+
+        assert cache.config.ttl_seconds == 7200
+        cache.close()
+
+    def test_正常系_親ディレクトリ自動作成(self, tmp_path: Path) -> None:
+        """create_persistent_cacheが親ディレクトリを自動作成することを確認。"""
+        cache_path = tmp_path / "subdir" / "nested" / "cache.db"
+        cache = create_persistent_cache(db_path=cache_path)
+
+        cache.set("key", "value")
+        assert cache_path.parent.exists()
+        cache.close()
+
+    def test_正常系_PERSISTENT_CACHE_CONFIGの値確認(self) -> None:
+        """PERSISTENT_CACHE_CONFIGが正しい値を持つことを確認。"""
+        assert PERSISTENT_CACHE_CONFIG.enabled is True
+        assert PERSISTENT_CACHE_CONFIG.ttl_seconds == 86400  # 24時間
+        assert PERSISTENT_CACHE_CONFIG.max_entries == 10000
+        assert PERSISTENT_CACHE_CONFIG.db_path is not None
+
+    def test_正常系_DEFAULT_CACHE_DB_PATHの値確認(self) -> None:
+        """DEFAULT_CACHE_DB_PATHが正しく設定されていることを確認。"""
+        assert DEFAULT_CACHE_DB_PATH.name == "market_data.db"
+        assert "data" in DEFAULT_CACHE_DB_PATH.parts
+        assert "cache" in DEFAULT_CACHE_DB_PATH.parts


### PR DESCRIPTION
## 概要

`market_analysis/utils/cache.py` を新パッケージ `market/cache/` に移植しました。

- SQLite ベースのキャッシュ実装（インメモリ/ファイルベース対応）
- TTL（有効期限）対応
- スレッドセーフ操作
- 自動期限切れエントリ削除
- グローバルキャッシュシングルトン

## 変更内容

### 新規作成
| ファイル | 説明 |
|---------|------|
| `src/market/cache/types.py` | `CacheConfig` dataclass |
| `src/market/cache/cache.py` | `SQLiteCache` 実装 |
| `src/market/cache/__init__.py` | 公開API定義 |
| `tests/market/unit/cache/test_cache.py` | 22テストケース |

### 変更
| ファイル | 変更内容 |
|---------|----------|
| `src/market/errors.py` | `CacheError`, `CACHE_ERROR` を追加 |
| `src/market/__init__.py` | `CacheError` をエクスポート |

## テストプラン

- [x] `make check-all` が通過
- [x] テストカバレッジ 84.27%（目標 80% 以上）
- [x] 22 テストケース全てパス

## 関連

- Closes #945
- Phase: Phase 1
- 計画書: docs/project/python-packages-refactoring.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)