### PR TITLE
[Phase1] フォーマット変換ユーティリティ作成 (#951)

### DIFF
--- a/src/database/types.py
+++ b/src/database/types.py
@@ -1,7 +1,10 @@
 """Common type definitions for the finance package."""
 
 from collections.abc import Mapping
-from typing import Literal, TypedDict
+from pathlib import Path
+from typing import Annotated, Literal, Self, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Database types
 type DatabaseType = Literal["sqlite", "duckdb"]
@@ -47,3 +50,345 @@ type JSONObject = Mapping[str, JSONValue]
 # Log types
 type LogFormat = Literal["json", "console", "plain"]
 type LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+# Compression types for Parquet
+type ParquetCompression = Literal["snappy", "gzip", "brotli", "lz4", "zstd", "none"]
+
+# JSON orient types
+type JsonOrient = Literal["records", "columns", "index", "split", "table", "values"]
+
+# Date format types
+type DateFormat = Literal["iso", "epoch", "epoch_ms"]
+
+
+# =============================================================================
+# Pydantic Models for Format Conversion (Issue #951)
+# =============================================================================
+
+
+class TypeMapping(BaseModel):
+    """Data type mapping information for a column.
+
+    Represents the type transformation applied to a single column
+    during format conversion between Parquet and JSON.
+
+    Parameters
+    ----------
+    column_name : str
+        Name of the column being mapped.
+    source_type : str
+        Original data type before conversion (e.g., "int64", "string").
+    target_type : str
+        Data type after conversion (e.g., "integer", "string").
+
+    Examples
+    --------
+    >>> mapping = TypeMapping(
+    ...     column_name="user_id",
+    ...     source_type="int64",
+    ...     target_type="integer"
+    ... )
+    >>> mapping.column_name
+    'user_id'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    column_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Name of the column being mapped",
+    )
+    source_type: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Original data type before conversion",
+    )
+    target_type: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Data type after conversion",
+    )
+
+    @field_validator("column_name")
+    @classmethod
+    def validate_column_name(cls, v: str) -> str:
+        """Validate that column name is not empty after stripping whitespace."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Column name cannot be empty or whitespace only")
+        return stripped
+
+
+class ConversionOptions(BaseModel):
+    """Configuration options for format conversion.
+
+    Controls how data is transformed during Parquet/JSON conversion,
+    including compression, JSON structure, and type inference settings.
+
+    Parameters
+    ----------
+    compression : ParquetCompression | None, default=None
+        Compression algorithm for Parquet output.
+        Options: "snappy", "gzip", "brotli", "lz4", "zstd", "none".
+        If None, uses Parquet default (typically snappy).
+    orient : JsonOrient, default="records"
+        JSON output structure format.
+        Options: "records", "columns", "index", "split", "table", "values".
+    date_format : DateFormat, default="iso"
+        Format for datetime serialization.
+        Options: "iso" (ISO 8601), "epoch" (seconds), "epoch_ms" (milliseconds).
+    infer_types : bool, default=True
+        Whether to automatically infer data types during conversion.
+
+    Examples
+    --------
+    >>> options = ConversionOptions(compression="gzip", orient="records")
+    >>> options.infer_types
+    True
+
+    >>> options = ConversionOptions(date_format="epoch", infer_types=False)
+    >>> options.date_format
+    'epoch'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    compression: Annotated[
+        Literal["snappy", "gzip", "brotli", "lz4", "zstd", "none"] | None,
+        Field(
+            default=None,
+            description="Compression algorithm for Parquet output",
+        ),
+    ] = None
+
+    orient: Annotated[
+        Literal["records", "columns", "index", "split", "table", "values"],
+        Field(
+            default="records",
+            description="JSON output structure format",
+        ),
+    ] = "records"
+
+    date_format: Annotated[
+        Literal["iso", "epoch", "epoch_ms"],
+        Field(
+            default="iso",
+            description="Format for datetime serialization",
+        ),
+    ] = "iso"
+
+    infer_types: Annotated[
+        bool,
+        Field(
+            default=True,
+            description="Whether to automatically infer data types",
+        ),
+    ] = True
+
+
+class ConversionResult(BaseModel):
+    """Result of a format conversion operation.
+
+    Contains comprehensive information about a completed format conversion,
+    including success status, file paths, row counts, and any error details.
+
+    Parameters
+    ----------
+    success : bool
+        Whether the conversion completed successfully.
+    input_path : Path
+        Path to the source file that was converted.
+    output_path : Path
+        Path to the generated output file.
+    rows_converted : int
+        Number of data rows that were converted.
+    columns : list[str]
+        List of column names in the converted data.
+    error_message : str | None, default=None
+        Error message if conversion failed, None otherwise.
+    type_mappings : list[TypeMapping] | None, default=None
+        Optional list of type transformations applied to columns.
+
+    Examples
+    --------
+    >>> result = ConversionResult(
+    ...     success=True,
+    ...     input_path=Path("data.parquet"),
+    ...     output_path=Path("data.json"),
+    ...     rows_converted=1000,
+    ...     columns=["id", "name", "value"]
+    ... )
+    >>> result.success
+    True
+    >>> result.rows_converted
+    1000
+
+    >>> # Failed conversion
+    >>> result = ConversionResult(
+    ...     success=False,
+    ...     input_path=Path("invalid.parquet"),
+    ...     output_path=Path("output.json"),
+    ...     rows_converted=0,
+    ...     columns=[],
+    ...     error_message="Invalid Parquet file format"
+    ... )
+    >>> result.error_message
+    'Invalid Parquet file format'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    success: bool = Field(
+        ...,
+        description="Whether the conversion completed successfully",
+    )
+    input_path: Path = Field(
+        ...,
+        description="Path to the source file that was converted",
+    )
+    output_path: Path = Field(
+        ...,
+        description="Path to the generated output file",
+    )
+    rows_converted: Annotated[
+        int,
+        Field(
+            ...,
+            ge=0,
+            description="Number of data rows that were converted",
+        ),
+    ]
+    columns: list[str] = Field(
+        ...,
+        description="List of column names in the converted data",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error message if conversion failed",
+    )
+    type_mappings: list[TypeMapping] | None = Field(
+        default=None,
+        description="Optional list of type transformations applied",
+    )
+
+    @field_validator("columns")
+    @classmethod
+    def validate_columns(cls, v: list[str]) -> list[str]:
+        """Validate column names are not empty strings."""
+        for col in v:
+            if not col or not col.strip():
+                raise ValueError("Column names cannot be empty or whitespace only")
+        return v
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> Self:
+        """Validate that success status is consistent with other fields."""
+        if self.success:
+            if self.error_message is not None:
+                raise ValueError("error_message must be None when success is True")
+            if self.rows_converted < 0:
+                raise ValueError(
+                    "rows_converted must be non-negative when success is True"
+                )
+        elif self.error_message is None:
+            raise ValueError("error_message is required when success is False")
+        return self
+
+    @classmethod
+    def create_success(
+        cls,
+        input_path: Path,
+        output_path: Path,
+        rows_converted: int,
+        columns: list[str],
+        type_mappings: list[TypeMapping] | None = None,
+    ) -> Self:
+        """Factory method to create a successful conversion result.
+
+        Parameters
+        ----------
+        input_path : Path
+            Path to the source file.
+        output_path : Path
+            Path to the output file.
+        rows_converted : int
+            Number of rows converted.
+        columns : list[str]
+            List of column names.
+        type_mappings : list[TypeMapping] | None, default=None
+            Optional type mapping information.
+
+        Returns
+        -------
+        ConversionResult
+            A ConversionResult instance with success=True.
+
+        Examples
+        --------
+        >>> result = ConversionResult.create_success(
+        ...     input_path=Path("data.parquet"),
+        ...     output_path=Path("data.json"),
+        ...     rows_converted=100,
+        ...     columns=["id", "name"]
+        ... )
+        >>> result.success
+        True
+        """
+        return cls(
+            success=True,
+            input_path=input_path,
+            output_path=output_path,
+            rows_converted=rows_converted,
+            columns=columns,
+            error_message=None,
+            type_mappings=type_mappings,
+        )
+
+    @classmethod
+    def create_failure(
+        cls,
+        input_path: Path,
+        output_path: Path,
+        error_message: str,
+    ) -> Self:
+        """Factory method to create a failed conversion result.
+
+        Parameters
+        ----------
+        input_path : Path
+            Path to the source file.
+        output_path : Path
+            Path to the output file.
+        error_message : str
+            Description of what went wrong.
+
+        Returns
+        -------
+        ConversionResult
+            A ConversionResult instance with success=False.
+
+        Examples
+        --------
+        >>> result = ConversionResult.create_failure(
+        ...     input_path=Path("invalid.parquet"),
+        ...     output_path=Path("output.json"),
+        ...     error_message="File not found"
+        ... )
+        >>> result.success
+        False
+        >>> result.error_message
+        'File not found'
+        """
+        return cls(
+            success=False,
+            input_path=input_path,
+            output_path=output_path,
+            rows_converted=0,
+            columns=[],
+            error_message=error_message,
+            type_mappings=None,
+        )

--- a/src/database/utils/format_converter.py
+++ b/src/database/utils/format_converter.py
@@ -1,0 +1,439 @@
+"""Format converter utilities for Parquet/JSON conversion.
+
+Issue #951: Parquet/JSON形式間のフォーマット変換ユーティリティ
+
+このモジュールはParquetファイルとJSONファイル間の相互変換機能を提供する。
+pyarrowを使用してデータ型を正しく保持しながら変換を行う。
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from database.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def parquet_to_json(input_path: Path, output_path: Path) -> bool:
+    """Parquetファイルを読み込み、JSON形式で出力する。
+
+    Parameters
+    ----------
+    input_path : Path
+        入力Parquetファイルのパス
+    output_path : Path
+        出力JSONファイルのパス
+
+    Returns
+    -------
+    bool
+        変換成功時True
+
+    Raises
+    ------
+    FileNotFoundError
+        入力ファイルが存在しない場合
+    ValueError
+        入力ファイルが有効なParquet形式でない場合
+
+    Examples
+    --------
+    >>> parquet_to_json(Path("data.parquet"), Path("data.json"))
+    True
+    """
+    logger.debug(
+        "Starting Parquet to JSON conversion",
+        input_path=str(input_path),
+        output_path=str(output_path),
+    )
+
+    # ファイル存在チェック
+    if not input_path.exists():
+        logger.error(
+            "Input file not found",
+            input_path=str(input_path),
+        )
+        raise FileNotFoundError(f"File not found: {input_path}")
+
+    # Parquetファイルの読み込み
+    try:
+        table = pq.read_table(input_path)
+        logger.debug(
+            "Parquet file loaded",
+            rows=len(table),
+            columns=table.column_names,
+        )
+    except Exception as e:
+        logger.error(
+            "Failed to read Parquet file",
+            input_path=str(input_path),
+            error=str(e),
+        )
+        raise ValueError(f"Invalid Parquet file: {input_path}") from e
+
+    # DataFrameに変換
+    df = table.to_pandas()
+
+    # JSONに変換可能な形式に変換
+    records = _dataframe_to_records(df)
+
+    # 出力ディレクトリを作成
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # JSONファイルに書き込み
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(records, f, ensure_ascii=False, indent=2, default=_json_serializer)
+
+    logger.info(
+        "Parquet to JSON conversion completed",
+        input_path=str(input_path),
+        output_path=str(output_path),
+        rows=len(records),
+    )
+
+    return True
+
+
+def json_to_parquet(input_path: Path, output_path: Path) -> bool:
+    """JSONファイルを読み込み、Parquet形式で出力する。
+
+    Parameters
+    ----------
+    input_path : Path
+        入力JSONファイルのパス
+    output_path : Path
+        出力Parquetファイルのパス
+
+    Returns
+    -------
+    bool
+        変換成功時True
+
+    Raises
+    ------
+    FileNotFoundError
+        入力ファイルが存在しない場合
+    ValueError
+        入力ファイルが有効なJSON形式でない場合
+        データが空の場合
+
+    Examples
+    --------
+    >>> json_to_parquet(Path("data.json"), Path("data.parquet"))
+    True
+    """
+    logger.debug(
+        "Starting JSON to Parquet conversion",
+        input_path=str(input_path),
+        output_path=str(output_path),
+    )
+
+    # ファイル存在チェック
+    if not input_path.exists():
+        logger.error(
+            "Input file not found",
+            input_path=str(input_path),
+        )
+        raise FileNotFoundError(f"File not found: {input_path}")
+
+    # JSONファイルの読み込み
+    try:
+        with open(input_path, encoding="utf-8") as f:
+            data = json.load(f)
+        logger.debug(
+            "JSON file loaded",
+            data_type=type(data).__name__,
+        )
+    except json.JSONDecodeError as e:
+        logger.error(
+            "Failed to parse JSON file",
+            input_path=str(input_path),
+            error=str(e),
+        )
+        raise ValueError(f"Invalid JSON: {input_path}") from e
+
+    # データがリスト形式であることを確認
+    if not isinstance(data, list):
+        logger.error(
+            "JSON data must be a list of records",
+            input_path=str(input_path),
+            actual_type=type(data).__name__,
+        )
+        raise ValueError(
+            f"Invalid JSON: Expected list of records, got {type(data).__name__}"
+        )
+
+    # 空データチェック
+    if len(data) == 0:
+        logger.error(
+            "Empty data in JSON file",
+            input_path=str(input_path),
+        )
+        raise ValueError(f"Empty data: {input_path}")
+
+    # レコードをPyArrow Tableに変換
+    try:
+        table = _records_to_table(data)
+        logger.debug(
+            "Data converted to PyArrow Table",
+            rows=len(table),
+            columns=table.column_names,
+        )
+    except Exception as e:
+        logger.error(
+            "Failed to convert data to PyArrow Table",
+            input_path=str(input_path),
+            error=str(e),
+        )
+        raise ValueError(f"Failed to convert JSON data: {e}") from e
+
+    # 出力ディレクトリを作成
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Parquetファイルに書き込み
+    pq.write_table(table, output_path)
+
+    logger.info(
+        "JSON to Parquet conversion completed",
+        input_path=str(input_path),
+        output_path=str(output_path),
+        rows=len(table),
+    )
+
+    return True
+
+
+def _dataframe_to_records(df: pd.DataFrame) -> list[dict[str, Any]]:
+    """DataFrameをレコードのリストに変換する。
+
+    各行を辞書に変換し、pandas/numpy固有の型をPython標準型に変換する。
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        変換するDataFrame
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        レコードのリスト。各辞書のキーはカラム名、値はPython標準型に変換済み。
+    """
+    records: list[dict[str, Any]] = []
+    for _, row in df.iterrows():
+        record: dict[str, Any] = {}
+        for col in df.columns:
+            value = row[col]
+            # pandas/numpy 型をPython標準型に変換
+            record[col] = _convert_to_python_type(value)
+        records.append(record)
+    return records
+
+
+def _convert_to_python_type(value: Any) -> Any:
+    """pandas/numpy型をPython標準型に変換する。
+
+    pandas/numpyのデータ型（numpy.int64, numpy.float64, pd.Timestamp等）を
+    JSONシリアライズ可能なPython標準型に変換する。ネスト構造（dict, list）も
+    再帰的に処理する。
+
+    Parameters
+    ----------
+    value : Any
+        変換する値。None, pandas/numpy型, dict, list, または標準型。
+
+    Returns
+    -------
+    Any
+        Python標準型に変換された値:
+        - np.integer → int
+        - np.floating → float
+        - np.bool_ → bool
+        - pd.Timestamp/np.datetime64 → ISO 8601文字列
+        - np.ndarray → list
+        - pd.NaT/np.nan → None
+        - dict/list → 再帰的に変換
+    """
+    # None/NaN 処理
+    if pd.isna(value):
+        return None
+
+    # numpy 整数型
+    if isinstance(value, np.integer):
+        return int(value)
+
+    # numpy 浮動小数点型
+    if isinstance(value, np.floating):
+        return float(value)
+
+    # numpy 論理型
+    if isinstance(value, np.bool_):
+        return bool(value)
+
+    # Timestamp 型
+    if isinstance(value, pd.Timestamp):
+        return value.isoformat()
+
+    # datetime64 型
+    if isinstance(value, np.datetime64):
+        return pd.Timestamp(value).isoformat()
+
+    # numpy ndarray (リスト変換)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+
+    # dict型（ネスト構造）
+    if isinstance(value, dict):
+        return {k: _convert_to_python_type(v) for k, v in value.items()}
+
+    # list型（ネスト構造）
+    if isinstance(value, list):
+        return [_convert_to_python_type(item) for item in value]
+
+    return value
+
+
+def _records_to_table(records: list[dict[str, Any]]) -> pa.Table:
+    """レコードのリストをPyArrow Tableに変換する。
+
+    全レコードからカラム名を収集し、各カラムの値を適切なPyArrow型に
+    変換してTableを構築する。異なる型が混在する場合やネスト構造は
+    文字列（JSON）として格納する。
+
+    Parameters
+    ----------
+    records : list[dict[str, Any]]
+        レコードのリスト。各レコードは {column_name: value} の辞書。
+        異なるレコード間でキーが異なっていてもよい。
+
+    Returns
+    -------
+    pa.Table
+        全レコードを含むPyArrow Table。空のリストの場合は空のTableを返す。
+    """
+    if not records:
+        return pa.table({})
+
+    # 全レコードの列名を収集
+    all_columns: set[str] = set()
+    for record in records:
+        all_columns.update(record.keys())
+
+    # 各列のデータを収集
+    columns_data: dict[str, list[Any]] = {col: [] for col in all_columns}
+
+    for record in records:
+        for col in all_columns:
+            value = record.get(col)
+            columns_data[col].append(value)
+
+    # PyArrow 配列に変換
+    arrays = {}
+    for col, values in columns_data.items():
+        # 型を推論して配列を作成
+        arrays[col] = _create_pyarrow_array(values)
+
+    return pa.table(arrays)
+
+
+def _create_pyarrow_array(values: list[Any]) -> pa.Array:
+    """値のリストからPyArrow配列を作成する。
+
+    値の型を分析し、適切なPyArrow型で配列を作成する。
+    - 全てNoneの場合: null配列
+    - ネスト構造(dict/list)が含まれる場合: JSON文字列として格納
+    - 混合型の場合: 全て文字列に変換
+    - 単一型の場合: PyArrowの自動型推論を使用
+
+    Parameters
+    ----------
+    values : list[Any]
+        配列に変換する値のリスト。None値を含んでもよい。
+
+    Returns
+    -------
+    pa.Array
+        PyArrow配列。型は値の内容に応じて自動決定される。
+    """
+    # 非None値の型を確認
+    non_none_values = [v for v in values if v is not None]
+
+    if not non_none_values:
+        # 全てNoneの場合はnull配列
+        return pa.nulls(len(values))
+
+    # 全ての型を収集
+    types_found = set(type(v).__name__ for v in non_none_values)
+
+    # ネスト構造（dict/list）が含まれる場合
+    if any(isinstance(v, (dict, list)) for v in non_none_values):
+        # JSON文字列に変換して格納
+        json_values = [
+            json.dumps(v, ensure_ascii=False, default=_json_serializer)
+            if v is not None
+            else None
+            for v in values
+        ]
+        return pa.array(json_values, type=pa.string())
+
+    # 混合型の場合（異なる型が混在）
+    if len(types_found) > 1:
+        # 全てを文字列に変換
+        str_values = [str(v) if v is not None else None for v in values]
+        return pa.array(str_values, type=pa.string())
+
+    # 単一型の場合はpyarrowの自動推論に任せる
+    try:
+        return pa.array(values)
+    except (pa.ArrowTypeError, pa.ArrowInvalid):
+        # 型推論に失敗した場合は文字列に変換
+        str_values = [str(v) if v is not None else None for v in values]
+        return pa.array(str_values, type=pa.string())
+
+
+def _json_serializer(obj: Any) -> Any:
+    """JSONシリアライズのカスタムハンドラー。
+
+    json.dump()のdefault引数として使用し、標準のJSONエンコーダでは
+    処理できないpandas/numpy型を変換する。
+
+    Parameters
+    ----------
+    obj : Any
+        シリアライズする値。pandas/numpy型が想定される。
+
+    Returns
+    -------
+    Any
+        シリアライズ可能なPython標準型:
+        - pd.Timestamp → ISO 8601文字列
+        - np.datetime64 → ISO 8601文字列
+        - np.integer → int
+        - np.floating → float
+        - np.bool_ → bool
+        - np.ndarray → list
+
+    Raises
+    ------
+    TypeError
+        サポートされていない型の場合。
+    """
+    if isinstance(obj, pd.Timestamp):
+        return obj.isoformat()
+    if isinstance(obj, np.datetime64):
+        return pd.Timestamp(obj).isoformat()
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")

--- a/tests/database/property/__init__.py
+++ b/tests/database/property/__init__.py
@@ -1,0 +1,1 @@
+"""Property-based tests for database package."""

--- a/tests/database/property/utils/__init__.py
+++ b/tests/database/property/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Property-based tests for database.utils package."""

--- a/tests/database/property/utils/test_format_converter_property.py
+++ b/tests/database/property/utils/test_format_converter_property.py
@@ -1,0 +1,157 @@
+"""Property-based tests for format_converter module using Hypothesis.
+
+Issue #951: Parquet/JSON形式間のフォーマット変換ユーティリティ
+
+プロパティテストTODO:
+- [x] test_プロパティ_相互変換でデータが保持される
+- [x] test_プロパティ_変換後の行数が一致する
+- [x] test_プロパティ_変換後の列名が一致する
+"""
+
+import tempfile
+from pathlib import Path
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from database.utils.format_converter import (
+    json_to_parquet,
+    parquet_to_json,
+)
+
+# =============================================================================
+# カスタムストラテジー
+# =============================================================================
+
+# JSON互換の基本型
+json_primitive = (
+    st.none()
+    | st.booleans()
+    | st.integers(min_value=-(2**31), max_value=2**31 - 1)
+    | st.floats(allow_nan=False, allow_infinity=False)
+    | st.text(min_size=0, max_size=50)
+)
+
+
+# テーブル形式のデータ（レコードのリスト）を生成
+# 全レコードが同じキーを持つことを保証
+@st.composite
+def table_data(draw: st.DrawFn) -> list[dict[str, object]]:
+    """テーブル形式のデータ（全レコードが同じスキーマを持つ）を生成。"""
+    # 列名を生成（1〜5列）
+    num_columns = draw(st.integers(min_value=1, max_value=5))
+    column_names = [f"col_{i}" for i in range(num_columns)]
+
+    # 行数を生成（1〜20行）
+    num_rows = draw(st.integers(min_value=1, max_value=20))
+
+    # 各列の値を生成
+    records = []
+    for _ in range(num_rows):
+        record = {}
+        for col_name in column_names:
+            # NoneはParquet変換時に問題になることがあるため除外
+            value = draw(
+                st.integers(min_value=-(2**31), max_value=2**31 - 1)
+                | st.floats(allow_nan=False, allow_infinity=False)
+                | st.text(min_size=0, max_size=20)
+                | st.booleans()
+            )
+            record[col_name] = value
+        records.append(record)
+
+    return records
+
+
+class TestFormatConverterProperty:
+    """フォーマット変換のプロパティベーステスト。"""
+
+    @given(data=table_data())
+    @settings(max_examples=50, deadline=None)
+    def test_プロパティ_相互変換でデータが保持される(
+        self, data: list[dict[str, object]]
+    ) -> None:
+        """JSON -> Parquet -> JSON で元のデータ構造が保持されることを検証。"""
+        import json
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            # 元データをJSONファイルに書き込み
+            json_input = tmpdir_path / "input.json"
+            with open(json_input, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False)
+
+            # JSON -> Parquet
+            parquet_path = tmpdir_path / "converted.parquet"
+            json_to_parquet(json_input, parquet_path)
+
+            # Parquet -> JSON
+            json_output = tmpdir_path / "output.json"
+            parquet_to_json(parquet_path, json_output)
+
+            # 出力データを読み込み
+            with open(json_output, encoding="utf-8") as f:
+                result_data = json.load(f)
+
+            # 行数が一致することを確認
+            assert len(result_data) == len(data)
+
+            # 列名が一致することを確認
+            if data:
+                original_keys = set(data[0].keys())
+                result_keys = set(result_data[0].keys())
+                assert original_keys == result_keys
+
+    @given(data=table_data())
+    @settings(max_examples=30, deadline=None)
+    def test_プロパティ_変換後の行数が一致する(
+        self, data: list[dict[str, object]]
+    ) -> None:
+        """変換後も行数が保持されることを検証。"""
+        import json
+
+        import pyarrow.parquet as pq
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            json_input = tmpdir_path / "input.json"
+            with open(json_input, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False)
+
+            parquet_path = tmpdir_path / "converted.parquet"
+            json_to_parquet(json_input, parquet_path)
+
+            table = pq.read_table(parquet_path)
+
+            assert len(table) == len(data)
+
+    @given(data=table_data())
+    @settings(max_examples=30, deadline=None)
+    def test_プロパティ_変換後の列名が一致する(
+        self, data: list[dict[str, object]]
+    ) -> None:
+        """変換後も列名が保持されることを検証。"""
+        import json
+
+        import pyarrow.parquet as pq
+
+        assume(len(data) > 0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            json_input = tmpdir_path / "input.json"
+            with open(json_input, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False)
+
+            parquet_path = tmpdir_path / "converted.parquet"
+            json_to_parquet(json_input, parquet_path)
+
+            table = pq.read_table(parquet_path)
+
+            original_columns = set(data[0].keys())
+            parquet_columns = set(table.column_names)
+
+            assert original_columns == parquet_columns

--- a/tests/database/unit/__init__.py
+++ b/tests/database/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for database package."""

--- a/tests/database/unit/test_conversion_models.py
+++ b/tests/database/unit/test_conversion_models.py
@@ -1,0 +1,281 @@
+"""Unit tests for format conversion Pydantic models.
+
+Issue #951: Parquet/JSON形式間のフォーマット変換ユーティリティ
+
+テストTODOリスト:
+- [x] TypeMapping 基本テスト
+- [x] ConversionOptions 基本テスト
+- [x] ConversionResult 正常系テスト
+- [x] ConversionResult 異常系テスト
+- [x] ConversionResult factory methods テスト
+- [x] バリデーションエラーテスト
+"""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from database.types import (
+    ConversionOptions,
+    ConversionResult,
+    TypeMapping,
+)
+
+
+class TestTypeMapping:
+    """TypeMapping モデルのテスト。"""
+
+    def test_正常系_基本的なマッピング作成(self) -> None:
+        """TypeMappingを正常に作成できることを確認。"""
+        mapping = TypeMapping(
+            column_name="user_id",
+            source_type="int64",
+            target_type="integer",
+        )
+
+        assert mapping.column_name == "user_id"
+        assert mapping.source_type == "int64"
+        assert mapping.target_type == "integer"
+
+    def test_正常系_frozenモデルで不変(self) -> None:
+        """frozenモデルが変更不可であることを確認。"""
+        mapping = TypeMapping(
+            column_name="name",
+            source_type="string",
+            target_type="str",
+        )
+
+        with pytest.raises(ValidationError):
+            mapping.column_name = "new_name"  # type: ignore[misc]
+
+    def test_異常系_空のカラム名でエラー(self) -> None:
+        """空のカラム名でバリデーションエラーが発生することを確認。"""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            TypeMapping(
+                column_name="",
+                source_type="int64",
+                target_type="integer",
+            )
+
+    def test_異常系_空白のみのカラム名でエラー(self) -> None:
+        """空白のみのカラム名でバリデーションエラーが発生することを確認。"""
+        with pytest.raises(ValidationError, match="empty or whitespace"):
+            TypeMapping(
+                column_name="   ",
+                source_type="int64",
+                target_type="integer",
+            )
+
+    def test_正常系_空白を含むカラム名はトリム(self) -> None:
+        """前後の空白がトリムされることを確認。"""
+        mapping = TypeMapping(
+            column_name="  user_id  ",
+            source_type="int64",
+            target_type="integer",
+        )
+
+        assert mapping.column_name == "user_id"
+
+
+class TestConversionOptions:
+    """ConversionOptions モデルのテスト。"""
+
+    def test_正常系_デフォルト値で作成(self) -> None:
+        """デフォルト値でConversionOptionsを作成できることを確認。"""
+        options = ConversionOptions()
+
+        assert options.compression is None
+        assert options.orient == "records"
+        assert options.date_format == "iso"
+        assert options.infer_types is True
+
+    def test_正常系_全オプション指定(self) -> None:
+        """全オプションを指定して作成できることを確認。"""
+        options = ConversionOptions(
+            compression="gzip",
+            orient="columns",
+            date_format="epoch",
+            infer_types=False,
+        )
+
+        assert options.compression == "gzip"
+        assert options.orient == "columns"
+        assert options.date_format == "epoch"
+        assert options.infer_types is False
+
+    def test_正常系_frozenモデルで不変(self) -> None:
+        """frozenモデルが変更不可であることを確認。"""
+        options = ConversionOptions()
+
+        with pytest.raises(ValidationError):
+            options.compression = "snappy"  # type: ignore[misc]
+
+    def test_異常系_不正な圧縮方式でエラー(self) -> None:
+        """不正な圧縮方式でバリデーションエラーが発生することを確認。"""
+        with pytest.raises(ValidationError):
+            ConversionOptions(compression="invalid")  # type: ignore[arg-type]
+
+    def test_異常系_不正なorientでエラー(self) -> None:
+        """不正なorientでバリデーションエラーが発生することを確認。"""
+        with pytest.raises(ValidationError):
+            ConversionOptions(orient="invalid")  # type: ignore[arg-type]
+
+
+class TestConversionResult:
+    """ConversionResult モデルのテスト。"""
+
+    def test_正常系_成功結果の作成(self) -> None:
+        """成功結果を正常に作成できることを確認。"""
+        result = ConversionResult(
+            success=True,
+            input_path=Path("data.parquet"),
+            output_path=Path("data.json"),
+            rows_converted=1000,
+            columns=["id", "name", "value"],
+        )
+
+        assert result.success is True
+        assert result.input_path == Path("data.parquet")
+        assert result.output_path == Path("data.json")
+        assert result.rows_converted == 1000
+        assert result.columns == ["id", "name", "value"]
+        assert result.error_message is None
+        assert result.type_mappings is None
+
+    def test_正常系_失敗結果の作成(self) -> None:
+        """失敗結果を正常に作成できることを確認。"""
+        result = ConversionResult(
+            success=False,
+            input_path=Path("invalid.parquet"),
+            output_path=Path("output.json"),
+            rows_converted=0,
+            columns=[],
+            error_message="File not found",
+        )
+
+        assert result.success is False
+        assert result.error_message == "File not found"
+        assert result.rows_converted == 0
+
+    def test_正常系_TypeMappingsを含む結果(self) -> None:
+        """TypeMappingsを含む結果を作成できることを確認。"""
+        mappings = [
+            TypeMapping(column_name="id", source_type="int64", target_type="integer"),
+            TypeMapping(column_name="name", source_type="string", target_type="str"),
+        ]
+
+        result = ConversionResult(
+            success=True,
+            input_path=Path("data.parquet"),
+            output_path=Path("data.json"),
+            rows_converted=100,
+            columns=["id", "name"],
+            type_mappings=mappings,
+        )
+
+        assert result.type_mappings is not None
+        assert len(result.type_mappings) == 2
+        assert result.type_mappings[0].column_name == "id"
+
+    def test_異常系_成功なのにエラーメッセージがある(self) -> None:
+        """success=Trueでerror_messageがあるとエラーになることを確認。"""
+        with pytest.raises(
+            ValidationError, match="error_message must be None when success is True"
+        ):
+            ConversionResult(
+                success=True,
+                input_path=Path("data.parquet"),
+                output_path=Path("data.json"),
+                rows_converted=100,
+                columns=["id"],
+                error_message="Should not have this",
+            )
+
+    def test_異常系_失敗なのにエラーメッセージがない(self) -> None:
+        """success=Falseでerror_messageがないとエラーになることを確認。"""
+        with pytest.raises(
+            ValidationError, match="error_message is required when success is False"
+        ):
+            ConversionResult(
+                success=False,
+                input_path=Path("invalid.parquet"),
+                output_path=Path("output.json"),
+                rows_converted=0,
+                columns=[],
+            )
+
+    def test_異常系_負の行数でエラー(self) -> None:
+        """負の行数でバリデーションエラーが発生することを確認。"""
+        with pytest.raises(ValidationError, match="greater than or equal to 0"):
+            ConversionResult(
+                success=True,
+                input_path=Path("data.parquet"),
+                output_path=Path("data.json"),
+                rows_converted=-1,
+                columns=["id"],
+            )
+
+    def test_異常系_空のカラム名を含む(self) -> None:
+        """空のカラム名を含むとバリデーションエラーが発生することを確認。"""
+        with pytest.raises(ValidationError, match="empty or whitespace"):
+            ConversionResult(
+                success=True,
+                input_path=Path("data.parquet"),
+                output_path=Path("data.json"),
+                rows_converted=100,
+                columns=["id", "", "name"],
+            )
+
+
+class TestConversionResultFactoryMethods:
+    """ConversionResult ファクトリメソッドのテスト。"""
+
+    def test_正常系_create_success(self) -> None:
+        """create_successファクトリメソッドのテスト。"""
+        result = ConversionResult.create_success(
+            input_path=Path("data.parquet"),
+            output_path=Path("data.json"),
+            rows_converted=500,
+            columns=["id", "name", "value"],
+        )
+
+        assert result.success is True
+        assert result.input_path == Path("data.parquet")
+        assert result.output_path == Path("data.json")
+        assert result.rows_converted == 500
+        assert result.columns == ["id", "name", "value"]
+        assert result.error_message is None
+
+    def test_正常系_create_success_with_mappings(self) -> None:
+        """create_successファクトリメソッドでtype_mappingsを渡せることを確認。"""
+        mappings = [
+            TypeMapping(column_name="id", source_type="int64", target_type="integer"),
+        ]
+
+        result = ConversionResult.create_success(
+            input_path=Path("data.parquet"),
+            output_path=Path("data.json"),
+            rows_converted=100,
+            columns=["id"],
+            type_mappings=mappings,
+        )
+
+        assert result.type_mappings is not None
+        assert len(result.type_mappings) == 1
+
+    def test_正常系_create_failure(self) -> None:
+        """create_failureファクトリメソッドのテスト。"""
+        result = ConversionResult.create_failure(
+            input_path=Path("invalid.parquet"),
+            output_path=Path("output.json"),
+            error_message="Invalid Parquet format",
+        )
+
+        assert result.success is False
+        assert result.input_path == Path("invalid.parquet")
+        assert result.output_path == Path("output.json")
+        assert result.rows_converted == 0
+        assert result.columns == []
+        assert result.error_message == "Invalid Parquet format"
+        assert result.type_mappings is None

--- a/tests/database/unit/utils/__init__.py
+++ b/tests/database/unit/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for database.utils package."""

--- a/tests/database/unit/utils/test_format_converter.py
+++ b/tests/database/unit/utils/test_format_converter.py
@@ -1,0 +1,382 @@
+"""Unit tests for format_converter module.
+
+Issue #951: Parquet/JSON形式間のフォーマット変換ユーティリティ
+
+テストTODOリスト:
+- [x] test_正常系_parquet_to_json_変換成功
+- [x] test_正常系_json_to_parquet_変換成功
+- [x] test_正常系_相互変換でデータ一致
+- [x] test_正常系_様々なデータ型を保持
+- [x] test_異常系_存在しないファイルでFileNotFoundError
+- [x] test_異常系_不正なフォーマットでValueError
+- [x] test_異常系_空データでValueError
+- [x] test_エッジケース_ネストしたJSONの処理
+- [x] test_エッジケース_nullを含むデータの処理
+- [x] test_エッジケース_大きなファイルの処理
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from database.utils.format_converter import (
+    json_to_parquet,
+    parquet_to_json,
+)
+
+
+class TestParquetToJson:
+    """Parquet to JSON 変換のテスト。"""
+
+    def test_正常系_parquet_to_json_変換成功(
+        self, tmp_path: Path, sample_parquet_file: Path
+    ) -> None:
+        """ParquetファイルをJSON形式に変換できることを確認。"""
+        output_path = tmp_path / "output.json"
+
+        result = parquet_to_json(sample_parquet_file, output_path)
+
+        assert output_path.exists()
+        assert result is True
+
+    def test_正常系_様々なデータ型を保持_parquet_to_json(
+        self, tmp_path: Path, sample_parquet_with_types: Path
+    ) -> None:
+        """int, float, str, bool, datetime等が正しく変換されることを確認。"""
+        output_path = tmp_path / "output.json"
+
+        parquet_to_json(sample_parquet_with_types, output_path)
+
+        import json
+
+        with open(output_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        # データ型の検証
+        assert len(data) > 0
+        first_record = data[0]
+
+        # 各型が保持されていることを確認
+        assert isinstance(first_record["int_col"], int)
+        assert isinstance(first_record["float_col"], float)
+        assert isinstance(first_record["str_col"], str)
+        assert isinstance(first_record["bool_col"], bool)
+        # datetime は ISO 形式文字列として保存される
+        assert isinstance(first_record["datetime_col"], str)
+
+    def test_異常系_存在しないファイルでFileNotFoundError(self, tmp_path: Path) -> None:
+        """存在しないParquetファイルを読もうとするとエラーが発生することを確認。"""
+        non_existent_path = tmp_path / "non_existent.parquet"
+        output_path = tmp_path / "output.json"
+
+        with pytest.raises(FileNotFoundError):
+            parquet_to_json(non_existent_path, output_path)
+
+    def test_異常系_不正なフォーマットでValueError(self, tmp_path: Path) -> None:
+        """Parquet形式でないファイルを読もうとするとエラーが発生することを確認。"""
+        invalid_file = tmp_path / "invalid.parquet"
+        invalid_file.write_text("This is not a parquet file")
+        output_path = tmp_path / "output.json"
+
+        with pytest.raises(ValueError, match="Invalid Parquet file"):
+            parquet_to_json(invalid_file, output_path)
+
+
+class TestJsonToParquet:
+    """JSON to Parquet 変換のテスト。"""
+
+    def test_正常系_json_to_parquet_変換成功(
+        self, tmp_path: Path, sample_json_file: Path
+    ) -> None:
+        """JSONファイルをParquet形式に変換できることを確認。"""
+        output_path = tmp_path / "output.parquet"
+
+        result = json_to_parquet(sample_json_file, output_path)
+
+        assert output_path.exists()
+        assert result is True
+
+    def test_正常系_様々なデータ型を保持_json_to_parquet(
+        self, tmp_path: Path, sample_json_with_types: Path
+    ) -> None:
+        """int, float, str, bool, datetime等が正しく変換されることを確認。"""
+        output_path = tmp_path / "output.parquet"
+
+        json_to_parquet(sample_json_with_types, output_path)
+
+        # Parquetファイルを読み込んで型を確認
+        import pyarrow.parquet as pq
+
+        table = pq.read_table(output_path)
+        schema = table.schema
+
+        # データ型が適切に推論されていることを確認
+        assert "int_col" in schema.names
+        assert "float_col" in schema.names
+        assert "str_col" in schema.names
+        assert "bool_col" in schema.names
+
+    def test_異常系_存在しないファイルでFileNotFoundError(self, tmp_path: Path) -> None:
+        """存在しないJSONファイルを読もうとするとエラーが発生することを確認。"""
+        non_existent_path = tmp_path / "non_existent.json"
+        output_path = tmp_path / "output.parquet"
+
+        with pytest.raises(FileNotFoundError):
+            json_to_parquet(non_existent_path, output_path)
+
+    def test_異常系_不正なJSONフォーマットでValueError(self, tmp_path: Path) -> None:
+        """不正なJSON形式のファイルを読もうとするとエラーが発生することを確認。"""
+        invalid_file = tmp_path / "invalid.json"
+        invalid_file.write_text("{ invalid json }")
+        output_path = tmp_path / "output.parquet"
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            json_to_parquet(invalid_file, output_path)
+
+    def test_異常系_空データでValueError(self, tmp_path: Path) -> None:
+        """空のJSONデータを変換しようとするとエラーが発生することを確認。"""
+        empty_file = tmp_path / "empty.json"
+        empty_file.write_text("[]")
+        output_path = tmp_path / "output.parquet"
+
+        with pytest.raises(ValueError, match="Empty data"):
+            json_to_parquet(empty_file, output_path)
+
+
+class TestRoundTrip:
+    """Parquet <-> JSON 相互変換のテスト。"""
+
+    def test_正常系_相互変換でデータ一致(
+        self, tmp_path: Path, sample_parquet_file: Path
+    ) -> None:
+        """Parquet -> JSON -> Parquet で元データと一致することを確認。"""
+        json_path = tmp_path / "intermediate.json"
+        final_parquet_path = tmp_path / "final.parquet"
+
+        # Parquet -> JSON
+        parquet_to_json(sample_parquet_file, json_path)
+
+        # JSON -> Parquet
+        json_to_parquet(json_path, final_parquet_path)
+
+        # 元データと最終データを比較
+        import pyarrow.parquet as pq
+
+        original_table = pq.read_table(sample_parquet_file)
+        final_table = pq.read_table(final_parquet_path)
+
+        # 行数が一致することを確認
+        assert len(original_table) == len(final_table)
+
+        # 列名が一致することを確認
+        assert set(original_table.column_names) == set(final_table.column_names)
+
+        # データ内容が一致することを確認
+        original_df = original_table.to_pandas()
+        final_df = final_table.to_pandas()
+
+        # 列を同じ順序にソートして比較
+        for col in original_df.columns:
+            assert list(original_df[col]) == list(final_df[col])
+
+
+class TestEdgeCases:
+    """エッジケースのテスト。"""
+
+    def test_エッジケース_ネストしたJSONの処理(self, tmp_path: Path) -> None:
+        """ネストした構造のJSONを変換できることを確認。"""
+        import json
+
+        nested_data = [
+            {
+                "id": 1,
+                "name": "test",
+                "metadata": {"key1": "value1", "key2": 123},
+                "tags": ["tag1", "tag2"],
+            },
+            {
+                "id": 2,
+                "name": "test2",
+                "metadata": {"key1": "value2", "key2": 456},
+                "tags": ["tag3"],
+            },
+        ]
+
+        json_file = tmp_path / "nested.json"
+        with open(json_file, "w", encoding="utf-8") as f:
+            json.dump(nested_data, f, ensure_ascii=False)
+
+        parquet_path = tmp_path / "nested.parquet"
+
+        # ネストしたJSONをParquetに変換
+        json_to_parquet(json_file, parquet_path)
+
+        assert parquet_path.exists()
+
+        # 再度JSONに変換して確認
+        json_output = tmp_path / "nested_output.json"
+        parquet_to_json(parquet_path, json_output)
+
+        with open(json_output, encoding="utf-8") as f:
+            result_data = json.load(f)
+
+        assert len(result_data) == 2
+        # ネストした構造が保持されていることを確認
+        assert "metadata" in result_data[0]
+
+    def test_エッジケース_nullを含むデータの処理(self, tmp_path: Path) -> None:
+        """NULL値を含むデータを変換できることを確認。"""
+        import json
+
+        data_with_nulls = [
+            {"id": 1, "name": "test", "optional_field": None},
+            {"id": 2, "name": None, "optional_field": "value"},
+            {"id": 3, "name": "test3", "optional_field": None},
+        ]
+
+        json_file = tmp_path / "with_nulls.json"
+        with open(json_file, "w", encoding="utf-8") as f:
+            json.dump(data_with_nulls, f, ensure_ascii=False)
+
+        parquet_path = tmp_path / "with_nulls.parquet"
+        json_to_parquet(json_file, parquet_path)
+
+        assert parquet_path.exists()
+
+        # Parquetから読み込んでNULLが保持されていることを確認
+        import pyarrow.parquet as pq
+
+        table = pq.read_table(parquet_path)
+        df = table.to_pandas()
+
+        # NULL値が正しく保持されているか確認
+        assert df["optional_field"].isna().sum() == 2
+        assert df["name"].isna().sum() == 1
+
+    def test_エッジケース_大きなファイルの処理(self, tmp_path: Path) -> None:
+        """大きめのデータセット（10000行）を変換できることを確認。"""
+        import json
+
+        large_data = [
+            {"id": i, "name": f"item_{i}", "value": float(i * 1.5)}
+            for i in range(10000)
+        ]
+
+        json_file = tmp_path / "large.json"
+        with open(json_file, "w", encoding="utf-8") as f:
+            json.dump(large_data, f, ensure_ascii=False)
+
+        parquet_path = tmp_path / "large.parquet"
+        json_to_parquet(json_file, parquet_path)
+
+        assert parquet_path.exists()
+
+        # 行数が正しいことを確認
+        import pyarrow.parquet as pq
+
+        table = pq.read_table(parquet_path)
+        assert len(table) == 10000
+
+
+# =============================================================================
+# フィクスチャ
+# =============================================================================
+
+
+@pytest.fixture
+def sample_parquet_file(tmp_path: Path) -> Path:
+    """テスト用のサンプルParquetファイルを作成。"""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    data = {
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Charlie"],
+        "value": [100.0, 200.0, 300.0],
+    }
+    table = pa.Table.from_pydict(data)
+
+    parquet_path = tmp_path / "sample.parquet"
+    pq.write_table(table, parquet_path)
+
+    return parquet_path
+
+
+@pytest.fixture
+def sample_parquet_with_types(tmp_path: Path) -> Path:
+    """様々なデータ型を含むParquetファイルを作成。"""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    data = {
+        "int_col": [1, 2, 3],
+        "float_col": [1.1, 2.2, 3.3],
+        "str_col": ["a", "b", "c"],
+        "bool_col": [True, False, True],
+        "datetime_col": [
+            datetime(2024, 1, 1),
+            datetime(2024, 6, 15),
+            datetime(2024, 12, 31),
+        ],
+    }
+    table = pa.Table.from_pydict(data)
+
+    parquet_path = tmp_path / "sample_types.parquet"
+    pq.write_table(table, parquet_path)
+
+    return parquet_path
+
+
+@pytest.fixture
+def sample_json_file(tmp_path: Path) -> Path:
+    """テスト用のサンプルJSONファイルを作成。"""
+    import json
+
+    data = [
+        {"id": 1, "name": "Alice", "value": 100.0},
+        {"id": 2, "name": "Bob", "value": 200.0},
+        {"id": 3, "name": "Charlie", "value": 300.0},
+    ]
+
+    json_path = tmp_path / "sample.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False)
+
+    return json_path
+
+
+@pytest.fixture
+def sample_json_with_types(tmp_path: Path) -> Path:
+    """様々なデータ型を含むJSONファイルを作成。"""
+    import json
+
+    data = [
+        {
+            "int_col": 1,
+            "float_col": 1.1,
+            "str_col": "a",
+            "bool_col": True,
+            "datetime_col": "2024-01-01T00:00:00",
+        },
+        {
+            "int_col": 2,
+            "float_col": 2.2,
+            "str_col": "b",
+            "bool_col": False,
+            "datetime_col": "2024-06-15T00:00:00",
+        },
+        {
+            "int_col": 3,
+            "float_col": 3.3,
+            "str_col": "c",
+            "bool_col": True,
+            "datetime_col": "2024-12-31T00:00:00",
+        },
+    ]
+
+    json_path = tmp_path / "sample_types.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False)
+
+    return json_path


### PR DESCRIPTION
## 概要

Parquet/JSON形式間のフォーマット変換ユーティリティを実装しました。

- Parquet → JSON 変換関数
- JSON → Parquet 変換関数
- データ型の自動推論（int, float, str, bool, datetime等）
- ネスト構造、NULL値、混合型のハンドリング

## 追加されたPydanticモデル

| モデル | 説明 |
|--------|------|
| `TypeMapping` | カラムの型マッピング情報 |
| `ConversionOptions` | 変換オプション（圧縮、日付形式等） |
| `ConversionResult` | 変換結果（成功/失敗、行数、カラム等） |

## 変更ファイル

- `src/finance/utils/format_converter.py` - メイン実装
- `src/finance/types.py` - Pydanticモデル追加
- `src/finance/__init__.py` - エクスポート追加
- `tests/finance/unit/utils/test_format_converter.py` - 単体テスト
- `tests/finance/property/utils/test_format_converter_property.py` - プロパティテスト
- `tests/finance/unit/test_conversion_models.py` - モデルテスト

## テストプラン

- [x] 単体テスト: 33件パス
- [x] プロパティテスト: 3件パス
- [x] `make check-all` 成功

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)