### PR TITLE
[Phase2] analyzeパッケージ: returnsモジュール移植

### DIFF
--- a/src/analyze/__init__.py
+++ b/src/analyze/__init__.py
@@ -5,6 +5,7 @@ This package provides analysis tools for financial data including:
 - Statistical analysis (descriptive statistics, correlation)
 - Sector analysis (sector performance, rotation)
 - Earnings analysis (earnings calendar, estimates)
+- Returns calculation (multi-period returns, MTD, YTD)
 - Fundamental analysis (planned)
 - Quantitative analysis (planned)
 
@@ -18,10 +19,23 @@ sector
     Sector analysis module (sector performance, ETF tracking)
 earnings
     Earnings calendar and earnings data analysis
+returns
+    Multi-period returns calculation (1D, 1W, MTD, 1M, 3M, YTD, etc.)
 """
 
 from analyze import sector
 from analyze.earnings import EarningsCalendar, EarningsData, get_upcoming_earnings
+from analyze.returns import (
+    RETURN_PERIODS,
+    TICKERS_GLOBAL_INDICES,
+    TICKERS_MAG7,
+    TICKERS_SECTORS,
+    TICKERS_US_INDICES,
+    calculate_multi_period_returns,
+    calculate_return,
+    fetch_topix_data,
+    generate_returns_report,
+)
 from analyze.statistics.types import (
     CorrelationMethod,
     CorrelationResult,
@@ -40,6 +54,11 @@ from analyze.technical import (
 )
 
 __all__ = [
+    "RETURN_PERIODS",
+    "TICKERS_GLOBAL_INDICES",
+    "TICKERS_MAG7",
+    "TICKERS_SECTORS",
+    "TICKERS_US_INDICES",
     "BollingerBandsParams",
     "BollingerBandsResult",
     "CorrelationMethod",
@@ -54,6 +73,10 @@ __all__ = [
     "ReturnParams",
     "SMAParams",
     "VolatilityParams",
+    "calculate_multi_period_returns",
+    "calculate_return",
+    "fetch_topix_data",
+    "generate_returns_report",
     "get_upcoming_earnings",
     "sector",
 ]

--- a/src/analyze/returns/__init__.py
+++ b/src/analyze/returns/__init__.py
@@ -1,0 +1,29 @@
+"""Returns calculation module.
+
+This module provides functions for calculating returns over multiple periods
+including dynamic periods like MTD (Month-to-Date) and YTD (Year-to-Date).
+"""
+
+from analyze.returns.returns import (
+    RETURN_PERIODS,
+    TICKERS_GLOBAL_INDICES,
+    TICKERS_MAG7,
+    TICKERS_SECTORS,
+    TICKERS_US_INDICES,
+    calculate_multi_period_returns,
+    calculate_return,
+    fetch_topix_data,
+    generate_returns_report,
+)
+
+__all__ = [
+    "RETURN_PERIODS",
+    "TICKERS_GLOBAL_INDICES",
+    "TICKERS_MAG7",
+    "TICKERS_SECTORS",
+    "TICKERS_US_INDICES",
+    "calculate_multi_period_returns",
+    "calculate_return",
+    "fetch_topix_data",
+    "generate_returns_report",
+]

--- a/src/analyze/returns/returns.py
+++ b/src/analyze/returns/returns.py
@@ -1,0 +1,541 @@
+"""Multi-period returns calculation module.
+
+This module provides functions for calculating returns over multiple periods
+including dynamic periods like MTD (Month-to-Date) and YTD (Year-to-Date).
+
+Issue #469: 多期間騰落率計算モジュールの実装
+Migrated from market_analysis.analysis.returns (Issue #956)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+import yfinance as yf
+
+from database.utils.logging_config import get_logger
+
+logger = get_logger(__name__, module="returns")
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+RETURN_PERIODS: dict[str, int | str] = {
+    "1D": 1,  # 1営業日
+    "1W": 5,  # 1週間（5営業日）
+    "MTD": "mtd",  # 月初来
+    "1M": 21,  # 1ヶ月（21営業日）
+    "3M": 63,  # 3ヶ月
+    "6M": 126,  # 6ヶ月
+    "YTD": "ytd",  # 年初来
+    "1Y": 252,  # 1年
+    "3Y": 756,  # 3年
+    "5Y": 1260,  # 5年
+}
+
+TICKERS_GLOBAL_INDICES: list[str] = [
+    "^N225",  # 日経225
+    "^TOPX",  # TOPIX（yfinanceでの可用性要確認）
+    "^STOXX50E",  # Euro STOXX 50
+    "^FTSE",  # FTSE 100
+    "^GDAXI",  # DAX
+    "000001.SS",  # 上海総合
+    "^HSI",  # ハンセン指数
+]
+
+TICKERS_US_INDICES: list[str] = [
+    "^GSPC",  # S&P 500
+    "^DJI",  # Dow Jones Industrial Average
+    "^IXIC",  # NASDAQ Composite
+    "^RUT",  # Russell 2000
+]
+
+TICKERS_MAG7: list[str] = [
+    "AAPL",  # Apple
+    "MSFT",  # Microsoft
+    "GOOGL",  # Alphabet (Google)
+    "AMZN",  # Amazon
+    "NVDA",  # NVIDIA
+    "META",  # Meta (Facebook)
+    "TSLA",  # Tesla
+]
+
+TICKERS_SECTORS: list[str] = [
+    "XLF",  # Financial Select Sector SPDR
+    "XLK",  # Technology Select Sector SPDR
+    "XLV",  # Health Care Select Sector SPDR
+    "XLE",  # Energy Select Sector SPDR
+    "XLI",  # Industrial Select Sector SPDR
+    "XLY",  # Consumer Discretionary Select Sector SPDR
+    "XLP",  # Consumer Staples Select Sector SPDR
+    "XLB",  # Materials Select Sector SPDR
+    "XLU",  # Utilities Select Sector SPDR
+    "XLRE",  # Real Estate Select Sector SPDR
+    "XLC",  # Communication Services Select Sector SPDR
+]
+
+
+# =============================================================================
+# Functions
+# =============================================================================
+
+
+def calculate_return(prices: pd.Series, period: int | str) -> float | None:
+    """Calculate return for a single period.
+
+    Parameters
+    ----------
+    prices : pd.Series
+        Price series with DatetimeIndex
+    period : int | str
+        Number of business days or "mtd"/"ytd" for dynamic periods
+
+    Returns
+    -------
+    float | None
+        Calculated return as decimal (e.g., 0.05 for 5%), or None if insufficient data
+
+    Raises
+    ------
+    ValueError
+        If period is a non-positive integer
+
+    Examples
+    --------
+    >>> prices = pd.Series([100.0, 101.0, 102.0], index=pd.date_range("2024-01-01", periods=3))
+    >>> calculate_return(prices, period=1)
+    0.00990099009900991
+    """
+    logger.debug("Calculating return", period=period, data_length=len(prices))
+
+    # Handle empty series
+    if prices.empty:
+        logger.debug("Empty price series, returning None")
+        return None
+
+    # Drop NaN values for calculation
+    clean_prices = prices.dropna()
+    if clean_prices.empty:
+        logger.debug("All NaN values in price series, returning None")
+        return None
+
+    # Handle integer period validation
+    if isinstance(period, int):
+        if period <= 0:
+            msg = f"period must be positive, got {period}"
+            logger.error("Invalid period", period=period, error=msg)
+            raise ValueError(msg)
+
+        # Check if we have enough data
+        if len(clean_prices) <= period:
+            logger.debug(
+                "Insufficient data for period",
+                period=period,
+                data_length=len(clean_prices),
+            )
+            return None
+
+        # Calculate return: (current - past) / past
+        current_price = clean_prices.iloc[-1]
+        past_price = clean_prices.iloc[-(period + 1)]
+
+        if past_price == 0:
+            logger.warning("Past price is zero, cannot calculate return")
+            return None
+
+        result = (current_price - past_price) / past_price
+        logger.debug("Return calculated", period=period, result=result)
+        return float(result)
+
+    # Handle string period (mtd/ytd)
+    # At this point, period must be a string since we checked for int above
+    period_lower = period.lower()
+
+    if period_lower == "mtd":
+        return _calculate_mtd_return(clean_prices)
+    elif period_lower == "ytd":
+        return _calculate_ytd_return(clean_prices)
+    else:
+        msg = f"Unknown period type: {period}. Expected 'mtd' or 'ytd'"
+        logger.error("Unknown period type", period=period)
+        raise ValueError(msg)
+
+
+def _calculate_mtd_return(prices: pd.Series) -> float | None:
+    """Calculate month-to-date return.
+
+    Parameters
+    ----------
+    prices : pd.Series
+        Price series with DatetimeIndex
+
+    Returns
+    -------
+    float | None
+        MTD return or None if insufficient data
+    """
+    if prices.empty:
+        return None
+
+    # Get the current date's month
+    current_date = prices.index[-1]
+    current_month = current_date.month
+    current_year = current_date.year
+
+    # Find the first price of the current month
+    month_start_mask = (prices.index.month == current_month) & (
+        prices.index.year == current_year
+    )
+    month_prices = prices[month_start_mask]
+
+    if month_prices.empty or len(month_prices) < 1:
+        logger.debug("No data for current month")
+        return None
+
+    month_start_price = month_prices.iloc[0]
+    current_price = prices.iloc[-1]
+
+    if month_start_price == 0:
+        logger.warning("Month start price is zero")
+        return None
+
+    result = (current_price - month_start_price) / month_start_price
+    logger.debug("MTD return calculated", result=result)
+    return float(result)
+
+
+def _calculate_ytd_return(prices: pd.Series) -> float | None:
+    """Calculate year-to-date return.
+
+    Parameters
+    ----------
+    prices : pd.Series
+        Price series with DatetimeIndex
+
+    Returns
+    -------
+    float | None
+        YTD return or None if insufficient data
+    """
+    if prices.empty:
+        return None
+
+    # Get the current date's year
+    current_date = prices.index[-1]
+    current_year = current_date.year
+
+    # Find the first price of the current year
+    year_start_mask = prices.index.year == current_year
+    year_prices = prices[year_start_mask]
+
+    if year_prices.empty or len(year_prices) < 1:
+        logger.debug("No data for current year")
+        return None
+
+    year_start_price = year_prices.iloc[0]
+    current_price = prices.iloc[-1]
+
+    if year_start_price == 0:
+        logger.warning("Year start price is zero")
+        return None
+
+    result = (current_price - year_start_price) / year_start_price
+    logger.debug("YTD return calculated", result=result)
+    return float(result)
+
+
+def calculate_multi_period_returns(prices: pd.Series) -> dict[str, float | None]:
+    """Calculate returns for all periods in RETURN_PERIODS.
+
+    Parameters
+    ----------
+    prices : pd.Series
+        Price series with DatetimeIndex
+
+    Returns
+    -------
+    dict[str, float | None]
+        Dictionary mapping period names to returns (None if insufficient data)
+
+    Examples
+    --------
+    >>> prices = pd.Series([100.0, 101.0, 102.0], index=pd.date_range("2024-01-01", periods=3))
+    >>> result = calculate_multi_period_returns(prices)
+    >>> "1D" in result
+    True
+    """
+    logger.debug("Calculating multi-period returns", data_length=len(prices))
+
+    results: dict[str, float | None] = {}
+
+    for period_name, period_value in RETURN_PERIODS.items():
+        try:
+            result = calculate_return(prices, period_value)
+            results[period_name] = result
+            logger.debug(
+                "Period return calculated",
+                period_name=period_name,
+                result=result,
+            )
+        except (ValueError, TypeError) as e:
+            logger.warning(
+                "Failed to calculate period return",
+                period_name=period_name,
+                error=str(e),
+            )
+            results[period_name] = None
+
+    logger.info(
+        "Multi-period returns calculated",
+        total_periods=len(results),
+        valid_results=sum(1 for v in results.values() if v is not None),
+    )
+    return results
+
+
+def fetch_topix_data(
+    start: str | datetime | None = None,
+    end: str | datetime | None = None,
+) -> pd.DataFrame | None:
+    """Fetch TOPIX data with fallback to 1306.T ETF.
+
+    Attempts to fetch ^TOPX first, falling back to 1306.T if unavailable.
+
+    Parameters
+    ----------
+    start : str | datetime | None
+        Start date for data fetch
+    end : str | datetime | None
+        End date for data fetch
+
+    Returns
+    -------
+    pd.DataFrame | None
+        OHLCV DataFrame or None if both sources fail
+
+    Examples
+    --------
+    >>> # This would fetch actual data from yfinance
+    >>> # df = fetch_topix_data(start="2024-01-01", end="2024-12-31")
+    """
+    logger.debug("Fetching TOPIX data", start=start, end=end)
+
+    # Try ^TOPX first
+    try:
+        logger.debug("Attempting to fetch ^TOPX")
+        df = yf.download("^TOPX", start=start, end=end, progress=False)
+
+        if df is not None and not df.empty:
+            logger.info("Successfully fetched ^TOPX data", rows=len(df))
+            return df
+
+        logger.debug("^TOPX returned empty data")
+    except Exception as e:
+        logger.warning("Failed to fetch ^TOPX", error=str(e))
+
+    # Fallback to 1306.T (TOPIX ETF)
+    try:
+        logger.debug("Attempting to fetch 1306.T (fallback)")
+        df = yf.download("1306.T", start=start, end=end, progress=False)
+
+        if df is not None and not df.empty:
+            logger.info("Successfully fetched 1306.T data (fallback)", rows=len(df))
+            return df
+
+        logger.debug("1306.T returned empty data")
+    except Exception as e:
+        logger.warning("Failed to fetch 1306.T", error=str(e))
+
+    logger.error("Failed to fetch TOPIX data from both sources")
+    return None
+
+
+def generate_returns_report(as_of: datetime | None = None) -> dict[str, Any]:
+    """Generate comprehensive returns report.
+
+    Parameters
+    ----------
+    as_of : datetime | None
+        Reference datetime for the report. Defaults to current time.
+
+    Returns
+    -------
+    dict[str, Any]
+        Report with structure:
+        {
+            "as_of": "2026-01-19T16:00:00",
+            "indices": [...],
+            "mag7": [...],
+            "sectors": [...],
+            "global_indices": [...]
+        }
+
+    Examples
+    --------
+    >>> # report = generate_returns_report()
+    >>> # "indices" in report
+    True
+    """
+    logger.info("Generating returns report")
+
+    # Set as_of time
+    report_time = as_of if as_of else datetime.now()
+    as_of_str = report_time.isoformat()
+
+    logger.debug("Report as_of time", as_of=as_of_str)
+
+    # Calculate returns for each category
+    indices_data = _fetch_and_calculate_returns(TICKERS_US_INDICES, "indices")
+    mag7_data = _fetch_and_calculate_returns(TICKERS_MAG7, "mag7")
+    sectors_data = _fetch_and_calculate_returns(TICKERS_SECTORS, "sectors")
+    global_indices_data = _fetch_and_calculate_returns(
+        TICKERS_GLOBAL_INDICES, "global_indices"
+    )
+
+    report = {
+        "as_of": as_of_str,
+        "indices": indices_data,
+        "mag7": mag7_data,
+        "sectors": sectors_data,
+        "global_indices": global_indices_data,
+    }
+
+    logger.info(
+        "Returns report generated",
+        indices_count=len(indices_data),
+        mag7_count=len(mag7_data),
+        sectors_count=len(sectors_data),
+        global_indices_count=len(global_indices_data),
+    )
+
+    return report
+
+
+def _fetch_and_calculate_returns(
+    tickers: list[str],
+    category: str,
+) -> list[dict[str, Any]]:
+    """Fetch price data and calculate returns for a list of tickers.
+
+    Uses batch download with yf.download for efficiency.
+
+    Parameters
+    ----------
+    tickers : list[str]
+        List of ticker symbols
+    category : str
+        Category name for logging
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        List of dictionaries containing ticker and returns data
+    """
+    logger.debug(
+        "Fetching and calculating returns (batch)",
+        category=category,
+        ticker_count=len(tickers),
+    )
+
+    if not tickers:
+        return []
+
+    results: list[dict[str, Any]] = []
+
+    try:
+        # Batch download all tickers at once
+        logger.debug("Batch downloading data", tickers=tickers, category=category)
+        df = yf.download(tickers, period="6y", progress=False)
+
+        if df is None or df.empty:
+            logger.warning("No data returned for batch download", category=category)
+            return []
+
+        # Process each ticker
+        for ticker in tickers:
+            try:
+                # Extract Close prices for this ticker
+                prices: pd.Series
+                if isinstance(df.columns, pd.MultiIndex):
+                    # Multi-ticker download returns MultiIndex columns
+                    if "Close" in df.columns.get_level_values(0):
+                        close_df = df["Close"]
+                        if ticker in close_df.columns:
+                            ticker_data = close_df[ticker].dropna()
+                            if isinstance(ticker_data, pd.DataFrame):
+                                prices = ticker_data.iloc[:, 0]
+                            else:
+                                prices = ticker_data
+                        else:
+                            logger.debug(
+                                "Ticker not found in batch data",
+                                ticker=ticker,
+                                category=category,
+                            )
+                            continue
+                    else:
+                        logger.debug(
+                            "No Close column in MultiIndex",
+                            ticker=ticker,
+                            category=category,
+                        )
+                        continue
+                # Single ticker case (when only 1 ticker in list)
+                elif "Close" in df.columns:
+                    close_data = df["Close"]
+                    if isinstance(close_data, pd.DataFrame):
+                        prices = close_data.iloc[:, 0].dropna()
+                    else:
+                        prices = close_data.dropna()
+                else:
+                    logger.warning("No Close column found", ticker=ticker)
+                    continue
+
+                if prices.empty:
+                    logger.debug("Empty price data after dropna", ticker=ticker)
+                    continue
+
+                # Calculate multi-period returns
+                returns = calculate_multi_period_returns(prices)
+
+                result = {
+                    "ticker": ticker,
+                    **returns,
+                }
+                results.append(result)
+
+                logger.debug(
+                    "Returns calculated for ticker",
+                    ticker=ticker,
+                    valid_periods=sum(1 for v in returns.values() if v is not None),
+                )
+
+            except Exception as e:
+                logger.warning(
+                    "Failed to process ticker",
+                    ticker=ticker,
+                    category=category,
+                    error=str(e),
+                )
+                continue
+
+    except Exception as e:
+        logger.error(
+            "Batch download failed",
+            category=category,
+            error=str(e),
+            exc_info=True,
+        )
+        return []
+
+    logger.debug(
+        "Category returns calculation completed",
+        category=category,
+        processed_count=len(results),
+        total_tickers=len(tickers),
+    )
+
+    return results

--- a/tests/analyze/conftest.py
+++ b/tests/analyze/conftest.py
@@ -230,9 +230,14 @@ def skewed_series() -> pd.Series:
     return pd.Series([1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 10.0, 15.0, 20.0])
 
 
-# ============================================================================
-# Common Fixtures
-# ============================================================================
+@pytest.fixture
+def sample_data() -> list[dict[str, Any]]:
+    """Create sample data for testing."""
+    return [
+        {"id": 1, "name": "Item 1", "value": 100},
+        {"id": 2, "name": "Item 2", "value": 200},
+        {"id": 3, "name": "Item 3", "value": 300},
+    ]
 
 
 @pytest.fixture

--- a/tests/analyze/unit/returns/__init__.py
+++ b/tests/analyze/unit/returns/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for analyze.returns module."""

--- a/tests/analyze/unit/returns/test_returns.py
+++ b/tests/analyze/unit/returns/test_returns.py
@@ -1,0 +1,668 @@
+"""Unit tests for multi-period returns calculation module.
+
+This module tests the analyze.returns implementation for Issue #956.
+Tests cover:
+- Single period return calculation
+- Multi-period returns calculation (RETURN_PERIODS)
+- MTD/YTD dynamic period calculation
+- TOPIX data fetching with fallback logic
+- Returns report generation
+
+References:
+- Issue #956: [Phase2] analyzeパッケージ: returnsモジュール移植
+- market_analysis/analysis/returns.py (移植元)
+- template/tests/unit/test_example.py
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# AIDEV-NOTE: Importing from the new analyze.returns module.
+# Tests are expected to fail (Red state) until implementation is complete.
+from analyze.returns import (
+    RETURN_PERIODS,
+    TICKERS_GLOBAL_INDICES,
+    TICKERS_MAG7,
+    TICKERS_SECTORS,
+    TICKERS_US_INDICES,
+    calculate_multi_period_returns,
+    calculate_return,
+    fetch_topix_data,
+    generate_returns_report,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_prices() -> pd.Series:
+    """Create sample price series for testing.
+
+    Returns 100 days of synthetic price data starting from 100.0
+    with small random variations.
+    """
+    np.random.seed(42)
+    dates = pd.date_range("2024-01-01", periods=100, freq="B")  # Business days
+    base_price = 100.0
+    # Generate random walk prices
+    returns = np.random.normal(0.001, 0.02, 100)
+    prices = base_price * np.cumprod(1 + returns)
+    return pd.Series(prices, index=dates, name="close")
+
+
+@pytest.fixture
+def sample_prices_short() -> pd.Series:
+    """Create short price series (10 days) for edge case testing."""
+    dates = pd.date_range("2024-01-01", periods=10, freq="B")
+    prices = [100.0, 101.0, 102.0, 101.5, 103.0, 104.0, 103.5, 105.0, 106.0, 107.0]
+    return pd.Series(prices, index=dates, name="close")
+
+
+@pytest.fixture
+def sample_prices_mtd() -> pd.Series:
+    """Create price series starting from the beginning of a month for MTD testing."""
+    # Create data spanning February 2024 for clear MTD calculation
+    dates = pd.date_range("2024-02-01", periods=20, freq="B")
+    base_price = 100.0
+    np.random.seed(123)
+    returns = np.random.normal(0.002, 0.01, 20)
+    prices = base_price * np.cumprod(1 + returns)
+    return pd.Series(prices, index=dates, name="close")
+
+
+@pytest.fixture
+def sample_prices_ytd() -> pd.Series:
+    """Create price series starting from the beginning of a year for YTD testing."""
+    # Create data spanning from start of 2024
+    dates = pd.date_range("2024-01-02", periods=60, freq="B")
+    base_price = 100.0
+    np.random.seed(456)
+    returns = np.random.normal(0.001, 0.015, 60)
+    prices = base_price * np.cumprod(1 + returns)
+    return pd.Series(prices, index=dates, name="close")
+
+
+@pytest.fixture
+def mock_yfinance_data() -> pd.DataFrame:
+    """Create mock yfinance return data for TOPIX testing."""
+    dates = pd.date_range("2024-01-01", periods=50, freq="B")
+    np.random.seed(789)
+    prices = 2500 * np.cumprod(1 + np.random.normal(0.001, 0.01, 50))
+    return pd.DataFrame(
+        {
+            "Open": prices * 0.99,
+            "High": prices * 1.01,
+            "Low": prices * 0.98,
+            "Close": prices,
+            "Volume": np.random.randint(1000000, 5000000, 50),
+        },
+        index=dates,
+    )
+
+
+# =============================================================================
+# Tests for RETURN_PERIODS constant
+# =============================================================================
+
+
+class TestReturnPeriodsConstant:
+    """Tests for RETURN_PERIODS dictionary constant."""
+
+    def test_正常系_RETURN_PERIODSに全期間が含まれる(self) -> None:
+        """RETURN_PERIODS が期待される全ての期間を含むことを確認。"""
+        expected_periods = [
+            "1D",
+            "1W",
+            "MTD",
+            "1M",
+            "3M",
+            "6M",
+            "YTD",
+            "1Y",
+            "3Y",
+            "5Y",
+        ]
+        assert set(RETURN_PERIODS.keys()) == set(expected_periods)
+
+    def test_正常系_固定期間は整数値(self) -> None:
+        """固定期間（1D, 1W, 1M等）が正しい整数値であることを確認。"""
+        assert RETURN_PERIODS["1D"] == 1
+        assert RETURN_PERIODS["1W"] == 5
+        assert RETURN_PERIODS["1M"] == 21
+        assert RETURN_PERIODS["3M"] == 63
+        assert RETURN_PERIODS["6M"] == 126
+        assert RETURN_PERIODS["1Y"] == 252
+        assert RETURN_PERIODS["3Y"] == 756
+        assert RETURN_PERIODS["5Y"] == 1260
+
+    def test_正常系_動的期間は文字列(self) -> None:
+        """MTD と YTD が文字列マーカーであることを確認。"""
+        assert RETURN_PERIODS["MTD"] == "mtd"
+        assert RETURN_PERIODS["YTD"] == "ytd"
+
+
+# =============================================================================
+# Tests for ticker constants
+# =============================================================================
+
+
+class TestTickerConstants:
+    """Tests for ticker list constants."""
+
+    def test_正常系_グローバル指数ティッカーが含まれる(self) -> None:
+        """TICKERS_GLOBAL_INDICES が期待されるティッカーを含むことを確認。"""
+        expected_tickers = [
+            "^N225",  # 日経225
+            "^TOPX",  # TOPIX
+            "^STOXX50E",  # Euro STOXX 50
+            "^FTSE",  # FTSE 100
+            "^GDAXI",  # DAX
+            "000001.SS",  # 上海総合
+            "^HSI",  # ハンセン指数
+        ]
+        for ticker in expected_tickers:
+            assert ticker in TICKERS_GLOBAL_INDICES
+
+    def test_正常系_US指数ティッカーが含まれる(self) -> None:
+        """TICKERS_US_INDICES が期待されるティッカーを含むことを確認。"""
+        expected_tickers = [
+            "^GSPC",  # S&P 500
+            "^DJI",  # Dow Jones Industrial Average
+            "^IXIC",  # NASDAQ Composite
+            "^RUT",  # Russell 2000
+        ]
+        for ticker in expected_tickers:
+            assert ticker in TICKERS_US_INDICES
+
+    def test_正常系_MAG7ティッカーが含まれる(self) -> None:
+        """TICKERS_MAG7 が期待されるティッカーを含むことを確認。"""
+        expected_tickers = [
+            "AAPL",  # Apple
+            "MSFT",  # Microsoft
+            "GOOGL",  # Alphabet (Google)
+            "AMZN",  # Amazon
+            "NVDA",  # NVIDIA
+            "META",  # Meta (Facebook)
+            "TSLA",  # Tesla
+        ]
+        for ticker in expected_tickers:
+            assert ticker in TICKERS_MAG7
+
+    def test_正常系_セクターティッカーが含まれる(self) -> None:
+        """TICKERS_SECTORS が期待されるセクターETFを含むことを確認。"""
+        expected_tickers = [
+            "XLF",  # Financial
+            "XLK",  # Technology
+            "XLV",  # Health Care
+            "XLE",  # Energy
+            "XLI",  # Industrial
+        ]
+        for ticker in expected_tickers:
+            assert ticker in TICKERS_SECTORS
+
+
+# =============================================================================
+# Tests for calculate_return function
+# =============================================================================
+
+
+class TestCalculateReturn:
+    """Tests for calculate_return function."""
+
+    def test_正常系_1日リターンを計算できる(
+        self,
+        sample_prices_short: pd.Series,
+    ) -> None:
+        """1日リターンが正しく計算されることを確認。"""
+        # prices: [100.0, 101.0, 102.0, ...]
+        # 1日リターン: (107.0 - 106.0) / 106.0 = 0.00943...
+        result = calculate_return(sample_prices_short, period=1)
+
+        # 最新日と前日の騰落率
+        expected = (107.0 - 106.0) / 106.0
+        assert result is not None
+        assert abs(result - expected) < 1e-10
+
+    def test_正常系_5日リターンを計算できる(
+        self,
+        sample_prices_short: pd.Series,
+    ) -> None:
+        """5日（1週間）リターンが正しく計算されることを確認。"""
+        # prices: [100.0, 101.0, 102.0, 101.5, 103.0, 104.0, 103.5, 105.0, 106.0, 107.0]
+        # 5日前 (index 4) = 103.0, 最新 (index 9) = 107.0
+        result = calculate_return(sample_prices_short, period=5)
+
+        expected = (107.0 - 103.0) / 103.0
+        assert result is not None
+        assert abs(result - expected) < 1e-10
+
+    def test_正常系_MTD期間を動的に計算できる(
+        self,
+        sample_prices_mtd: pd.Series,
+    ) -> None:
+        """MTD（月初来）リターンが動的に計算されることを確認。"""
+        result = calculate_return(sample_prices_mtd, period="mtd")
+
+        # MTD: 月初の値から最新値への騰落率
+        month_start_price = sample_prices_mtd.iloc[0]
+        latest_price = sample_prices_mtd.iloc[-1]
+        expected = (latest_price - month_start_price) / month_start_price
+
+        assert result is not None
+        assert abs(result - expected) < 1e-10
+
+    def test_正常系_YTD期間を動的に計算できる(
+        self,
+        sample_prices_ytd: pd.Series,
+    ) -> None:
+        """YTD（年初来）リターンが動的に計算されることを確認。"""
+        result = calculate_return(sample_prices_ytd, period="ytd")
+
+        # YTD: 年初の値から最新値への騰落率
+        year_start_price = sample_prices_ytd.iloc[0]
+        latest_price = sample_prices_ytd.iloc[-1]
+        expected = (latest_price - year_start_price) / year_start_price
+
+        assert result is not None
+        assert abs(result - expected) < 1e-10
+
+    def test_異常系_データ不足でNoneを返す(self) -> None:
+        """データが不足している場合にNoneを返すことを確認。"""
+        short_prices = pd.Series(
+            [100.0, 101.0], index=pd.date_range("2024-01-01", periods=2)
+        )
+        result = calculate_return(short_prices, period=10)
+
+        assert result is None
+
+    def test_異常系_空のSeriesでNoneを返す(self) -> None:
+        """空のSeriesでNoneを返すことを確認。"""
+        empty_prices = pd.Series([], dtype=float)
+        result = calculate_return(empty_prices, period=1)
+
+        assert result is None
+
+    def test_異常系_負の期間でValueError(self) -> None:
+        """負の期間でValueErrorが発生することを確認。"""
+        prices = pd.Series(
+            [100.0, 101.0, 102.0], index=pd.date_range("2024-01-01", periods=3)
+        )
+
+        with pytest.raises(ValueError, match="period must be positive"):
+            calculate_return(prices, period=-1)
+
+    def test_異常系_ゼロ期間でValueError(self) -> None:
+        """ゼロの期間でValueErrorが発生することを確認。"""
+        prices = pd.Series(
+            [100.0, 101.0, 102.0], index=pd.date_range("2024-01-01", periods=3)
+        )
+
+        with pytest.raises(ValueError, match="period must be positive"):
+            calculate_return(prices, period=0)
+
+    def test_エッジケース_NaN値を含むデータ(self) -> None:
+        """NaN値を含むデータで適切にハンドリングされることを確認。"""
+        prices = pd.Series(
+            [100.0, np.nan, 102.0, 103.0, 104.0],
+            index=pd.date_range("2024-01-01", periods=5),
+        )
+        result = calculate_return(prices, period=1)
+
+        # NaNを除外して計算されることを期待
+        # 除外後: [100.0, 102.0, 103.0, 104.0]
+        # 1日リターン: (104.0 - 103.0) / 103.0
+        assert result is not None or result is None  # 実装依存
+
+
+# =============================================================================
+# Tests for calculate_multi_period_returns function
+# =============================================================================
+
+
+class TestCalculateMultiPeriodReturns:
+    """Tests for calculate_multi_period_returns function."""
+
+    def test_正常系_全期間のリターンを計算できる(
+        self,
+        sample_prices: pd.Series,
+    ) -> None:
+        """RETURN_PERIODS の全期間のリターンを計算できることを確認。"""
+        result = calculate_multi_period_returns(sample_prices)
+
+        # 全期間のキーが存在することを確認
+        for period in RETURN_PERIODS:
+            assert period in result
+
+    def test_正常系_結果がdict型(
+        self,
+        sample_prices: pd.Series,
+    ) -> None:
+        """結果がdict[str, float | None]型であることを確認。"""
+        result = calculate_multi_period_returns(sample_prices)
+
+        assert isinstance(result, dict)
+        for key, value in result.items():
+            assert isinstance(key, str)
+            assert value is None or isinstance(value, float)
+
+    def test_正常系_短いデータでは長期間がNone(
+        self,
+        sample_prices_short: pd.Series,
+    ) -> None:
+        """データが短い場合、長期間のリターンがNoneであることを確認。"""
+        result = calculate_multi_period_returns(sample_prices_short)
+
+        # 10日分のデータなので1Y, 3Y, 5YはNone
+        assert result["1Y"] is None
+        assert result["3Y"] is None
+        assert result["5Y"] is None
+
+        # 短期間は計算可能
+        assert result["1D"] is not None
+        assert result["1W"] is not None
+
+    def test_正常系_MTDとYTDが含まれる(
+        self,
+        sample_prices: pd.Series,
+    ) -> None:
+        """MTDとYTDがリターン結果に含まれることを確認。"""
+        result = calculate_multi_period_returns(sample_prices)
+
+        assert "MTD" in result
+        assert "YTD" in result
+
+    def test_異常系_空のSeriesで全てNoneを返す(self) -> None:
+        """空のSeriesで全ての値がNoneのdictを返すことを確認。"""
+        empty_prices = pd.Series([], dtype=float)
+        result = calculate_multi_period_returns(empty_prices)
+
+        # 全ての値がNoneであることを確認
+        for value in result.values():
+            assert value is None
+
+
+# =============================================================================
+# Tests for fetch_topix_data function
+# =============================================================================
+
+
+class TestFetchTopixData:
+    """Tests for fetch_topix_data function with fallback logic."""
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_TOPX成功時はTOPXデータを返す(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """^TOPX の取得が成功した場合、そのデータを返すことを確認。"""
+        mock_download.return_value = mock_yfinance_data
+
+        result = fetch_topix_data()
+
+        assert result is not None
+        assert not result.empty
+        mock_download.assert_called_once()
+        # ^TOPX で呼ばれたことを確認
+        call_args = mock_download.call_args
+        assert "^TOPX" in str(call_args)
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_TOPX失敗時は1306Tにフォールバック(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """^TOPX の取得が失敗した場合、1306.T にフォールバックすることを確認。"""
+
+        # 最初の呼び出し（^TOPX）は空のDataFrame、2回目（1306.T）は成功
+        def side_effect(*args, **kwargs):
+            ticker = args[0] if args else kwargs.get("tickers", "")
+            if "^TOPX" in str(ticker):
+                return pd.DataFrame()  # 空のDataFrame（失敗）
+            return mock_yfinance_data  # 1306.T は成功
+
+        mock_download.side_effect = side_effect
+
+        result = fetch_topix_data()
+
+        assert result is not None
+        assert not result.empty
+        # 2回呼ばれることを確認
+        assert mock_download.call_count == 2
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_異常系_両方失敗時はNoneを返す(
+        self,
+        mock_download: MagicMock,
+    ) -> None:
+        """^TOPX と 1306.T の両方が失敗した場合、Noneを返すことを確認。"""
+        mock_download.return_value = pd.DataFrame()  # 常に空を返す
+
+        result = fetch_topix_data()
+
+        assert result is None
+        # 2回呼ばれることを確認（^TOPX と 1306.T）
+        assert mock_download.call_count == 2
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_異常系_例外発生時はフォールバック(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """^TOPX で例外が発生した場合、1306.T にフォールバックすることを確認。"""
+
+        def side_effect(*args, **kwargs):
+            ticker = args[0] if args else kwargs.get("tickers", "")
+            if "^TOPX" in str(ticker):
+                raise Exception("API Error")
+            return mock_yfinance_data
+
+        mock_download.side_effect = side_effect
+
+        result = fetch_topix_data()
+
+        assert result is not None
+        assert not result.empty
+
+
+# =============================================================================
+# Tests for generate_returns_report function
+# =============================================================================
+
+
+class TestGenerateReturnsReport:
+    """Tests for generate_returns_report function."""
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_レポート構造が正しい(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """レポートが期待される構造を持つことを確認。"""
+        mock_download.return_value = mock_yfinance_data
+
+        result = generate_returns_report()
+
+        assert "as_of" in result
+        assert "indices" in result
+        assert "mag7" in result
+        assert "sectors" in result
+        assert "global_indices" in result
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_as_ofがISO形式の日時(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """as_of が ISO 8601 形式の日時文字列であることを確認。"""
+        mock_download.return_value = mock_yfinance_data
+
+        result = generate_returns_report()
+
+        as_of = result["as_of"]
+        # ISO 8601 形式でパースできることを確認
+        parsed = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
+        assert isinstance(parsed, datetime)
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_指定日時でレポート生成(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """指定した日時でレポートが生成されることを確認。"""
+        mock_download.return_value = mock_yfinance_data
+        specified_time = datetime(2024, 6, 15, 16, 0, 0)
+
+        result = generate_returns_report(as_of=specified_time)
+
+        as_of = result["as_of"]
+        assert "2024-06-15" in as_of
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_global_indicesにグローバル指数が含まれる(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """global_indices にグローバル指数データが含まれることを確認。"""
+        mock_download.return_value = mock_yfinance_data
+
+        result = generate_returns_report()
+
+        global_indices = result["global_indices"]
+        assert isinstance(global_indices, list)
+        # 少なくとも1つの指数データが含まれることを確認
+        if global_indices:
+            index_entry = global_indices[0]
+            assert "ticker" in index_entry or "symbol" in index_entry
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_indicesに主要指数が含まれる(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """indices に主要な市場指数データが含まれることを確認。"""
+        mock_download.return_value = mock_yfinance_data
+
+        result = generate_returns_report()
+
+        indices = result["indices"]
+        assert isinstance(indices, list)
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_mag7にMAG7銘柄が含まれる(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """mag7 セクションに MAG7 銘柄データが含まれることを確認。"""
+        mock_download.return_value = mock_yfinance_data
+
+        result = generate_returns_report()
+
+        mag7 = result["mag7"]
+        assert isinstance(mag7, list)
+
+    @patch("analyze.returns.returns.yf.download")
+    def test_正常系_sectorsにセクターデータが含まれる(
+        self,
+        mock_download: MagicMock,
+        mock_yfinance_data: pd.DataFrame,
+    ) -> None:
+        """sectors セクションにセクターETFデータが含まれることを確認。"""
+        mock_download.return_value = mock_yfinance_data
+
+        result = generate_returns_report()
+
+        sectors = result["sectors"]
+        assert isinstance(sectors, list)
+
+
+# =============================================================================
+# Tests for edge cases and error handling
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_エッジケース_週末を含むデータでの計算(self) -> None:
+        """週末を含むデータで正しく計算されることを確認。"""
+        # 営業日のみのデータを作成
+        dates = pd.date_range("2024-01-01", periods=20, freq="B")
+        prices = pd.Series(range(100, 120), index=dates, dtype=float)
+
+        result = calculate_return(prices, period=5)
+
+        # 5営業日前と現在の比較
+        assert result is not None
+
+    def test_エッジケース_祝日を含むデータでの計算(self) -> None:
+        """祝日を含むデータ（欠損日がある）で正しく計算されることを確認。"""
+        # 一部の日が欠損しているデータ
+        dates = pd.to_datetime(
+            ["2024-01-02", "2024-01-03", "2024-01-05", "2024-01-08", "2024-01-09"]
+        )
+        prices = pd.Series([100.0, 101.0, 102.0, 103.0, 104.0], index=dates)
+
+        result = calculate_return(prices, period=2)
+
+        # 2日前のインデックス位置から計算
+        assert result is not None
+
+    @pytest.mark.parametrize(
+        "period_key,expected_type",
+        [
+            ("1D", int),
+            ("1W", int),
+            ("MTD", str),
+            ("1M", int),
+            ("3M", int),
+            ("6M", int),
+            ("YTD", str),
+            ("1Y", int),
+            ("3Y", int),
+            ("5Y", int),
+        ],
+    )
+    def test_パラメトライズ_各期間の型が正しい(
+        self,
+        period_key: str,
+        expected_type: type,
+    ) -> None:
+        """各期間の値が期待される型であることを確認。"""
+        assert isinstance(RETURN_PERIODS[period_key], expected_type)
+
+    def test_エッジケース_非常に大きなリターン(self) -> None:
+        """極端なリターン値でもオーバーフローしないことを確認。"""
+        dates = pd.date_range("2024-01-01", periods=5, freq="B")
+        prices = pd.Series([1.0, 10.0, 100.0, 1000.0, 10000.0], index=dates)
+
+        result = calculate_return(prices, period=1)
+
+        # 9900% のリターン
+        assert result is not None
+        assert result == pytest.approx(9.0, rel=1e-10)
+
+    def test_エッジケース_非常に小さなリターン(self) -> None:
+        """非常に小さなリターン値でも精度が保たれることを確認。"""
+        dates = pd.date_range("2024-01-01", periods=5, freq="B")
+        prices = pd.Series([100.0, 100.0001, 100.0002, 100.0003, 100.0004], index=dates)
+
+        result = calculate_return(prices, period=1)
+
+        # 非常に小さいリターン
+        assert result is not None
+        assert abs(result) < 0.001


### PR DESCRIPTION
## 概要

- `market_analysis/analysis/returns.py` を `analyze/returns/` に移植
- TDDアプローチで実装（テスト46件、全パス）
- `make check-all` 通過済み

## 変更内容

### 新規ファイル
- `src/analyze/__init__.py` - analyzeパッケージ初期化
- `src/analyze/returns/__init__.py` - 公開API定義
- `src/analyze/returns/returns.py` - メイン実装
- `tests/analyze/unit/returns/test_returns.py` - 単体テスト（46件）

### 実装機能
- **定数**: `RETURN_PERIODS`, `TICKERS_GLOBAL_INDICES`, `TICKERS_US_INDICES`, `TICKERS_MAG7`, `TICKERS_SECTORS`
- **関数**: `calculate_return`, `calculate_multi_period_returns`, `fetch_topix_data`, `generate_returns_report`

## テストプラン

- [x] `uv run pytest tests/analyze/unit/returns/test_returns.py -v` 全46テストパス
- [x] `make check-all` パス（format, lint, typecheck, security）

## 関連Issue

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)