### PR TITLE
fix(rss): test_lock_manager の .lock 永続化 assertion を filelock 3.20+ 挙動に追従 (#3954)

### DIFF
--- a/tests/rss/unit/storage/test_lock_manager.py
+++ b/tests/rss/unit/storage/test_lock_manager.py
@@ -38,7 +38,12 @@ class TestLockFeeds:
     """Test lock_feeds context manager."""
 
     def test_lock_feeds_creates_lock_file(self, tmp_path: Path) -> None:
-        """Test that lock_feeds creates .feeds.lock file."""
+        """Test that lock_feeds creates .feeds.lock file while held.
+
+        Note: filelock 3.20+ UnixFileLock deletes the lock file on release
+        (see filelock._unix.UnixFileLock._release). Therefore we only assert
+        the file exists during the locked context, not after release.
+        """
         manager = LockManager(tmp_path)
         lock_file = tmp_path / ".feeds.lock"
 
@@ -48,8 +53,9 @@ class TestLockFeeds:
             # Lock file should exist while lock is held
             assert lock_file.exists()
 
-        # Lock file should still exist after release (FileLock behavior)
-        assert lock_file.exists()
+        # filelock 3.20+ removes the .lock file on release on Unix/macOS.
+        # We do not assert on post-release existence to remain compatible
+        # with both legacy and current filelock behavior.
 
     def test_lock_feeds_acquires_and_releases(self, tmp_path: Path) -> None:
         """Test that lock_feeds successfully acquires and releases lock."""
@@ -127,7 +133,12 @@ class TestLockItems:
     """Test lock_items context manager."""
 
     def test_lock_items_creates_lock_file(self, tmp_path: Path) -> None:
-        """Test that lock_items creates .items.lock file."""
+        """Test that lock_items creates .items.lock file while held.
+
+        Note: filelock 3.20+ UnixFileLock deletes the lock file on release
+        (see filelock._unix.UnixFileLock._release). Therefore we only assert
+        the file exists during the locked context, not after release.
+        """
         manager = LockManager(tmp_path)
         feed_id = "test-feed-id"
         lock_file = tmp_path / feed_id / ".items.lock"
@@ -138,8 +149,9 @@ class TestLockItems:
             # Lock file should exist while lock is held
             assert lock_file.exists()
 
-        # Lock file should still exist after release
-        assert lock_file.exists()
+        # filelock 3.20+ removes the .lock file on release on Unix/macOS.
+        # We do not assert on post-release existence to remain compatible
+        # with both legacy and current filelock behavior.
 
     def test_lock_items_creates_feed_directory(self, tmp_path: Path) -> None:
         """Test that lock_items creates feed directory if it doesn't exist."""


### PR DESCRIPTION
## 概要

Issue #3954: `tests/rss/unit/storage/test_lock_manager.py` の以下 2 件の単体テストが、依存 upgrade（uv.lock 最新化、filelock 3.29.0）以降失敗していた問題を修正。

- `TestLockFeeds::test_lock_feeds_creates_lock_file`
- `TestLockItems::test_lock_items_creates_lock_file`

## 原因

`filelock 3.20+` で `UnixFileLock._release()` の実装が変更され、Unix/macOS では release 時に `Path(self.lock_file).unlink()` が必ず呼ばれるようになった（`filelock._unix.UnixFileLock` docstring に「Lock file cleanup: Unix and macOS delete the lock file reliably after release」と明記）。

両テストは release 後に `.lock` ファイルが残ることを `assert` していたが、これは旧 filelock の偶発的挙動に依存していた。

## 修正方針

Issue に列挙された 3 つの選択肢のうち **選択肢 C（テスト側を新挙動に合わせる）** を採用。

- 実装（`src/rss/storage/lock_manager.py`）は filelock の公開 API（context manager / timeout / FileLockError 変換）に正しく準拠しており、振る舞い面の不具合は無いため変更不要。
- テストでは release 後の `.lock` 存在 assert を削除し、「ロック保持中はファイルが存在する」ことのみ検証する形に変更。
- Docstring に filelock 3.20+ の挙動と「post-release は assert しない理由」をコメントで明記。

なお `tests/rss/storage/unit/test_json_storage.py` は元々 `not lock_file.exists() or lock_file.stat().st_size == 0` という新挙動互換の書き方をしており修正不要。`tests/rss/integration/test_feed_workflow.py` も release 後の存在 assert は行っていない。

## テストプラン

- [x] `uv run pytest tests/rss/unit/storage/test_lock_manager.py -v` → 18/18 PASS
- [x] `uv run pytest tests/rss/` → 2016 PASS（playwright 未導入による無関係 1 件のみ FAIL）
- [x] `uv run ruff check tests/rss/unit/storage/test_lock_manager.py src/rss/storage/lock_manager.py` → All checks passed
- [x] `uv run pyright tests/rss/unit/storage/test_lock_manager.py src/rss/storage/lock_manager.py` → 0 errors
- [ ] CI Unit Tests ジョブで該当 2 件が解消することを確認

## 受け入れ条件（Issue より）

- [x] 該当 2 件のテストが `make test` でローカル成功
- [ ] CI Unit Tests ジョブで本 2 件が解消（PR push 後に確認）
- [x] 実装と test の整合性が取れている（filelock の現行 API に準拠）
- [x] pre-commit の rss スコープ（ruff/pyright/bandit）でエラーなし
  - 注: `notebook/FILING_NLP/` 由来の既存 ruff 警告は本 PR と無関係（PR #3952 でスコープ限定済み）

## 関連

- Fixes #3954
- 観測 PR: #3949, #3952
- filelock 3.29.0 の挙動: `filelock._unix.UnixFileLock._release` で `Path(self.lock_file).unlink()` を実行