### PR TITLE
fix(ci): Unit Tests 45件失敗を解消 (#3954 #3963 #3964)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,8 @@ notebook/__marimo__/
 # ======================================================================
 data/Transcript/
 data/duckdb/
-data/raw/
-data/exports/
+data/raw
+data/exports
 data/processed/
 data/market/
 data/sqlite/

--- a/data/exports
+++ b/data/exports
@@ -1,1 +1,0 @@
-/Volumes/personal_folder/data/exports

--- a/data/raw
+++ b/data/raw
@@ -1,1 +1,0 @@
-/Volumes/personal_folder/data/raw

--- a/tests/market/asean_common/unit/test_schema.py
+++ b/tests/market/asean_common/unit/test_schema.py
@@ -152,13 +152,15 @@ class TestUpsertTickersSchemaValidation:
         )
 
         # Patch _build_ticker_df to return our invalid DataFrame
+        # Note: pandera raises SchemaErrors (plural) for coerce_dtype failures.
+        # Older versions raised SchemaError (singular); accept both for compatibility.
         with (
             patch.object(
                 storage,
                 "_build_ticker_df",
                 return_value=invalid_df,
             ),
-            pytest.raises(pandera.errors.SchemaError),
+            pytest.raises((pandera.errors.SchemaError, pandera.errors.SchemaErrors)),
         ):
             storage.upsert_tickers(
                 [

--- a/tests/market/market_common/unit/test_schema.py
+++ b/tests/market/market_common/unit/test_schema.py
@@ -152,13 +152,15 @@ class TestUpsertTickersSchemaValidation:
         )
 
         # Patch _build_ticker_df to return our invalid DataFrame
+        # Note: pandera raises SchemaErrors (plural) for coerce_dtype failures.
+        # Older versions raised SchemaError (singular); accept both for compatibility.
         with (
             patch.object(
                 storage,
                 "_build_ticker_df",
                 return_value=invalid_df,
             ),
-            pytest.raises(pandera.errors.SchemaError),
+            pytest.raises((pandera.errors.SchemaError, pandera.errors.SchemaErrors)),
         ):
             storage.upsert_tickers(
                 [

--- a/tests/rss/unit/storage/test_lock_manager.py
+++ b/tests/rss/unit/storage/test_lock_manager.py
@@ -38,7 +38,12 @@ class TestLockFeeds:
     """Test lock_feeds context manager."""
 
     def test_lock_feeds_creates_lock_file(self, tmp_path: Path) -> None:
-        """Test that lock_feeds creates .feeds.lock file."""
+        """Test that lock_feeds creates .feeds.lock file while held.
+
+        Note: filelock 3.20+ UnixFileLock deletes the lock file on release
+        (see filelock._unix.UnixFileLock._release). Therefore we only assert
+        the file exists during the locked context, not after release.
+        """
         manager = LockManager(tmp_path)
         lock_file = tmp_path / ".feeds.lock"
 
@@ -48,8 +53,9 @@ class TestLockFeeds:
             # Lock file should exist while lock is held
             assert lock_file.exists()
 
-        # Lock file should still exist after release (FileLock behavior)
-        assert lock_file.exists()
+        # filelock 3.20+ removes the .lock file on release on Unix/macOS.
+        # We do not assert on post-release existence to remain compatible
+        # with both legacy and current filelock behavior.
 
     def test_lock_feeds_acquires_and_releases(self, tmp_path: Path) -> None:
         """Test that lock_feeds successfully acquires and releases lock."""
@@ -127,7 +133,12 @@ class TestLockItems:
     """Test lock_items context manager."""
 
     def test_lock_items_creates_lock_file(self, tmp_path: Path) -> None:
-        """Test that lock_items creates .items.lock file."""
+        """Test that lock_items creates .items.lock file while held.
+
+        Note: filelock 3.20+ UnixFileLock deletes the lock file on release
+        (see filelock._unix.UnixFileLock._release). Therefore we only assert
+        the file exists during the locked context, not after release.
+        """
         manager = LockManager(tmp_path)
         feed_id = "test-feed-id"
         lock_file = tmp_path / feed_id / ".items.lock"
@@ -138,8 +149,9 @@ class TestLockItems:
             # Lock file should exist while lock is held
             assert lock_file.exists()
 
-        # Lock file should still exist after release
-        assert lock_file.exists()
+        # filelock 3.20+ removes the .lock file on release on Unix/macOS.
+        # We do not assert on post-release existence to remain compatible
+        # with both legacy and current filelock behavior.
 
     def test_lock_items_creates_feed_directory(self, tmp_path: Path) -> None:
         """Test that lock_items creates feed directory if it doesn't exist."""


### PR DESCRIPTION
## 概要

PR #3955 で観測された Unit Tests 失敗を 3 Issue まとめて修正:

- **#3954 (2件)**: filelock 3.20+ で `.lock` ファイル永続化挙動が変更
- **#3963 (41件)**: `data/raw`・`data/exports` の git symlink が CI で broken symlink になり、`mkdir(parents=True, exist_ok=True)` で `is_dir() == False` のため `FileExistsError` を漏らしていた
- **#3964 (2件)**: pandera のバージョンアップで coerce_dtype 失敗時の例外が `SchemaError` (単数形) → `SchemaErrors` (複数形) に変化、`pytest.raises(SchemaError)` で受け取れなくなった

PR #3955 (#3954 単独) はこの PR に統合してクローズします。

## 変更内容

### Issue #3954: filelock 3.20+ 対応

- `tests/rss/unit/storage/test_lock_manager.py`: `.lock` ファイル永続化 assertion を新挙動に追従

### Issue #3963: `data/raw`・`data/exports` の symlink 削除

- `git rm --cached data/raw data/exports`（ローカルの個人 NAS 向け symlink は維持）
- `.gitignore` の `data/raw/`、`data/exports/` を末尾スラッシュなしに変更し、symlink ファイル自体もパターンマッチ対象に

### Issue #3964: pandera 新挙動に追従

- `tests/market/asean_common/unit/test_schema.py`: `pytest.raises((SchemaError, SchemaErrors))` で両対応
- `tests/market/market_common/unit/test_schema.py`: 同上

## Note

リポジトリには他にも `data/Transcript`、`data/duckdb`、`data/market` 等の symlink がコミットされている（合計 11 個）。本 PR ではテスト失敗を起こしている `data/raw`・`data/exports` のみ削除する保守的スコープ。
他の symlink は今後同じ問題を起こす可能性があるが、現状の CI 失敗には関与していないため別件として扱う。

## 受け入れ条件

- [x] Issue #3964 該当テスト 2 件がローカルで PASS
- [ ] CI Unit Tests で 45 件失敗が全解消
- [ ] `make check-all` が成功

## テストプラン

- [ ] CI Unit Tests Python 3.12 on ubuntu-latest が成功

## 関連

- Closes #3954
- Closes #3963
- Closes #3964
- 統合元: PR #3955