### PR TITLE
feat(market.fraser): FRASER REST API サブパッケージ (#3956-#3962)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,6 @@ GH_TOKEN=ghp_xxxxxxxxxxxx
 # FRED series configuration file (URL or local path)
 # Default: ./data/config/fred_series.json (relative to current working directory)
 # FRED_SERIES_ID_JSON=/path/to/fred_series.json
+
+# FRASER REST API key (https://fraser.stlouisfed.org/api - POST /api/api_key で発行)
+FRASER_API_KEY=your_api_key_here

--- a/data/config/fraser_titles.json
+++ b/data/config/fraser_titles.json
@@ -1,0 +1,8 @@
+{
+  "beige_book": null,
+  "fomc_minutes": 677,
+  "fomc_press_conferences": null,
+  "fomc_statements": null,
+  "frb_speeches": null,
+  "monetary_policy_report": null
+}

--- a/notebook/FRASER/fraser_demo.ipynb
+++ b/notebook/FRASER/fraser_demo.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fraser-demo-title",
+   "metadata": {},
+   "source": [
+    "# FRASER ライブラリ検証 demo notebook\n",
+    "\n",
+    "このノートブックは `market.fraser` ライブラリ（FRASER REST API クライアント）の動作確認用 thin demo です。\n",
+    "FOMC Minutes / Beige Book を実 API から取得し、`data/raw/fraser/` への保存と SQLite キャッシュ統合を確認します。\n",
+    "\n",
+    "## 前提条件\n",
+    "\n",
+    "- `FRASER_API_KEY` が `.env` に設定済み（取得方法は `src/market/fraser/README.md` を参照）\n",
+    "- インターネット接続（`https://fraser.stlouisfed.org/api/` にアクセス可能）\n",
+    "- `uv sync --all-extras` 完了済み\n",
+    "\n",
+    "## scope\n",
+    "\n",
+    "本 notebook は **ライブラリ動作確認** のみを目的とした thin demo です。NLP 前処理・センチメント分析・エンベディング投入などの下流処理は `notebook/FILING_NLP/` 側に委譲します（最終セル参照）。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fraser-demo-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": "from __future__ import annotations\n\nfrom pathlib import Path\n\nfrom dotenv import load_dotenv\n\nfrom market.fraser import (\n    BeigeBookFetcher,\n    FOMCMinutesFetcher,\n    FraserClient,\n)\n\n# .env から FRASER_API_KEY を環境変数として読込（FraserClient() が自動参照）\nload_dotenv()\n\nclient = FraserClient()\nprint(f\"FraserClient initialised: base_url={client.config.base_url}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fraser-demo-fomc-minutes",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demo 1: FOMC Minutes — 2024年の一覧取得 + 先頭1件のテキストDL\n",
+    "fetcher = FOMCMinutesFetcher(client=client)\n",
+    "meetings = fetcher.list_minutes((2024, 2024))\n",
+    "print(f\"Found {len(meetings)} FOMC Minutes in 2024\")\n",
+    "\n",
+    "if meetings:\n",
+    "    path, meeting = fetcher.fetch_text(meetings[0].item_id, prefer=\"txt\")\n",
+    "    assert isinstance(path, Path)\n",
+    "    print(f\"Saved: {path} ({path.stat().st_size:,} bytes)\")\n",
+    "    print(f\"meeting_date: {meeting.meeting_date}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fraser-demo-beige-book",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demo 2: Beige Book — 2024年分を並列DL（max_workers=4、30 req/min レート制限を尊重）\n",
+    "bb_fetcher = BeigeBookFetcher(client=client)\n",
+    "results = bb_fetcher.fetch_all((2024, 2024), max_workers=4)\n",
+    "\n",
+    "ok = sum(1 for v in results.values() if isinstance(v, Path))\n",
+    "print(f\"Downloaded {ok} / {len(results)} Beige Book reports\")\n",
+    "for item_id, value in list(results.items())[:3]:\n",
+    "    if isinstance(value, Path):\n",
+    "        print(f\"  - item_id={item_id}: {value} ({value.stat().st_size:,} bytes)\")\n",
+    "    else:\n",
+    "        print(f\"  - item_id={item_id}: ERROR {type(value).__name__}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fraser-demo-next-steps",
+   "metadata": {},
+   "source": [
+    "## 次ステップ — 下流 NLP パイプライン接続点\n",
+    "\n",
+    "本 notebook は FRASER ライブラリの動作確認のみを対象とした thin demo です。\n",
+    "下流の NLP パイプライン（FinBERT センチメント、エンベディング投入、レジーム接続など）は別レイヤーで実装されます:\n",
+    "\n",
+    "- [`notebook/FILING_NLP/`](../FILING_NLP/) — SEC Filings NLP パイプライン（FinBERT センチメント・チャンク化・埋め込み）。FRASER で取得した FOMC / Beige Book テキストも同パイプラインに投入可能です。\n",
+    "- `src/embedding/` — ChromaDB 投入パッケージ。FRASER 文書をベクトル DB に登録する場合の入口です。\n",
+    "- `src/factor/`（将来）— regime-switching 因子と FOMC センチメントを統合する factor 実装の予定。\n",
+    "\n",
+    "### 動作確認チェックリスト\n",
+    "\n",
+    "- [ ] `data/raw/fraser/fomc/minutes/` に txt または pdf が保存されている\n",
+    "- [ ] `data/raw/fraser/beige_book/` に複数の PDF / TXT が保存されている\n",
+    "- [ ] `data/cache/market_data.db` の `cache` テーブルに `fraser:` プレフィクスのキーが存在する\n",
+    "\n",
+    "### API key 運用\n",
+    "\n",
+    "API key の revoke + 再発行手順は `src/market/fraser/README.md` の Troubleshooting セクション「API キーを失効・再発行したい」を参照してください。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/market/fraser/README.md
+++ b/src/market/fraser/README.md
@@ -1,0 +1,320 @@
+# market.fraser
+
+FRASER（Federal Reserve Archival System for Economic Research）REST API を使用して連邦準備制度のアーカイブ文書（FOMC Minutes、Beige Book、Federal Reserve Board Speeches など）を取得するモジュール。
+
+## Features
+
+- **30 req/min レート制限を尊重する `DualWindowRateLimiter`**: 1分窓・1時間窓の両方を監視し、`market.alphavantage.rate_limiter` の実装を再利用。
+- **SQLite キャッシュ統合**: `market.cache.SQLiteCache` を共有し、エンドポイント別に最適化された TTL（アイテムメタデータ 24h、マスターリスト 7d など）でキャッシュ。
+- **SSRF / CWE-209 / CWE-532 対策**: ホスト名ホワイトリスト（`ALLOWED_HOSTS`）、レスポンスログ切り詰め（`MAX_RESPONSE_BODY_LOG`）、`FraserConfig.api_key` の `repr=False`。
+- **Pydantic V2 ドメインモデル**: `FraserItem` / `FOMCMeeting` / `BeigeBookReport` などを `populate_by_name=True` + `extra='ignore'` で前方互換に設計。
+- **アトミックファイルダウンロード**: `tempfile.NamedTemporaryFile` + `Path.replace()` で部分ファイルが残らない。`item_id` 単位のロックで同一アイテムの重複ダウンロードを防止。
+
+## インストール
+
+このモジュールは `market` パッケージの一部です。
+
+```bash
+# リポジトリ全体の依存関係をインストール
+uv sync --all-extras
+```
+
+## 設定
+
+### API キーの取得
+
+FRASER API キーは `POST /api/api_key` で発行します（無料・即時）。
+
+```bash
+# 1. 申請者の email を含めてリクエスト
+curl -X POST "https://fraser.stlouisfed.org/api/api_key" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "your@example.com"}'
+# レスポンスに API キーが含まれます。
+```
+
+### API キーの設定
+
+**方法1: `.env` ファイル（推奨）**
+
+```bash
+# .env に追加（リポジトリ直下）
+FRASER_API_KEY=your_api_key_here
+```
+
+**方法2: 環境変数**
+
+```bash
+export FRASER_API_KEY="your_api_key_here"
+```
+
+**方法3: 直接指定**
+
+```python
+from market.fraser import FraserClient, FraserConfig
+
+client = FraserClient(config=FraserConfig(api_key="your_api_key_here"))
+```
+
+## Quick Start
+
+### ユースケース 1: 2024 年の FOMC Minutes 一覧取得
+
+```python
+from market.fraser import FOMCMinutesFetcher
+
+# 1. FOMCMinutesFetcher を作成（.env から API キー自動読込）
+fetcher = FOMCMinutesFetcher()
+
+# 2. 2024 年の FOMC Minutes を取得
+meetings = fetcher.list_minutes(year_range=(2024, 2024))
+
+# 3. 結果を確認
+print(f"取得件数: {len(meetings)}")
+for meeting in meetings:
+    print(f"  - {meeting.date.isoformat()}: itemId={meeting.item_id} | {meeting.title}")
+```
+
+**出力例:**
+
+```
+取得件数: 8
+  - 2024-01-31: itemId=634123 | Minutes of the FOMC Meeting, January 30-31, 2024
+  - 2024-03-20: itemId=634124 | Minutes of the FOMC Meeting, March 19-20, 2024
+  - 2024-05-01: itemId=634125 | Minutes of the FOMC Meeting, April 30-May 1, 2024
+  ...
+```
+
+### ユースケース 2: 特定 Minutes の TXT ダウンロード + メタデータ保存
+
+```python
+from market.fraser import FOMCMinutesFetcher
+
+fetcher = FOMCMinutesFetcher()
+
+# item_id を指定して TXT を取得（PDF にフォールバック可能）
+path, meeting = fetcher.fetch_text(item_id=634123, prefer="txt")
+
+print(f"保存先: {path}")
+print(f"ファイルサイズ: {path.stat().st_size} bytes")
+print(f"メタデータ: {path.with_suffix('.meta.json')}")
+print(f"meeting_date: {meeting.meeting_date}")
+```
+
+**出力例:**
+
+```
+保存先: data/raw/fraser/fomc/minutes/2024-01-31_634123.txt
+ファイルサイズ: 87543 bytes
+メタデータ: data/raw/fraser/fomc/minutes/2024-01-31_634123.meta.json
+meeting_date: 2024-01-31
+```
+
+## 公開サーフェス（HF1 確定: 8 シンボル）
+
+`from market.fraser import ...` で利用可能なシンボルは以下の 8 つに限定されています。
+内部ユーティリティ（`FraserSession`, `FraserDownloader`, `parser.*` など）は
+サブモジュールから直接インポートしてください。
+
+| シンボル | 種別 | 用途 |
+|---------|------|------|
+| `FraserClient` | クラス | REST API クライアント本体 |
+| `FOMCMinutesFetcher` | クラス | FOMC Minutes 取得（PR3 で追加） |
+| `FraserConfig` | dataclass | 設定（認証・タイムアウト・レート制限） |
+| `FOMCMeeting` | Pydantic V2 model | FOMC ミーティングのドメインモデル |
+| `FraserError` | 例外基底 | 全 FRASER 例外の catch-all |
+| `FraserAuthError` | 例外 | 認証失敗（401/403） |
+| `FraserParseError` | 例外 | レスポンスパース失敗 |
+| `FraserRateLimitError` | 例外 | レート制限超過（429） |
+
+## API Reference
+
+### `FraserClient`
+
+```python
+class FraserClient:
+    def __init__(
+        self,
+        config: FraserConfig | None = None,
+        session: FraserSession | None = None,
+        cache: SQLiteCache | None = None,
+    ) -> None: ...
+
+    def list_items(self, title_id: int, limit: int = 50, page: int = 1, *, use_cache: bool = True) -> list[FraserItem]: ...
+    def get_item(self, item_id: int, *, use_cache: bool = True) -> FraserItem: ...
+    def get_title(self, title_id: int, *, use_cache: bool = True) -> FraserTitle: ...
+    def get_toc(self, item_id: int, *, use_cache: bool = True) -> list[FraserTocEntry]: ...
+    def get_authors(self, *, use_cache: bool = True) -> list[FraserAuthor]: ...
+    def get_subjects(self, *, use_cache: bool = True) -> list[FraserSubject]: ...
+    def get_themes(self, *, use_cache: bool = True) -> list[FraserTheme]: ...
+    def get_timeline(self, title_id: int, *, use_cache: bool = True) -> list[FraserTimelineEvent]: ...
+```
+
+### `FOMCMinutesFetcher`
+
+```python
+class FOMCMinutesFetcher(BaseFraserFetcher):
+    doc_type: DocType  # = DocType.FOMC_MINUTES
+
+    def __init__(
+        self,
+        client: FraserClient | None = None,
+        downloader: FraserDownloader | None = None,
+        base_dir: Path = Path("data/raw/fraser"),
+    ) -> None: ...
+
+    def list_minutes(
+        self,
+        year_range: tuple[int, int],
+        *,
+        limit: int = 100,
+    ) -> list[FOMCMeeting]: ...
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "txt",
+    ) -> tuple[Path, FOMCMeeting]: ...
+
+    def fetch_pdf(self, item_id: int) -> tuple[Path, FOMCMeeting]: ...
+```
+
+| 引数 | 型 | デフォルト | 説明 |
+|------|----|-----------|------|
+| `year_range` | `tuple[int, int]` | 必須 | `(start_year, end_year)` 両端含む |
+| `limit` | `int` | 100 | 1 ページあたりの取得件数 |
+| `item_id` | `int` | 必須 | FRASER アイテム ID |
+| `prefer` | `'txt' \| 'pdf'` | `'txt'` | 優先フォーマット（フォールバック自動） |
+
+### `FraserConfig`
+
+```python
+@dataclass(frozen=True)
+class FraserConfig:
+    api_key: str = ""           # 空なら FRASER_API_KEY 環境変数を参照
+    base_url: str = "https://fraser.stlouisfed.org/api"
+    timeout: float = 30.0        # > 0 必須
+    requests_per_minute: int = 30  # >= 1 必須
+    requests_per_hour: int = 1800
+    retry_config: RetryConfig = field(default_factory=RetryConfig)
+```
+
+### `FOMCMeeting`
+
+`FraserItem` を継承し、FOMC 固有フィールドを追加した Pydantic V2 モデル。
+
+| フィールド | 型 | 説明 |
+|-----------|----|------|
+| `item_id` | `int` | FRASER アイテム ID |
+| `title` | `str` | タイトル |
+| `date` | `date` | 公開日（`YYYY-MM-DD` / `YYYY-MM` / `YYYY` 自動正規化） |
+| `meeting_date` | `date \| None` | 会議日（FOMC メタデータが含まれる場合のみ） |
+| `meeting_type` | `str \| None` | 会議種別（`regular` / `intermeeting` など） |
+| `location` | `FraserLocation \| None` | PDF/TXT URL |
+| `description` | `str \| None` | 概要 |
+
+### エラー階層
+
+```
+FraserError
+├── FraserAuthError          (401/403)
+├── FraserRateLimitError     (429, retry_after 保持)
+├── FraserNotFoundError      (404)
+├── FraserAPIError           (その他 4xx/5xx)
+├── FraserParseError         (Pydantic ValidationError ラップ)
+├── FraserDownloadError      (ファイル DL 失敗)
+└── FraserValidationError    (設定値違反)
+```
+
+公開サーフェスには `FraserError` / `FraserAuthError` / `FraserParseError` / `FraserRateLimitError` の
+4 つのみが含まれます。それ以外は `market.fraser.errors` から直接インポートしてください。
+
+## Examples
+
+実動作例は `notebook/FRASER/fraser_demo.ipynb` に追加予定（PR5 で整備）。
+
+それまでは [Quick Start](#quick-start) のスニペットを Python REPL や
+スクリプトに貼り付けて実行することで動作確認できます。
+
+## Troubleshooting
+
+### 1. `FraserAuthError: FRASER API key not provided.`
+
+`FRASER_API_KEY` 環境変数が未設定です。`.env` ファイルに以下を追加してください。
+
+```bash
+FRASER_API_KEY=your_api_key_here
+```
+
+API キーをまだ発行していない場合は [API キーの取得](#api-キーの取得) を参照。
+
+### 2. `FraserRateLimitError: Rate limit exceeded (HTTP 429)`
+
+FRASER API は **30 リクエスト/分** を超えると 429 を返します。
+
+- `FraserConfig.requests_per_minute` はデフォルトで 30 に設定済みなので、通常は自動で待機します。
+- スロットルを超えた場合は `retry_after` 属性（秒数）を確認して再試行までスリープしてください。
+
+```python
+from market.fraser import FraserRateLimitError
+
+try:
+    items = client.list_items(title_id=677)
+except FraserRateLimitError as e:
+    print(f"Retry after {e.retry_after} seconds")
+```
+
+### 3. `FraserValidationError: title_id for 'beige_book' is not configured.`
+
+`market.fraser.constants.KNOWN_TITLE_IDS` で `None` のままになっている文書タイプの `title_id` を
+発見・登録する必要があります。以下の CLI を実行してください。
+
+```bash
+uv run python -m market.fraser.scripts.discover_titles \
+    --output data/config/fraser_titles.json \
+    --interactive
+```
+
+確認した `title_id` を `KNOWN_TITLE_IDS` にハードコードするか、出力された JSON ファイルを
+`data/config/fraser_titles.json` に配置すると `BaseFraserFetcher._resolve_title_id()` が自動でフォールバック解決します。
+
+### 4. API キーを失効・再発行したい
+
+漏洩が疑われる場合は以下の手順で revoke + 再発行します。
+
+```bash
+# 1. 旧 API キーを revoke
+curl -X DELETE "https://fraser.stlouisfed.org/api/api_key" \
+  -H "X-Api-Key: <old_key>"
+
+# 2. 新規 API キーを再発行
+curl -X POST "https://fraser.stlouisfed.org/api/api_key" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "your@example.com"}'
+
+# 3. .env を更新
+sed -i '' 's/FRASER_API_KEY=.*/FRASER_API_KEY=<new_key>/' .env
+```
+
+詳細な運用手順は PR5（`notebook/FRASER/fraser_demo.ipynb`）で整備予定。
+
+### 5. ダウンロードファイルが `.tmp` のまま残る
+
+通常は `tempfile.NamedTemporaryFile` + `finally` ブロックで自動削除されますが、
+プロセスが異常終了した場合に残骸が残る可能性があります。以下のコマンドで安全に削除できます。
+
+```bash
+find data/raw/fraser/ -name "*.tmp" -delete
+```
+
+## 関連モジュール
+
+- `market.fred` - FRED API（経済指標時系列データ）
+- `market.alphavantage` - Alpha Vantage API（株価・ファンダメンタル）
+- `market.cache` - SQLite キャッシュ層（FRASER でも共有）
+
+## ライセンス
+
+このモジュールは quants リポジトリのライセンスに従います。
+FRASER API の利用にあたっては [FRASER 利用規約](https://fraser.stlouisfed.org/) を遵守してください。

--- a/src/market/fraser/README.md
+++ b/src/market/fraser/README.md
@@ -232,10 +232,18 @@ FraserError
 
 ## Examples
 
-実動作例は `notebook/FRASER/fraser_demo.ipynb` に追加予定（PR5 で整備）。
+動作確認用 thin demo notebook を用意しています:
 
-それまでは [Quick Start](#quick-start) のスニペットを Python REPL や
-スクリプトに貼り付けて実行することで動作確認できます。
+- [`notebook/FRASER/fraser_demo.ipynb`](../../../notebook/FRASER/fraser_demo.ipynb) — `FraserClient` 初期化、`FOMCMinutesFetcher` で 2024 年 FOMC Minutes 取得、`BeigeBookFetcher.fetch_all` で並列ダウンロードのデモ（5 セル構成、`.env` の `FRASER_API_KEY` 必須）
+
+実行手順:
+
+```bash
+# 前提: .env に FRASER_API_KEY を設定
+uv run jupyter nbconvert --to notebook --execute --inplace notebook/FRASER/fraser_demo.ipynb
+```
+
+下流の NLP 処理（FinBERT センチメント、ChromaDB 投入など）は別レイヤーで実装します。詳細は notebook の最終セル「次ステップ」を参照してください。
 
 ## Troubleshooting
 
@@ -281,12 +289,12 @@ uv run python -m market.fraser.scripts.discover_titles \
 
 ### 4. API キーを失効・再発行したい
 
-漏洩が疑われる場合は以下の手順で revoke + 再発行します。
+漏洩が疑われる場合・キーがコミット履歴等に残ってしまった場合は、以下の手順で revoke + 再発行します。
 
 ```bash
-# 1. 旧 API キーを revoke
-curl -X DELETE "https://fraser.stlouisfed.org/api/api_key" \
-  -H "X-Api-Key: <old_key>"
+# 1. 旧 API キーを revoke（FRASER ダッシュボード経由）
+#    https://fraser.stlouisfed.org/ にログインし、API キー管理画面から対象キーを削除
+#    REST API での revoke はサポートされていません（2026-05 時点）
 
 # 2. 新規 API キーを再発行
 curl -X POST "https://fraser.stlouisfed.org/api/api_key" \
@@ -295,9 +303,16 @@ curl -X POST "https://fraser.stlouisfed.org/api/api_key" \
 
 # 3. .env を更新
 sed -i '' 's/FRASER_API_KEY=.*/FRASER_API_KEY=<new_key>/' .env
+
+# 4. NAS 同期環境では .env をローカル ↔ NAS で同期
+#    （quants リポジトリでは /sync-nas コマンドを使用）
 ```
 
-詳細な運用手順は PR5（`notebook/FRASER/fraser_demo.ipynb`）で整備予定。
+**運用上の注意**:
+
+- 旧キーが過去の git 履歴・notebook 出力に残っている場合、revoke 完了後は履歴書き換え（`git filter-branch` 等）は **不要**（revoke 済みのキーは無効化されているため二次被害なし）。
+- notebook の出力セルにキーが残らないよう、コミット前に `jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace <notebook>` で出力をクリアすることを推奨。
+- API キーは `FraserConfig` で `repr=False` 指定されているため、`print(client.config)` 等でログ出力されることはありません（CWE-532 対策）。
 
 ### 5. ダウンロードファイルが `.tmp` のまま残る
 

--- a/src/market/fraser/__init__.py
+++ b/src/market/fraser/__init__.py
@@ -1,0 +1,90 @@
+"""FRASER REST API client package.
+
+This package provides a client for the FRASER REST API
+(https://fraser.stlouisfed.org/api) to retrieve Federal Reserve archive
+documents such as FOMC minutes/statements/press conferences, Beige Book
+reports, Federal Reserve Board speeches, and Monetary Policy Reports.
+
+Modules
+-------
+constants : API URL, environment variable names, default configuration.
+errors : Exception hierarchy for FRASER API operations (7 classes,
+    direct ``Exception`` inheritance to avoid circular imports).
+types : Configuration dataclasses (``FraserConfig``, ``RetryConfig``,
+    ``FetchOptions``) and the ``DocType`` enum.
+rate_limiter : Re-exports ``DualWindowRateLimiter`` from
+    ``market.alphavantage.rate_limiter`` and provides
+    ``get_fraser_rate_limiter`` factory.
+models : Pydantic V2 response models for FRASER API data.
+
+Notes
+-----
+This package follows the same module structure as ``market.alphavantage``
+and ``market.polymarket`` to keep new-API onboarding consistent. The
+error hierarchy intentionally inherits directly from ``Exception``
+(not from ``MarketError``) to avoid circular imports.
+"""
+
+from market.fraser.errors import (
+    FraserAPIError,
+    FraserAuthError,
+    FraserDownloadError,
+    FraserError,
+    FraserNotFoundError,
+    FraserParseError,
+    FraserRateLimitError,
+    FraserValidationError,
+)
+from market.fraser.models import (
+    BeigeBookReport,
+    FOMCMeeting,
+    FraserAuthor,
+    FraserItem,
+    FraserLocation,
+    FraserSubject,
+    FraserTheme,
+    FraserTimelineEvent,
+    FraserTitle,
+    FraserTocEntry,
+    FRBSpeech,
+    MonetaryPolicyReport,
+)
+from market.fraser.rate_limiter import (
+    DualWindowRateLimiter,
+    get_fraser_rate_limiter,
+)
+from market.fraser.types import (
+    DocType,
+    FetchOptions,
+    FraserConfig,
+    RetryConfig,
+)
+
+__all__ = [
+    "BeigeBookReport",
+    "DocType",
+    "DualWindowRateLimiter",
+    "FOMCMeeting",
+    "FRBSpeech",
+    "FetchOptions",
+    "FraserAPIError",
+    "FraserAuthError",
+    "FraserAuthor",
+    "FraserConfig",
+    "FraserDownloadError",
+    "FraserError",
+    "FraserItem",
+    "FraserLocation",
+    "FraserNotFoundError",
+    "FraserParseError",
+    "FraserRateLimitError",
+    "FraserSubject",
+    "FraserTheme",
+    "FraserTimelineEvent",
+    "FraserTitle",
+    "FraserTocEntry",
+    "FraserValidationError",
+    "MonetaryPolicyReport",
+    "RetryConfig",
+    "get_fraser_rate_limiter",
+]

--- a/src/market/fraser/__init__.py
+++ b/src/market/fraser/__init__.py
@@ -1,13 +1,12 @@
 """market.fraser - FRASER REST API subpackage.
 
-The public surface is intentionally minimal (10 symbols) so that the
-package boundary stays stable while internal modules continue to
-evolve. Internal helpers (``FraserSession``, ``FraserDownloader``,
-parser functions, etc.) remain importable from their respective
-submodules but are excluded from the package ``__all__`` to discourage
-cross-package coupling.
+The public surface stays curated so the package boundary is stable
+while internal modules continue to evolve. Internal helpers
+(``FraserSession``, ``FraserDownloader``, parser functions, etc.)
+remain importable from their respective submodules but are excluded
+from the package ``__all__`` to discourage cross-package coupling.
 
-Public surface (10 symbols)
+Public surface (16 symbols)
 ---------------------------
 FraserClient
     High-level FRASER REST API client.
@@ -17,10 +16,22 @@ FOMCStatementsFetcher
     Concrete fetcher for FOMC policy Statement documents.
 FOMCPressConferencesFetcher
     Concrete fetcher for FOMC chair Press Conference transcripts.
+BeigeBookFetcher
+    Concrete fetcher for Beige Book reports with parallel download.
+FRBSpeechFetcher
+    Concrete fetcher for FRB speeches with speaker filtering.
+MonetaryPolicyReportFetcher
+    Concrete fetcher for Monetary Policy Reports to the Congress.
 FraserConfig
     Configuration dataclass (auth, HTTP timeout, rate limits).
 FOMCMeeting
     Pydantic V2 domain model for FOMC meeting documents.
+BeigeBookReport
+    Pydantic V2 domain model for Beige Book reports.
+FRBSpeech
+    Pydantic V2 domain model for FRB speeches.
+MonetaryPolicyReport
+    Pydantic V2 domain model for Monetary Policy Reports.
 FraserError
     Base exception for the FRASER subpackage.
 FraserAuthError
@@ -32,9 +43,12 @@ FraserRateLimitError
 
 Examples
 --------
->>> from market.fraser import FOMCMinutesFetcher
->>> fetcher = FOMCMinutesFetcher()  # doctest: +SKIP
->>> minutes = fetcher.list_minutes(year_range=(2024, 2024))  # doctest: +SKIP
+>>> from market.fraser import BeigeBookFetcher, FRBSpeechFetcher
+>>> bb = BeigeBookFetcher()  # doctest: +SKIP
+>>> reports = bb.fetch_all((2023, 2024), max_workers=4)  # doctest: +SKIP
+>>> speeches = FRBSpeechFetcher().list_speeches(  # doctest: +SKIP
+...     year_range=(2024, 2024), speaker="Powell"
+... )
 """
 
 from market.fraser.client import FraserClient
@@ -44,25 +58,39 @@ from market.fraser.errors import (
     FraserParseError,
     FraserRateLimitError,
 )
+from market.fraser.fetchers.beige_book import BeigeBookFetcher
 from market.fraser.fetchers.fomc import (
     FOMCMinutesFetcher,
     FOMCPressConferencesFetcher,
     FOMCStatementsFetcher,
 )
-from market.fraser.models import FOMCMeeting
+from market.fraser.fetchers.monetary_policy import MonetaryPolicyReportFetcher
+from market.fraser.fetchers.speeches import FRBSpeechFetcher
+from market.fraser.models import (
+    BeigeBookReport,
+    FOMCMeeting,
+    FRBSpeech,
+    MonetaryPolicyReport,
+)
 from market.fraser.types import FraserConfig
 
 __version__ = "0.1.0"
 
 __all__ = [
+    "BeigeBookFetcher",
+    "BeigeBookReport",
     "FOMCMeeting",
     "FOMCMinutesFetcher",
     "FOMCPressConferencesFetcher",
     "FOMCStatementsFetcher",
+    "FRBSpeech",
+    "FRBSpeechFetcher",
     "FraserAuthError",
     "FraserClient",
     "FraserConfig",
     "FraserError",
     "FraserParseError",
     "FraserRateLimitError",
+    "MonetaryPolicyReport",
+    "MonetaryPolicyReportFetcher",
 ]

--- a/src/market/fraser/__init__.py
+++ b/src/market/fraser/__init__.py
@@ -1,18 +1,22 @@
 """market.fraser - FRASER REST API subpackage.
 
-The public surface is intentionally minimal (8 symbols, HF1-confirmed)
-so that the package boundary stays stable while internal modules
-continue to evolve. Internal helpers (``FraserSession``,
-``FraserDownloader``, parser functions, etc.) remain importable from
-their respective submodules but are excluded from the package
-``__all__`` to discourage cross-package coupling.
+The public surface is intentionally minimal (10 symbols) so that the
+package boundary stays stable while internal modules continue to
+evolve. Internal helpers (``FraserSession``, ``FraserDownloader``,
+parser functions, etc.) remain importable from their respective
+submodules but are excluded from the package ``__all__`` to discourage
+cross-package coupling.
 
-Public surface (8 symbols)
---------------------------
+Public surface (10 symbols)
+---------------------------
 FraserClient
     High-level FRASER REST API client.
 FOMCMinutesFetcher
     Concrete fetcher for FOMC Minutes documents.
+FOMCStatementsFetcher
+    Concrete fetcher for FOMC policy Statement documents.
+FOMCPressConferencesFetcher
+    Concrete fetcher for FOMC chair Press Conference transcripts.
 FraserConfig
     Configuration dataclass (auth, HTTP timeout, rate limits).
 FOMCMeeting
@@ -40,7 +44,11 @@ from market.fraser.errors import (
     FraserParseError,
     FraserRateLimitError,
 )
-from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+from market.fraser.fetchers.fomc import (
+    FOMCMinutesFetcher,
+    FOMCPressConferencesFetcher,
+    FOMCStatementsFetcher,
+)
 from market.fraser.models import FOMCMeeting
 from market.fraser.types import FraserConfig
 
@@ -49,6 +57,8 @@ __version__ = "0.1.0"
 __all__ = [
     "FOMCMeeting",
     "FOMCMinutesFetcher",
+    "FOMCPressConferencesFetcher",
+    "FOMCStatementsFetcher",
     "FraserAuthError",
     "FraserClient",
     "FraserConfig",

--- a/src/market/fraser/__init__.py
+++ b/src/market/fraser/__init__.py
@@ -25,6 +25,17 @@ error hierarchy intentionally inherits directly from ``Exception``
 (not from ``MarketError``) to avoid circular imports.
 """
 
+from market.fraser.cache import (
+    AUTHOR_SUBJECT_THEME_TTL,
+    ITEM_METADATA_TTL,
+    ITEMS_LIST_TTL,
+    TIMELINE_TTL,
+    TITLE_METADATA_TTL,
+    get_fraser_cache,
+    make_fraser_cache_key,
+)
+from market.fraser.client import FraserClient
+from market.fraser.downloader import FraserDownloader
 from market.fraser.errors import (
     FraserAPIError,
     FraserAuthError,
@@ -62,6 +73,11 @@ from market.fraser.types import (
 )
 
 __all__ = [
+    "AUTHOR_SUBJECT_THEME_TTL",
+    "ITEMS_LIST_TTL",
+    "ITEM_METADATA_TTL",
+    "TIMELINE_TTL",
+    "TITLE_METADATA_TTL",
     "BeigeBookReport",
     "DocType",
     "DualWindowRateLimiter",
@@ -71,8 +87,10 @@ __all__ = [
     "FraserAPIError",
     "FraserAuthError",
     "FraserAuthor",
+    "FraserClient",
     "FraserConfig",
     "FraserDownloadError",
+    "FraserDownloader",
     "FraserError",
     "FraserItem",
     "FraserLocation",
@@ -88,5 +106,7 @@ __all__ = [
     "FraserValidationError",
     "MonetaryPolicyReport",
     "RetryConfig",
+    "get_fraser_cache",
     "get_fraser_rate_limiter",
+    "make_fraser_cache_key",
 ]

--- a/src/market/fraser/__init__.py
+++ b/src/market/fraser/__init__.py
@@ -53,6 +53,7 @@ from market.fraser.rate_limiter import (
     DualWindowRateLimiter,
     get_fraser_rate_limiter,
 )
+from market.fraser.session import FraserSession
 from market.fraser.types import (
     DocType,
     FetchOptions,
@@ -78,6 +79,7 @@ __all__ = [
     "FraserNotFoundError",
     "FraserParseError",
     "FraserRateLimitError",
+    "FraserSession",
     "FraserSubject",
     "FraserTheme",
     "FraserTimelineEvent",

--- a/src/market/fraser/__init__.py
+++ b/src/market/fraser/__init__.py
@@ -1,112 +1,58 @@
-"""FRASER REST API client package.
+"""market.fraser - FRASER REST API subpackage.
 
-This package provides a client for the FRASER REST API
-(https://fraser.stlouisfed.org/api) to retrieve Federal Reserve archive
-documents such as FOMC minutes/statements/press conferences, Beige Book
-reports, Federal Reserve Board speeches, and Monetary Policy Reports.
+The public surface is intentionally minimal (8 symbols, HF1-confirmed)
+so that the package boundary stays stable while internal modules
+continue to evolve. Internal helpers (``FraserSession``,
+``FraserDownloader``, parser functions, etc.) remain importable from
+their respective submodules but are excluded from the package
+``__all__`` to discourage cross-package coupling.
 
-Modules
--------
-constants : API URL, environment variable names, default configuration.
-errors : Exception hierarchy for FRASER API operations (7 classes,
-    direct ``Exception`` inheritance to avoid circular imports).
-types : Configuration dataclasses (``FraserConfig``, ``RetryConfig``,
-    ``FetchOptions``) and the ``DocType`` enum.
-rate_limiter : Re-exports ``DualWindowRateLimiter`` from
-    ``market.alphavantage.rate_limiter`` and provides
-    ``get_fraser_rate_limiter`` factory.
-models : Pydantic V2 response models for FRASER API data.
+Public surface (8 symbols)
+--------------------------
+FraserClient
+    High-level FRASER REST API client.
+FOMCMinutesFetcher
+    Concrete fetcher for FOMC Minutes documents.
+FraserConfig
+    Configuration dataclass (auth, HTTP timeout, rate limits).
+FOMCMeeting
+    Pydantic V2 domain model for FOMC meeting documents.
+FraserError
+    Base exception for the FRASER subpackage.
+FraserAuthError
+    Raised on authentication / authorisation failures.
+FraserParseError
+    Raised on response parsing failures.
+FraserRateLimitError
+    Raised when the FRASER rate limit is exceeded.
 
-Notes
------
-This package follows the same module structure as ``market.alphavantage``
-and ``market.polymarket`` to keep new-API onboarding consistent. The
-error hierarchy intentionally inherits directly from ``Exception``
-(not from ``MarketError``) to avoid circular imports.
+Examples
+--------
+>>> from market.fraser import FOMCMinutesFetcher
+>>> fetcher = FOMCMinutesFetcher()  # doctest: +SKIP
+>>> minutes = fetcher.list_minutes(year_range=(2024, 2024))  # doctest: +SKIP
 """
 
-from market.fraser.cache import (
-    AUTHOR_SUBJECT_THEME_TTL,
-    ITEM_METADATA_TTL,
-    ITEMS_LIST_TTL,
-    TIMELINE_TTL,
-    TITLE_METADATA_TTL,
-    get_fraser_cache,
-    make_fraser_cache_key,
-)
 from market.fraser.client import FraserClient
-from market.fraser.downloader import FraserDownloader
 from market.fraser.errors import (
-    FraserAPIError,
     FraserAuthError,
-    FraserDownloadError,
     FraserError,
-    FraserNotFoundError,
     FraserParseError,
     FraserRateLimitError,
-    FraserValidationError,
 )
-from market.fraser.models import (
-    BeigeBookReport,
-    FOMCMeeting,
-    FraserAuthor,
-    FraserItem,
-    FraserLocation,
-    FraserSubject,
-    FraserTheme,
-    FraserTimelineEvent,
-    FraserTitle,
-    FraserTocEntry,
-    FRBSpeech,
-    MonetaryPolicyReport,
-)
-from market.fraser.rate_limiter import (
-    DualWindowRateLimiter,
-    get_fraser_rate_limiter,
-)
-from market.fraser.session import FraserSession
-from market.fraser.types import (
-    DocType,
-    FetchOptions,
-    FraserConfig,
-    RetryConfig,
-)
+from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+from market.fraser.models import FOMCMeeting
+from market.fraser.types import FraserConfig
+
+__version__ = "0.1.0"
 
 __all__ = [
-    "AUTHOR_SUBJECT_THEME_TTL",
-    "ITEMS_LIST_TTL",
-    "ITEM_METADATA_TTL",
-    "TIMELINE_TTL",
-    "TITLE_METADATA_TTL",
-    "BeigeBookReport",
-    "DocType",
-    "DualWindowRateLimiter",
     "FOMCMeeting",
-    "FRBSpeech",
-    "FetchOptions",
-    "FraserAPIError",
+    "FOMCMinutesFetcher",
     "FraserAuthError",
-    "FraserAuthor",
     "FraserClient",
     "FraserConfig",
-    "FraserDownloadError",
-    "FraserDownloader",
     "FraserError",
-    "FraserItem",
-    "FraserLocation",
-    "FraserNotFoundError",
     "FraserParseError",
     "FraserRateLimitError",
-    "FraserSession",
-    "FraserSubject",
-    "FraserTheme",
-    "FraserTimelineEvent",
-    "FraserTitle",
-    "FraserTocEntry",
-    "FraserValidationError",
-    "MonetaryPolicyReport",
-    "RetryConfig",
-    "get_fraser_cache",
-    "get_fraser_rate_limiter",
-    "make_fraser_cache_key",
 ]

--- a/src/market/fraser/cache.py
+++ b/src/market/fraser/cache.py
@@ -1,0 +1,152 @@
+"""Cache helpers for the FRASER REST API module.
+
+This module provides TTL constants for each FRASER endpoint category
+and convenience functions for obtaining a SQLiteCache instance configured
+for FRASER data, plus a SHA-256 based cache-key builder.
+
+The implementation deliberately delegates to the shared
+``market.cache.cache`` infrastructure (``SQLiteCache``,
+``create_persistent_cache``) and does **not** define its own
+``SQLiteCache`` subclass, mirroring the pattern used by
+``market.alphavantage.cache`` and ``market.jquants.cache``. This decision
+was confirmed during PR1 HF1 review (see ``docs/project/project-108``).
+
+See Also
+--------
+market.cache.cache : Core ``SQLiteCache`` implementation.
+market.alphavantage.cache : Reference implementation with the same
+    delegation pattern.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Final
+
+from market.cache.cache import SQLiteCache, create_persistent_cache
+from utils_core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# TTL constants (seconds)
+# ---------------------------------------------------------------------------
+
+TITLE_METADATA_TTL: Final[int] = 2592000
+"""TTL for FRASER title metadata (30 days).
+
+Title-level metadata (publisher, item_count, description) changes
+infrequently.
+"""
+
+ITEMS_LIST_TTL: Final[int] = 604800
+"""TTL for paginated item lists under a title (7 days).
+
+Item listings can pick up new releases, so a shorter TTL is used.
+"""
+
+ITEM_METADATA_TTL: Final[int] = 2592000
+"""TTL for individual item metadata (30 days)."""
+
+AUTHOR_SUBJECT_THEME_TTL: Final[int] = 2592000
+"""TTL for author / subject / theme tag lookups (30 days).
+
+These reference tables are essentially static.
+"""
+
+TIMELINE_TTL: Final[int] = 604800
+"""TTL for timeline event lookups (7 days)."""
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def get_fraser_cache(ttl: int = ITEM_METADATA_TTL) -> SQLiteCache:
+    """Get a SQLiteCache instance configured for FRASER data.
+
+    Creates a persistent cache sharing the same ``market_data.db``
+    database as the rest of the ``market`` package (no separate FRASER
+    database file, no separate process). Callers must use the
+    ``"fraser:"`` prefix on every cache key so the namespace stays
+    distinct.
+
+    Parameters
+    ----------
+    ttl : int
+        Default TTL in seconds applied when a caller does not pass
+        an explicit ``ttl`` to ``SQLiteCache.set`` (default:
+        :data:`ITEM_METADATA_TTL` = 30 days).
+
+    Returns
+    -------
+    SQLiteCache
+        A configured cache instance writing to the shared
+        ``market_data.db``.
+
+    Examples
+    --------
+    >>> cache = get_fraser_cache()  # doctest: +SKIP
+    >>> cache.set("fraser:title:677", payload, ttl=TITLE_METADATA_TTL)
+    """
+    cache = create_persistent_cache(
+        ttl_seconds=ttl,
+        max_entries=10000,
+    )
+    logger.debug("FRASER cache instance created", ttl_seconds=ttl)
+    return cache
+
+
+def make_fraser_cache_key(endpoint: str, params: dict[str, Any]) -> str:
+    """Build a deterministic, collision-resistant FRASER cache key.
+
+    The key is constructed as ``"fraser:" + sha256(endpoint + sorted_params)``
+    so that:
+
+    - The ``"fraser:"`` prefix isolates FRASER entries from other
+      packages sharing the same ``market_data.db``.
+    - ``params`` ordering is normalised via ``sort_keys=True`` so that
+      callers passing dictionaries in different insertion orders still
+      produce the same key.
+
+    Parameters
+    ----------
+    endpoint : str
+        API endpoint path (e.g., ``"/items"``, ``"/title/677"``).
+    params : dict[str, Any]
+        Query parameters used for the request. May be empty.
+
+    Returns
+    -------
+    str
+        Cache key of the form ``"fraser:<64-char hex digest>"``.
+
+    Examples
+    --------
+    >>> key = make_fraser_cache_key("/items", {"titleId": 677, "limit": 10})
+    >>> key.startswith("fraser:")
+    True
+    >>> len(key) == len("fraser:") + 64
+    True
+    """
+    payload = json.dumps(
+        {"endpoint": endpoint, "params": params},
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"fraser:{digest}"
+
+
+__all__ = [
+    "AUTHOR_SUBJECT_THEME_TTL",
+    "ITEMS_LIST_TTL",
+    "ITEM_METADATA_TTL",
+    "TIMELINE_TTL",
+    "TITLE_METADATA_TTL",
+    "get_fraser_cache",
+    "make_fraser_cache_key",
+]

--- a/src/market/fraser/client.py
+++ b/src/market/fraser/client.py
@@ -45,7 +45,7 @@ from market.fraser.cache import (
     make_fraser_cache_key,
 )
 from market.fraser.constants import FRASER_API_KEY_ENV
-from market.fraser.errors import FraserAuthError
+from market.fraser.errors import FraserAuthError, FraserValidationError
 from market.fraser.rate_limiter import get_fraser_rate_limiter
 from market.fraser.session import FraserSession
 from market.fraser.types import FraserConfig
@@ -183,10 +183,29 @@ class FraserClient:
         list[FraserItem]
             Items belonging to the title.
 
+        Raises
+        ------
+        FraserValidationError
+            When ``limit`` is outside ``[1, 1000]`` or ``page < 1``.
+
         Examples
         --------
         >>> items = client.list_items(title_id=677, limit=5)  # doctest: +SKIP
         """
+        # Surface bad pagination args before the network round-trip so
+        # the failure mode is a domain error, not an opaque 4xx (CWE-20).
+        if not 1 <= limit <= 1000:
+            raise FraserValidationError(
+                f"limit must be between 1 and 1000, got {limit}",
+                field="limit",
+                value=limit,
+            )
+        if page < 1:
+            raise FraserValidationError(
+                f"page must be >= 1, got {page}",
+                field="page",
+                value=page,
+            )
         endpoint = "/items"
         params: dict[str, Any] = {
             "titleId": title_id,

--- a/src/market/fraser/client.py
+++ b/src/market/fraser/client.py
@@ -1,0 +1,389 @@
+"""High-level client for FRASER REST API access.
+
+This module provides the :class:`FraserClient` class, which integrates
+:class:`FraserSession` (HTTP + rate limiting + retries) with
+:func:`market.fraser.parser` (Pydantic validation) and a shared
+:class:`market.cache.cache.SQLiteCache` so that callers receive typed
+domain models with transparent caching.
+
+Eight public methods are exposed, mirroring the FRASER REST endpoints
+used by the project:
+
+- :meth:`list_items` (``GET /items``)
+- :meth:`get_item` (``GET /item/{id}``)
+- :meth:`get_title` (``GET /title/{id}``)
+- :meth:`get_toc` (``GET /item/{id}/toc``)
+- :meth:`get_authors` (``GET /authors``)
+- :meth:`get_subjects` (``GET /subjects``)
+- :meth:`get_themes` (``GET /themes``)
+- :meth:`get_timeline` (``GET /title/{id}/timeline``)
+
+Each method follows the same cache-key → cache.get → session.get →
+parser → cache.set pipeline so behaviour stays uniform and easy to test.
+
+See Also
+--------
+market.fraser.session : Underlying HTTP session.
+market.fraser.cache : TTL constants + ``get_fraser_cache`` factory.
+market.fraser.parser : Pydantic validation wrappers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING, Any
+
+from market.fraser import parser
+from market.fraser.cache import (
+    AUTHOR_SUBJECT_THEME_TTL,
+    ITEM_METADATA_TTL,
+    ITEMS_LIST_TTL,
+    TIMELINE_TTL,
+    TITLE_METADATA_TTL,
+    get_fraser_cache,
+    make_fraser_cache_key,
+)
+from market.fraser.constants import FRASER_API_KEY_ENV
+from market.fraser.errors import FraserAuthError
+from market.fraser.rate_limiter import get_fraser_rate_limiter
+from market.fraser.session import FraserSession
+from market.fraser.types import FraserConfig
+from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from market.cache.cache import SQLiteCache
+    from market.fraser.models import (
+        FraserAuthor,
+        FraserItem,
+        FraserSubject,
+        FraserTheme,
+        FraserTimelineEvent,
+        FraserTitle,
+        FraserTocEntry,
+    )
+
+logger = get_logger(__name__)
+
+
+class FraserClient:
+    """High-level client for the FRASER REST API.
+
+    Parameters
+    ----------
+    config : FraserConfig | None
+        FRASER configuration. When ``None``, a default configuration is
+        built and the API key is read from the ``FRASER_API_KEY``
+        environment variable. ``FraserAuthError`` is raised if no key is
+        configured.
+    session : FraserSession | None
+        Optional pre-built session. Useful for tests / dependency
+        injection. When supplied, ``config`` is ignored for session
+        construction (but still used for cache prefix consistency).
+    cache : SQLiteCache | None
+        Optional pre-built cache. When ``None``, a default persistent
+        cache is created via :func:`get_fraser_cache`.
+
+    Raises
+    ------
+    FraserAuthError
+        When no API key is available (neither in ``config`` nor in the
+        environment).
+
+    Examples
+    --------
+    >>> with FraserClient() as client:  # doctest: +SKIP
+    ...     items = client.list_items(title_id=677, limit=10)
+    ...     print(len(items))
+    """
+
+    def __init__(
+        self,
+        config: FraserConfig | None = None,
+        session: FraserSession | None = None,
+        cache: SQLiteCache | None = None,
+    ) -> None:
+        if config is None:
+            api_key = os.environ.get(FRASER_API_KEY_ENV, "")
+            if not api_key and session is None:
+                raise FraserAuthError(
+                    "FRASER API key not provided. "
+                    f"Set {FRASER_API_KEY_ENV} environment variable or pass "
+                    "FraserConfig(api_key=...) explicitly."
+                )
+            config = FraserConfig(api_key=api_key)
+
+        self._config: FraserConfig = config
+
+        if session is None:
+            self._session: FraserSession = FraserSession(
+                config=self._config,
+                rate_limiter=get_fraser_rate_limiter(self._config),
+                retry_config=self._config.retry_config,
+            )
+        else:
+            self._session = session
+
+        self._cache: SQLiteCache = cache if cache is not None else get_fraser_cache()
+
+        logger.info(
+            "FraserClient initialised",
+            base_url=self._config.base_url,
+        )
+
+    # =========================================================================
+    # Context manager
+    # =========================================================================
+
+    def __enter__(self) -> FraserClient:
+        """Return ``self`` for use in ``with`` statements."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Close the underlying session on context exit."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        self._session.close()
+        logger.debug("FraserClient closed")
+
+    # =========================================================================
+    # Public endpoint methods
+    # =========================================================================
+
+    def list_items(
+        self,
+        title_id: int,
+        limit: int = 50,
+        page: int = 1,
+        *,
+        use_cache: bool = True,
+    ) -> list[FraserItem]:
+        """List items for a given title (``GET /items``).
+
+        Parameters
+        ----------
+        title_id : int
+            FRASER title identifier (e.g., ``677`` for FOMC).
+        limit : int
+            Page size (default: 50).
+        page : int
+            1-based page index (default: 1).
+        use_cache : bool
+            When ``False``, bypass the cache for this call.
+
+        Returns
+        -------
+        list[FraserItem]
+            Items belonging to the title.
+
+        Examples
+        --------
+        >>> items = client.list_items(title_id=677, limit=5)  # doctest: +SKIP
+        """
+        endpoint = "/items"
+        params: dict[str, Any] = {
+            "titleId": title_id,
+            "limit": limit,
+            "page": page,
+        }
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=ITEMS_LIST_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_items(data)
+
+    def get_item(
+        self,
+        item_id: int,
+        *,
+        use_cache: bool = True,
+    ) -> FraserItem:
+        """Fetch a single item by ID (``GET /item/{id}``)."""
+        endpoint = f"/item/{item_id}"
+        params: dict[str, Any] = {}
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=ITEM_METADATA_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_item(data)
+
+    def get_title(
+        self,
+        title_id: int,
+        *,
+        use_cache: bool = True,
+    ) -> FraserTitle:
+        """Fetch a title by ID (``GET /title/{id}``)."""
+        endpoint = f"/title/{title_id}"
+        params: dict[str, Any] = {}
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=TITLE_METADATA_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_title(data)
+
+    def get_toc(
+        self,
+        item_id: int,
+        *,
+        use_cache: bool = True,
+    ) -> list[FraserTocEntry]:
+        """Fetch an item's table of contents (``GET /item/{id}/toc``)."""
+        endpoint = f"/item/{item_id}/toc"
+        params: dict[str, Any] = {}
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=ITEM_METADATA_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_toc(data)
+
+    def get_authors(
+        self,
+        *,
+        use_cache: bool = True,
+    ) -> list[FraserAuthor]:
+        """Fetch the master authors list (``GET /authors``)."""
+        endpoint = "/authors"
+        params: dict[str, Any] = {}
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=AUTHOR_SUBJECT_THEME_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_authors(data)
+
+    def get_subjects(
+        self,
+        *,
+        use_cache: bool = True,
+    ) -> list[FraserSubject]:
+        """Fetch the master subjects list (``GET /subjects``)."""
+        endpoint = "/subjects"
+        params: dict[str, Any] = {}
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=AUTHOR_SUBJECT_THEME_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_subjects(data)
+
+    def get_themes(
+        self,
+        *,
+        use_cache: bool = True,
+    ) -> list[FraserTheme]:
+        """Fetch the master themes list (``GET /themes``)."""
+        endpoint = "/themes"
+        params: dict[str, Any] = {}
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=AUTHOR_SUBJECT_THEME_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_themes(data)
+
+    def get_timeline(
+        self,
+        title_id: int,
+        *,
+        use_cache: bool = True,
+    ) -> list[FraserTimelineEvent]:
+        """Fetch a title's timeline (``GET /title/{id}/timeline``)."""
+        endpoint = f"/title/{title_id}/timeline"
+        params: dict[str, Any] = {}
+        data = self._fetch_json(
+            endpoint=endpoint,
+            params=params,
+            ttl=TIMELINE_TTL,
+            use_cache=use_cache,
+        )
+        return parser.parse_timeline(data)
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _fetch_json(
+        self,
+        *,
+        endpoint: str,
+        params: dict[str, Any],
+        ttl: int,
+        use_cache: bool,
+    ) -> Any:
+        """Fetch a JSON payload with cache-aware read-through semantics.
+
+        Pipeline
+        --------
+        1. Build a deterministic cache key via :func:`make_fraser_cache_key`.
+        2. When ``use_cache`` is ``True``, return the cached JSON if hit.
+        3. On miss (or ``use_cache=False``), call
+           :meth:`FraserSession.get_with_retry` and decode the body.
+        4. Store the decoded body in the cache for ``ttl`` seconds.
+
+        Parameters
+        ----------
+        endpoint : str
+            API endpoint path (e.g., ``"/items"``).
+        params : dict[str, Any]
+            Query parameters.
+        ttl : int
+            TTL in seconds for the cache entry.
+        use_cache : bool
+            When ``False``, skip the cache lookup but still write the
+            fresh response to the cache for subsequent callers.
+
+        Returns
+        -------
+        Any
+            Decoded JSON payload (dict / list / scalar).
+        """
+        key = make_fraser_cache_key(endpoint, params)
+        if use_cache:
+            cached = self._cache.get(key)
+            if cached is not None:
+                logger.debug(
+                    "Cache hit",
+                    endpoint=endpoint,
+                    key_prefix=key[:24] + "...",
+                )
+                return json.loads(cached) if isinstance(cached, str) else cached
+
+        response = self._session.get_with_retry(endpoint, params=params)
+        data: Any = response.json()
+
+        try:
+            payload = json.dumps(data, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            payload = None
+        if payload is not None:
+            self._cache.set(key, payload, ttl=ttl)
+            logger.debug(
+                "Cache populated",
+                endpoint=endpoint,
+                key_prefix=key[:24] + "...",
+                ttl_seconds=ttl,
+            )
+
+        return data
+
+
+__all__ = ["FraserClient"]

--- a/src/market/fraser/client.py
+++ b/src/market/fraser/client.py
@@ -132,6 +132,22 @@ class FraserClient:
         )
 
     # =========================================================================
+    # Public accessors
+    # =========================================================================
+
+    @property
+    def session(self) -> FraserSession:
+        """Return the underlying :class:`FraserSession`.
+
+        Exposing the session via a public property lets collaborators
+        (e.g. :class:`FraserDownloader`) reuse the same authenticated
+        HTTP client without reaching into the leading-underscore field
+        ``_session``. This keeps the DIP boundary clean: callers depend
+        on the public interface, not on the storage detail.
+        """
+        return self._session
+
+    # =========================================================================
     # Context manager
     # =========================================================================
 

--- a/src/market/fraser/constants.py
+++ b/src/market/fraser/constants.py
@@ -81,6 +81,8 @@ DEFAULT_TIMEOUT: Final[float] = 30.0
 # 6. Document type metadata
 # ---------------------------------------------------------------------------
 
+# AIDEV-TODO: project-115 task-2 で `python -m market.fraser.scripts.discover_titles`
+# を実行し、残り 5 つの None を確定値に置き換え、型を `dict[str, int]` に変更する。
 KNOWN_TITLE_IDS: Final[dict[str, int | None]] = {
     "fomc_minutes": 677,
     "fomc_statements": None,

--- a/src/market/fraser/constants.py
+++ b/src/market/fraser/constants.py
@@ -98,6 +98,10 @@ are to be populated by the ``scripts/discover_titles.py`` CLI added in
 task-2 of PR1 (manual fill-in, no automatic AST rewriting per HF1).
 """
 
+# NOTE: The canonical source of truth lives at
+# :pyattr:`market.fraser.types.DocType.subdir`. We expose a frozen copy
+# here for legacy callers that imported ``DOC_TYPE_SUBDIRS`` directly;
+# new code should reach the data through ``DocType.subdir`` (OCP).
 DOC_TYPE_SUBDIRS: Final[dict[str, str]] = {
     "fomc_minutes": "fomc/minutes",
     "fomc_statements": "fomc/statements",
@@ -108,8 +112,9 @@ DOC_TYPE_SUBDIRS: Final[dict[str, str]] = {
 }
 """Mapping of document type keys to their on-disk subdirectory layout.
 
-Used by the downloader to choose the destination directory under the
-configured ``download_dir`` root.
+Legacy direct accessor. Prefer :pyattr:`market.fraser.types.DocType.subdir`
+in new code so that adding a new ``DocType`` only requires editing the
+enum (Open/Closed Principle).
 """
 
 # ---------------------------------------------------------------------------

--- a/src/market/fraser/constants.py
+++ b/src/market/fraser/constants.py
@@ -1,0 +1,127 @@
+"""Constants for FRASER REST API client module.
+
+This module defines all constants used by the FRASER REST API client,
+including the API base URL, SSRF prevention whitelist, environment
+variable names, rate limit defaults, HTTP configuration values,
+known title IDs, and document type subdirectory mapping.
+
+See Also
+--------
+market.alphavantage.constants : Similar constant pattern used by the
+    Alpha Vantage module (constant structure + CWE annotation style).
+"""
+
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# 1. API URL constants
+# ---------------------------------------------------------------------------
+
+BASE_URL: Final[str] = "https://fraser.stlouisfed.org/api"
+"""Base URL for the FRASER REST API.
+
+All API requests are constructed by appending path segments and query
+parameters to this base URL (e.g., ``BASE_URL + "/title/677"``).
+"""
+
+# ---------------------------------------------------------------------------
+# 2. Security constants
+# ---------------------------------------------------------------------------
+
+ALLOWED_HOSTS: Final[frozenset[str]] = frozenset({"fraser.stlouisfed.org"})
+"""Whitelist of allowed hostnames for SSRF prevention (CWE-918).
+
+Only requests to these hosts are permitted by the FRASER session layer.
+Requests to any other host will raise ``ValueError``.
+"""
+
+MAX_RESPONSE_BODY_LOG: Final[int] = 2048
+"""Maximum number of characters to log from response bodies (CWE-209).
+
+Prevents sensitive data from being exposed in log messages by truncating
+response body content to this length.
+"""
+
+# ---------------------------------------------------------------------------
+# 3. Environment variable names
+# ---------------------------------------------------------------------------
+
+FRASER_API_KEY_ENV: Final[str] = "FRASER_API_KEY"
+"""Environment variable name for FRASER API key.
+
+The FRASER API key is issued via ``POST /api/api_key`` and is required
+for authenticated endpoints.
+"""
+
+# ---------------------------------------------------------------------------
+# 4. Rate limit default values
+# ---------------------------------------------------------------------------
+
+DEFAULT_REQUESTS_PER_MINUTE: Final[int] = 30
+"""Default maximum number of API requests per minute.
+
+FRASER API enforces 30 requests/minute per API key.
+"""
+
+DEFAULT_REQUESTS_PER_HOUR: Final[int] = 1800
+"""Default maximum number of API requests per hour.
+
+Computed as ``DEFAULT_REQUESTS_PER_MINUTE * 60`` to keep the hourly
+ceiling aligned with the per-minute limit (30 * 60 = 1800).
+"""
+
+# ---------------------------------------------------------------------------
+# 5. HTTP default configuration values
+# ---------------------------------------------------------------------------
+
+DEFAULT_TIMEOUT: Final[float] = 30.0
+"""Default HTTP request timeout in seconds."""
+
+# ---------------------------------------------------------------------------
+# 6. Document type metadata
+# ---------------------------------------------------------------------------
+
+KNOWN_TITLE_IDS: Final[dict[str, int | None]] = {
+    "fomc_minutes": 677,
+    "fomc_statements": None,
+    "fomc_press_conferences": None,
+    "beige_book": None,
+    "monetary_policy_report": None,
+    "frb_speeches": None,
+}
+"""Mapping of document type keys to their FRASER title IDs.
+
+Only ``fomc_minutes`` (677) is confirmed. The remaining ``None`` values
+are to be populated by the ``scripts/discover_titles.py`` CLI added in
+task-2 of PR1 (manual fill-in, no automatic AST rewriting per HF1).
+"""
+
+DOC_TYPE_SUBDIRS: Final[dict[str, str]] = {
+    "fomc_minutes": "fomc/minutes",
+    "fomc_statements": "fomc/statements",
+    "fomc_press_conferences": "fomc/press_conferences",
+    "beige_book": "beige_book",
+    "monetary_policy_report": "monetary_policy",
+    "frb_speeches": "speeches",
+}
+"""Mapping of document type keys to their on-disk subdirectory layout.
+
+Used by the downloader to choose the destination directory under the
+configured ``download_dir`` root.
+"""
+
+# ---------------------------------------------------------------------------
+# Module exports
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "ALLOWED_HOSTS",
+    "BASE_URL",
+    "DEFAULT_REQUESTS_PER_HOUR",
+    "DEFAULT_REQUESTS_PER_MINUTE",
+    "DEFAULT_TIMEOUT",
+    "DOC_TYPE_SUBDIRS",
+    "FRASER_API_KEY_ENV",
+    "KNOWN_TITLE_IDS",
+    "MAX_RESPONSE_BODY_LOG",
+]

--- a/src/market/fraser/downloader.py
+++ b/src/market/fraser/downloader.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import tempfile
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Literal
 
 import httpx
 
@@ -210,7 +210,7 @@ class FraserDownloader:
         item: FraserItem,
         doc_subdir: str,
         *,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
         force: bool = False,
     ) -> tuple[Path, Path]:
         """Download an item's primary asset and write its metadata sidecar.
@@ -246,26 +246,33 @@ class FraserDownloader:
             When the item has no usable URL or the download fails.
         """
         lock = self._get_or_create_lock(item.item_id)
-        with lock:
-            url, ext = self._select_url(item, prefer=prefer)
+        try:
+            with lock:
+                url, ext = self._select_url(item, prefer=prefer)
 
-            target_dir = self.base_dir / doc_subdir
-            asset_filename = f"{item.date.isoformat()}_{item.item_id}.{ext}"
-            asset_path = target_dir / asset_filename
-            meta_path = target_dir / f"{item.date.isoformat()}_{item.item_id}.meta.json"
+                target_dir = self.base_dir / doc_subdir
+                asset_filename = f"{item.date.isoformat()}_{item.item_id}.{ext}"
+                asset_path = target_dir / asset_filename
+                meta_path = (
+                    target_dir / f"{item.date.isoformat()}_{item.item_id}.meta.json"
+                )
 
-            self.download(url, asset_path, force=force)
+                self.download(url, asset_path, force=force)
 
-            target_dir.mkdir(parents=True, exist_ok=True)
-            meta_payload = item.model_dump_json(indent=2, by_alias=False)
-            meta_path.write_text(meta_payload, encoding="utf-8")
+                target_dir.mkdir(parents=True, exist_ok=True)
+                meta_payload = item.model_dump_json(indent=2, by_alias=False)
+                meta_path.write_text(meta_payload, encoding="utf-8")
 
-            logger.debug(
-                "Meta sidecar written",
-                meta_path=str(meta_path),
-                item_id=item.item_id,
-            )
-            return asset_path, meta_path
+                logger.debug(
+                    "Meta sidecar written",
+                    meta_path=str(meta_path),
+                    item_id=item.item_id,
+                )
+                return asset_path, meta_path
+        finally:
+            # Release the per-item lock entry so a long-running batch does
+            # not accumulate one Lock object per processed item_id.
+            self._release_lock(item.item_id)
 
     # =========================================================================
     # Internal helpers
@@ -291,32 +298,41 @@ class FraserDownloader:
                 self._locks[item_id] = lock
             return lock
 
-    def _stream_to(self, url: str, tmp_file: Any) -> None:
+    def _release_lock(self, item_id: int) -> None:
+        """Drop the per-``item_id`` lock entry after the download settles.
+
+        Prevents unbounded growth of ``self._locks`` when a long-running
+        batch processes many distinct items. Safe to call even when the
+        entry is missing (no-op).
+        """
+        with self._locks_master:
+            self._locks.pop(item_id, None)
+
+    def _stream_to(self, url: str, tmp_file: IO[bytes]) -> None:
         """Stream ``url`` into the open ``tmp_file`` handle.
 
-        Uses ``httpx.stream`` so the response is consumed incrementally.
-        Status codes are checked via ``response.raise_for_status()``
-        before writing any bytes so that error pages are never persisted.
+        Uses :meth:`FraserSession.stream` so the SSRF / HTTPS guards are
+        enforced consistently with regular API calls (CWE-918). Status
+        codes are checked via ``response.raise_for_status()`` before
+        writing any bytes so that error pages are never persisted.
 
         Parameters
         ----------
         url : str
             Source URL.
-        tmp_file : Any
+        tmp_file : IO[bytes]
             Open writable binary file object (typically the handle
-            returned by ``tempfile.NamedTemporaryFile``).
+            returned by :class:`tempfile.NamedTemporaryFile`).
 
         Raises
         ------
+        FraserValidationError
+            If ``url`` fails SSRF / HTTPS validation.
         FraserDownloadError
             On HTTP / I/O failure.
         """
-        # Reuse the session's underlying httpx.Client so that timeout,
-        # SSL verification, and any session-level configuration are kept
-        # consistent with regular API requests.
-        client: httpx.Client = self._session._client
         try:
-            with client.stream("GET", url) as response:
+            with self._session.stream(url) as response:
                 response.raise_for_status()
                 for chunk in response.iter_bytes(chunk_size=self._chunk_size):
                     if chunk:
@@ -335,7 +351,9 @@ class FraserDownloader:
             ) from exc
 
     @staticmethod
-    def _select_url(item: FraserItem, *, prefer: str) -> tuple[str, str]:
+    def _select_url(
+        item: FraserItem, *, prefer: Literal["txt", "pdf"]
+    ) -> tuple[str, str]:
         """Pick a URL from ``item.location`` honouring the ``prefer`` flag.
 
         Falls back to the other format when the preferred one is

--- a/src/market/fraser/downloader.py
+++ b/src/market/fraser/downloader.py
@@ -28,6 +28,7 @@ market.fraser.errors : :class:`FraserDownloadError` raised on failure.
 
 from __future__ import annotations
 
+import json
 import tempfile
 import threading
 from pathlib import Path
@@ -115,6 +116,22 @@ class FraserDownloader:
     ) -> Path:
         """Stream ``url`` to ``target_path`` with atomic rename semantics.
 
+        See :meth:`download_with_integrity` for the underlying
+        implementation. This convenience wrapper discards the integrity
+        headers — use :meth:`download_with_integrity` if you need them.
+        """
+        path, _integrity = self.download_with_integrity(url, target_path, force=force)
+        return path
+
+    def download_with_integrity(
+        self,
+        url: str,
+        target_path: Path,
+        *,
+        force: bool = False,
+    ) -> tuple[Path, dict[str, str]]:
+        """Stream ``url`` to ``target_path`` and capture integrity headers.
+
         Skips the download entirely when ``target_path`` already exists
         and ``force`` is ``False``. Otherwise the bytes are streamed into
         a same-directory ``tempfile.NamedTemporaryFile`` and atomically
@@ -134,8 +151,12 @@ class FraserDownloader:
 
         Returns
         -------
-        Path
-            The destination ``target_path``.
+        tuple[Path, dict[str, str]]
+            ``(target_path, integrity_headers)``. ``integrity_headers``
+            contains any of ``etag`` / ``content-md5`` / ``last-modified``
+            returned by the server (lower-cased keys, empty dict on
+            skip path). The caller can persist these to verify
+            file integrity on future runs (CWE-354).
 
         Raises
         ------
@@ -149,7 +170,7 @@ class FraserDownloader:
                 "Download skipped (exists, force=False)",
                 target=str(target_path),
             )
-            return target_path
+            return target_path, {}
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -162,7 +183,7 @@ class FraserDownloader:
                 prefix=f"{target_path.stem}_",
             ) as tmp_file:
                 tmp_path = Path(tmp_file.name)
-                self._stream_to(url, tmp_file)
+                integrity = self._stream_to(url, tmp_file)
 
             # Atomic publish (same-volume rename guaranteed by tmp dir).
             tmp_path.replace(target_path)
@@ -171,10 +192,11 @@ class FraserDownloader:
                 url=url,
                 target=str(target_path),
                 bytes=target_path.stat().st_size,
+                integrity_keys=sorted(integrity.keys()),
             )
             # ``tmp_path`` has been moved; suppress finally cleanup.
             tmp_path = None
-            return target_path
+            return target_path, integrity
 
         except FraserDownloadError:
             # Already a domain error from ``_stream_to`` — re-raise.
@@ -257,10 +279,20 @@ class FraserDownloader:
                     target_dir / f"{item.date.isoformat()}_{item.item_id}.meta.json"
                 )
 
-                self.download(url, asset_path, force=force)
+                _path, integrity = self.download_with_integrity(
+                    url, asset_path, force=force
+                )
 
                 target_dir.mkdir(parents=True, exist_ok=True)
-                meta_payload = item.model_dump_json(indent=2, by_alias=False)
+                # Combine the item dump with the integrity headers so the
+                # sidecar carries enough information to spot-check the
+                # asset on future runs (ETag / Content-MD5 / Last-Modified).
+                meta_dict = item.model_dump(by_alias=False, mode="json")
+                if integrity:
+                    meta_dict["_integrity"] = integrity
+                meta_payload = json.dumps(
+                    meta_dict, indent=2, ensure_ascii=False, default=str
+                )
                 meta_path.write_text(meta_payload, encoding="utf-8")
 
                 logger.debug(
@@ -308,7 +340,7 @@ class FraserDownloader:
         with self._locks_master:
             self._locks.pop(item_id, None)
 
-    def _stream_to(self, url: str, tmp_file: IO[bytes]) -> None:
+    def _stream_to(self, url: str, tmp_file: IO[bytes]) -> dict[str, str]:
         """Stream ``url`` into the open ``tmp_file`` handle.
 
         Uses :meth:`FraserSession.stream` so the SSRF / HTTPS guards are
@@ -324,6 +356,13 @@ class FraserDownloader:
             Open writable binary file object (typically the handle
             returned by :class:`tempfile.NamedTemporaryFile`).
 
+        Returns
+        -------
+        dict[str, str]
+            Lower-cased mapping of any integrity-related response
+            headers (``etag`` / ``content-md5`` / ``last-modified``).
+            Missing headers are simply absent from the dict.
+
         Raises
         ------
         FraserValidationError
@@ -331,12 +370,20 @@ class FraserDownloader:
         FraserDownloadError
             On HTTP / I/O failure.
         """
+        integrity: dict[str, str] = {}
         try:
             with self._session.stream(url) as response:
                 response.raise_for_status()
                 for chunk in response.iter_bytes(chunk_size=self._chunk_size):
                     if chunk:
                         tmp_file.write(chunk)
+                # Capture integrity hints once the body has streamed
+                # without error. ``response.headers`` is case-insensitive.
+                for header_name in ("etag", "content-md5", "last-modified"):
+                    value = response.headers.get(header_name)
+                    if value:
+                        integrity[header_name] = value
+            return integrity
         except httpx.HTTPStatusError as exc:
             raise FraserDownloadError(
                 message=(f"HTTP {exc.response.status_code} while downloading {url}"),

--- a/src/market/fraser/downloader.py
+++ b/src/market/fraser/downloader.py
@@ -1,0 +1,392 @@
+"""File downloader for FRASER PDF / TXT assets.
+
+This module exposes :class:`FraserDownloader`, a thread-safe helper for
+streaming FRASER asset files to disk with atomic rename semantics. The
+downloader uses standard-library primitives only (``tempfile``,
+``pathlib``, ``threading``) and intentionally avoids external locking
+libraries such as ``filelock`` — see PR1 HF1 review notes.
+
+Key behaviours
+--------------
+- Stream downloads via ``httpx.stream`` so large PDFs do not load fully
+  into memory.
+- Write into ``tempfile.NamedTemporaryFile`` in the **same** target
+  directory, then ``Path.replace()`` to ensure atomic publish on POSIX
+  and Windows (same-volume requirement satisfied because the temp file
+  lives next to the destination).
+- Clean up the tmp file via ``finally`` so HTTP failures never leave
+  ``*.tmp`` debris.
+- Serialise concurrent downloads of the **same** ``item_id`` via an
+  ``item_id``-keyed ``threading.Lock`` dictionary; different items run
+  in parallel.
+
+See Also
+--------
+market.fraser.session : Underlying :class:`FraserSession` used for HTTP.
+market.fraser.errors : :class:`FraserDownloadError` raised on failure.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from market.fraser.errors import FraserDownloadError
+from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from market.fraser.models import FraserItem
+    from market.fraser.session import FraserSession
+
+logger = get_logger(__name__)
+
+# Default download chunk size (bytes). 8 KiB matches Python's default
+# socket read buffer and keeps memory pressure low.
+_DEFAULT_CHUNK_SIZE: int = 8192
+
+# Filename suffix used while the download is in progress. The suffix is
+# only visible if a process dies between ``NamedTemporaryFile`` creation
+# and ``Path.replace()``; ``finally`` cleanup removes it otherwise.
+_TMP_SUFFIX: str = ".tmp"
+
+
+class FraserDownloader:
+    """Stream FRASER PDF / TXT assets to disk with atomic rename.
+
+    Parameters
+    ----------
+    session : FraserSession
+        Authenticated FRASER session. The downloader reuses the
+        session's underlying ``httpx.Client`` so that polite delays and
+        rate limiting still apply.
+    base_dir : Path
+        Filesystem root for downloads (default:
+        ``Path("data/raw/fraser")``). All ``download_with_meta`` writes
+        are placed under this root.
+    chunk_size : int
+        Stream chunk size in bytes (default: 8192). Exposed for testing.
+
+    Examples
+    --------
+    >>> session = FraserSession()  # doctest: +SKIP
+    >>> dl = FraserDownloader(session)  # doctest: +SKIP
+    >>> dl.download(  # doctest: +SKIP
+    ...     "https://fraser.stlouisfed.org/files/doc/1001.pdf",
+    ...     Path("data/raw/fraser/fomc/minutes/2024-01-31_1001.pdf"),
+    ... )
+    """
+
+    def __init__(
+        self,
+        session: FraserSession,
+        base_dir: Path = Path("data/raw/fraser"),
+        chunk_size: int = _DEFAULT_CHUNK_SIZE,
+    ) -> None:
+        self._session: FraserSession = session
+        self.base_dir: Path = Path(base_dir)
+        self._chunk_size: int = chunk_size
+
+        # Per-item locks (created lazily) plus a master lock that guards
+        # the dict itself. This mirrors the standard "lock for the lock
+        # registry" pattern used in concurrent caches.
+        self._locks: dict[int, threading.Lock] = {}
+        self._locks_master: threading.Lock = threading.Lock()
+
+        logger.debug(
+            "FraserDownloader initialised",
+            base_dir=str(self.base_dir),
+            chunk_size=self._chunk_size,
+        )
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def download(
+        self,
+        url: str,
+        target_path: Path,
+        *,
+        force: bool = False,
+    ) -> Path:
+        """Stream ``url`` to ``target_path`` with atomic rename semantics.
+
+        Skips the download entirely when ``target_path`` already exists
+        and ``force`` is ``False``. Otherwise the bytes are streamed into
+        a same-directory ``tempfile.NamedTemporaryFile`` and atomically
+        published via ``Path.replace()`` on success.
+
+        Parameters
+        ----------
+        url : str
+            Source URL (must be an HTTPS FRASER URL — the session layer
+            enforces this).
+        target_path : Path
+            Destination path on disk. Parent directories are created on
+            demand.
+        force : bool
+            When ``True``, re-download even if the destination already
+            exists.
+
+        Returns
+        -------
+        Path
+            The destination ``target_path``.
+
+        Raises
+        ------
+        FraserDownloadError
+            On any HTTP / I/O failure. The temporary file is always
+            removed in the failure path.
+        """
+        target_path = Path(target_path)
+        if target_path.exists() and not force:
+            logger.debug(
+                "Download skipped (exists, force=False)",
+                target=str(target_path),
+            )
+            return target_path
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=target_path.parent,
+                delete=False,
+                suffix=_TMP_SUFFIX,
+                prefix=f"{target_path.stem}_",
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                self._stream_to(url, tmp_file)
+
+            # Atomic publish (same-volume rename guaranteed by tmp dir).
+            tmp_path.replace(target_path)
+            logger.info(
+                "Download succeeded",
+                url=url,
+                target=str(target_path),
+                bytes=target_path.stat().st_size,
+            )
+            # ``tmp_path`` has been moved; suppress finally cleanup.
+            tmp_path = None
+            return target_path
+
+        except FraserDownloadError:
+            # Already a domain error from ``_stream_to`` — re-raise.
+            raise
+        except (OSError, httpx.HTTPError) as exc:
+            logger.error(
+                "Download failed",
+                url=url,
+                target=str(target_path),
+                error=str(exc),
+                exc_info=True,
+            )
+            raise FraserDownloadError(
+                message=f"Failed to download {url}: {exc}",
+                url=url,
+                cause=exc,
+            ) from exc
+        finally:
+            # ``tmp_path`` is None after a successful replace; otherwise
+            # remove the residue so partial downloads never linger.
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except OSError as cleanup_exc:
+                    logger.warning(
+                        "Failed to clean up temp file",
+                        tmp_path=str(tmp_path),
+                        error=str(cleanup_exc),
+                    )
+
+    def download_with_meta(
+        self,
+        item: FraserItem,
+        doc_subdir: str,
+        *,
+        prefer: str = "txt",
+        force: bool = False,
+    ) -> tuple[Path, Path]:
+        """Download an item's primary asset and write its metadata sidecar.
+
+        Acquires the per-``item_id`` lock so that concurrent callers do
+        not redundantly download the same item. Different items still
+        run in parallel.
+
+        Parameters
+        ----------
+        item : FraserItem
+            Validated item model. Must have ``location`` populated with
+            at least one URL matching ``prefer`` (or the fallback
+            format).
+        doc_subdir : str
+            Subdirectory under :attr:`base_dir` (e.g.,
+            ``"fomc/minutes"``).
+        prefer : str
+            Preferred format, ``"txt"`` or ``"pdf"``. The other format
+            is used as fallback if the preferred is missing.
+        force : bool
+            Re-download even if the file already exists on disk.
+
+        Returns
+        -------
+        tuple[Path, Path]
+            ``(asset_path, metadata_path)``. The metadata sidecar is a
+            JSON dump of the item model.
+
+        Raises
+        ------
+        FraserDownloadError
+            When the item has no usable URL or the download fails.
+        """
+        lock = self._get_or_create_lock(item.item_id)
+        with lock:
+            url, ext = self._select_url(item, prefer=prefer)
+
+            target_dir = self.base_dir / doc_subdir
+            asset_filename = f"{item.date.isoformat()}_{item.item_id}.{ext}"
+            asset_path = target_dir / asset_filename
+            meta_path = target_dir / f"{item.date.isoformat()}_{item.item_id}.meta.json"
+
+            self.download(url, asset_path, force=force)
+
+            target_dir.mkdir(parents=True, exist_ok=True)
+            meta_payload = item.model_dump_json(indent=2, by_alias=False)
+            meta_path.write_text(meta_payload, encoding="utf-8")
+
+            logger.debug(
+                "Meta sidecar written",
+                meta_path=str(meta_path),
+                item_id=item.item_id,
+            )
+            return asset_path, meta_path
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _get_or_create_lock(self, item_id: int) -> threading.Lock:
+        """Return the lock associated with ``item_id``, creating if needed.
+
+        Parameters
+        ----------
+        item_id : int
+            FRASER item identifier.
+
+        Returns
+        -------
+        threading.Lock
+            The per-item lock instance.
+        """
+        with self._locks_master:
+            lock = self._locks.get(item_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._locks[item_id] = lock
+            return lock
+
+    def _stream_to(self, url: str, tmp_file: Any) -> None:
+        """Stream ``url`` into the open ``tmp_file`` handle.
+
+        Uses ``httpx.stream`` so the response is consumed incrementally.
+        Status codes are checked via ``response.raise_for_status()``
+        before writing any bytes so that error pages are never persisted.
+
+        Parameters
+        ----------
+        url : str
+            Source URL.
+        tmp_file : Any
+            Open writable binary file object (typically the handle
+            returned by ``tempfile.NamedTemporaryFile``).
+
+        Raises
+        ------
+        FraserDownloadError
+            On HTTP / I/O failure.
+        """
+        # Reuse the session's underlying httpx.Client so that timeout,
+        # SSL verification, and any session-level configuration are kept
+        # consistent with regular API requests.
+        client: httpx.Client = self._session._client
+        try:
+            with client.stream("GET", url) as response:
+                response.raise_for_status()
+                for chunk in response.iter_bytes(chunk_size=self._chunk_size):
+                    if chunk:
+                        tmp_file.write(chunk)
+        except httpx.HTTPStatusError as exc:
+            raise FraserDownloadError(
+                message=(f"HTTP {exc.response.status_code} while downloading {url}"),
+                url=url,
+                cause=exc,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise FraserDownloadError(
+                message=f"HTTP error while downloading {url}: {exc}",
+                url=url,
+                cause=exc,
+            ) from exc
+
+    @staticmethod
+    def _select_url(item: FraserItem, *, prefer: str) -> tuple[str, str]:
+        """Pick a URL from ``item.location`` honouring the ``prefer`` flag.
+
+        Falls back to the other format when the preferred one is
+        unavailable.
+
+        Parameters
+        ----------
+        item : FraserItem
+            Item whose ``location`` carries PDF / TXT URLs.
+        prefer : str
+            ``"txt"`` or ``"pdf"``.
+
+        Returns
+        -------
+        tuple[str, str]
+            ``(url, extension)``.
+
+        Raises
+        ------
+        FraserDownloadError
+            When the item has no URLs of either format.
+        """
+        if item.location is None:
+            raise FraserDownloadError(
+                message=f"Item {item.item_id} has no location",
+                url="",
+                cause=None,
+            )
+
+        txt_urls = item.location.text_url or []
+        pdf_urls = item.location.pdf_url or []
+
+        if prefer == "txt":
+            if txt_urls:
+                return txt_urls[0], "txt"
+            if pdf_urls:
+                return pdf_urls[0], "pdf"
+        elif prefer == "pdf":
+            if pdf_urls:
+                return pdf_urls[0], "pdf"
+            if txt_urls:
+                return txt_urls[0], "txt"
+
+        raise FraserDownloadError(
+            message=(
+                f"Item {item.item_id} has no usable URL "
+                f"(prefer={prefer!r}, pdf={len(pdf_urls)}, txt={len(txt_urls)})"
+            ),
+            url="",
+            cause=None,
+        )
+
+
+__all__ = ["FraserDownloader"]

--- a/src/market/fraser/errors.py
+++ b/src/market/fraser/errors.py
@@ -1,0 +1,330 @@
+"""Custom exception classes for the FRASER REST API module.
+
+This module provides a hierarchy of exception classes for handling
+various error conditions specific to FRASER API operations,
+including authentication failures, rate limiting, document not found
+errors, generic API errors, response parsing errors, download errors,
+and validation errors.
+
+Exception Hierarchy
+-------------------
+FraserError (base, inherits ``Exception`` directly)
+    FraserAuthError (401 / 403 - authentication / authorisation)
+    FraserRateLimitError (429 - rate limit exceeded, holds Retry-After)
+    FraserNotFoundError (404 - resource not found)
+    FraserAPIError (generic 4xx / 5xx - holds url, status_code, body)
+    FraserParseError (response parsing failure)
+    FraserDownloadError (file download failure)
+    FraserValidationError (configuration / input validation failure)
+
+Notes
+-----
+This follows the ``Exception``-direct-inheritance pattern used by
+``market.alphavantage.errors.AlphaVantageError`` to avoid circular
+imports with ``market.errors.MarketError``. The choice was confirmed
+during PR1 HF1 review.
+
+See Also
+--------
+market.alphavantage.errors : Reference implementation (direct
+    ``Exception`` inheritance, same rationale).
+"""
+
+
+class FraserError(Exception):
+    """Base exception for all FRASER API operations.
+
+    All FRASER-specific exceptions inherit from this class, providing
+    a single catch point for callers that need to handle any
+    FRASER-related failure generically.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the failure.
+
+    Attributes
+    ----------
+    message : str
+        The error message.
+
+    Examples
+    --------
+    >>> try:
+    ...     raise FraserError("FRASER API operation failed")
+    ... except FraserError as e:
+    ...     print(e.message)
+    FRASER API operation failed
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class FraserAuthError(FraserError):
+    """Exception raised when FRASER authentication / authorisation fails.
+
+    Raised when the API returns HTTP 401 (unauthorised) or 403
+    (forbidden), typically because the API key is missing, invalid,
+    or revoked.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the auth failure.
+
+    Examples
+    --------
+    >>> raise FraserAuthError("Invalid API key (HTTP 401)")
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class FraserRateLimitError(FraserError):
+    """Exception raised when the FRASER API rate limit is exceeded.
+
+    Raised when the API returns HTTP 429. The ``retry_after`` attribute
+    captures the ``Retry-After`` header value (in seconds) when the
+    server provides it, allowing callers to back off appropriately.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the rate limit.
+    retry_after : float | None
+        Suggested delay in seconds before retrying (parsed from the
+        ``Retry-After`` response header), or ``None`` when absent.
+
+    Attributes
+    ----------
+    retry_after : float | None
+        The suggested retry delay in seconds.
+
+    Examples
+    --------
+    >>> raise FraserRateLimitError("Rate limit exceeded", retry_after=60.0)
+    """
+
+    def __init__(self, message: str, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class FraserNotFoundError(FraserError):
+    """Exception raised when a FRASER resource is not found.
+
+    Raised when the API returns HTTP 404, indicating the requested
+    title, item, or other resource does not exist.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the missing resource.
+
+    Examples
+    --------
+    >>> raise FraserNotFoundError("Title 999999 not found")
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class FraserAPIError(FraserError):
+    """Exception raised for generic FRASER API errors (4xx / 5xx).
+
+    Used when the API returns a non-success status code that is not
+    handled by the more specific ``FraserAuthError``,
+    ``FraserRateLimitError``, or ``FraserNotFoundError``.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the API failure.
+    url : str
+        The API endpoint URL that returned the error.
+    status_code : int
+        The HTTP status code returned by the API.
+    response_body : str
+        The raw response body (truncated by ``MAX_RESPONSE_BODY_LOG``
+        in the session layer to avoid CWE-209 information leakage).
+
+    Attributes
+    ----------
+    url : str
+        The API endpoint URL.
+    status_code : int
+        The HTTP status code.
+    response_body : str
+        The raw response body.
+
+    Examples
+    --------
+    >>> raise FraserAPIError(
+    ...     "API returned HTTP 500",
+    ...     url="https://fraser.stlouisfed.org/api/title/677",
+    ...     status_code=500,
+    ...     response_body='{"error": "Internal Server Error"}',
+    ... )
+    """
+
+    def __init__(
+        self,
+        message: str,
+        url: str,
+        status_code: int,
+        response_body: str,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class FraserParseError(FraserError):
+    """Exception raised when FRASER response parsing fails.
+
+    Raised when the API returns a response that cannot be parsed into
+    the expected data structure (e.g., missing expected fields,
+    malformed JSON, unexpected schema).
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the parse failure.
+    raw_data : str
+        The raw data that could not be parsed.
+    field : str
+        The field or key that was expected but missing or malformed.
+    cause : Exception | None
+        The underlying exception that caused the parse failure,
+        when applicable.
+
+    Attributes
+    ----------
+    raw_data : str
+        The raw data that could not be parsed.
+    field : str
+        The expected field or key.
+    cause : Exception | None
+        The underlying cause, if any.
+
+    Examples
+    --------
+    >>> raise FraserParseError(
+    ...     "Missing 'items' key in response",
+    ...     raw_data='{"meta": {...}}',
+    ...     field="items",
+    ... )
+    """
+
+    def __init__(
+        self,
+        message: str,
+        raw_data: str,
+        field: str,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.raw_data = raw_data
+        self.field = field
+        self.cause = cause
+
+
+class FraserDownloadError(FraserError):
+    """Exception raised when a FRASER file download fails.
+
+    Raised when the downloader cannot fetch a binary asset (PDF, TXT)
+    from FRASER (e.g., network failure, partial response, write error).
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the download failure.
+    url : str
+        The asset URL that failed to download.
+    cause : Exception | None
+        The underlying exception that caused the download failure,
+        when applicable.
+
+    Attributes
+    ----------
+    url : str
+        The asset URL.
+    cause : Exception | None
+        The underlying cause, if any.
+
+    Examples
+    --------
+    >>> raise FraserDownloadError(
+    ...     "Failed to download PDF",
+    ...     url="https://fraser.stlouisfed.org/files/docs/...",
+    ... )
+    """
+
+    def __init__(
+        self,
+        message: str,
+        url: str,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.cause = cause
+
+
+class FraserValidationError(FraserError):
+    """Exception raised when FRASER configuration or input validation fails.
+
+    Raised by ``FraserConfig.__post_init__`` and other validation paths
+    when a parameter is outside its valid range.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error message describing the validation failure.
+    field : str
+        The field that failed validation.
+    value : object
+        The invalid value that caused the validation failure.
+
+    Attributes
+    ----------
+    field : str
+        The field that failed validation.
+    value : object
+        The invalid value.
+
+    Examples
+    --------
+    >>> raise FraserValidationError(
+    ...     "timeout must be positive",
+    ...     field="timeout",
+    ...     value=0,
+    ... )
+    """
+
+    def __init__(
+        self,
+        message: str,
+        field: str,
+        value: object,
+    ) -> None:
+        super().__init__(message)
+        self.field = field
+        self.value = value
+
+
+__all__ = [
+    "FraserAPIError",
+    "FraserAuthError",
+    "FraserDownloadError",
+    "FraserError",
+    "FraserNotFoundError",
+    "FraserParseError",
+    "FraserRateLimitError",
+    "FraserValidationError",
+]

--- a/src/market/fraser/fetchers/__init__.py
+++ b/src/market/fraser/fetchers/__init__.py
@@ -1,26 +1,44 @@
 """Fetcher subpackage for ``market.fraser``.
 
-Re-exports the abstract :class:`BaseFraserFetcher` base class and the
-three concrete FOMC fetchers (Minutes from PR3, Statements + Press
-Conferences from PR4 前半). Subsequent PRs extend this module with the
-remaining Beige Book / Speeches / Monetary Policy Report fetchers.
+Re-exports the abstract :class:`BaseFraserFetcher` base class plus all
+concrete fetcher classes:
+
+- :class:`FOMCMinutesFetcher` — FOMC minutes (PR3).
+- :class:`FOMCStatementsFetcher` — FOMC policy statements (PR4 前半).
+- :class:`FOMCPressConferencesFetcher` — FOMC press conference
+  transcripts (PR4 前半).
+- :class:`BeigeBookFetcher` — Beige Book reports with parallel
+  download support (PR4 後半).
+- :class:`FRBSpeechFetcher` — Federal Reserve Board speeches with
+  optional speaker filtering (PR4 後半).
+- :class:`MonetaryPolicyReportFetcher` — Monetary Policy Reports to the
+  Congress, PDF-first (PR4 後半).
 
 See Also
 --------
 market.fraser.fetchers.base : Abstract base class.
 market.fraser.fetchers.fomc : FOMC-specific fetchers.
+market.fraser.fetchers.beige_book : Beige Book fetcher.
+market.fraser.fetchers.speeches : FRB speech fetcher.
+market.fraser.fetchers.monetary_policy : Monetary Policy Report fetcher.
 """
 
 from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.fetchers.beige_book import BeigeBookFetcher
 from market.fraser.fetchers.fomc import (
     FOMCMinutesFetcher,
     FOMCPressConferencesFetcher,
     FOMCStatementsFetcher,
 )
+from market.fraser.fetchers.monetary_policy import MonetaryPolicyReportFetcher
+from market.fraser.fetchers.speeches import FRBSpeechFetcher
 
 __all__ = [
     "BaseFraserFetcher",
+    "BeigeBookFetcher",
     "FOMCMinutesFetcher",
     "FOMCPressConferencesFetcher",
     "FOMCStatementsFetcher",
+    "FRBSpeechFetcher",
+    "MonetaryPolicyReportFetcher",
 ]

--- a/src/market/fraser/fetchers/__init__.py
+++ b/src/market/fraser/fetchers/__init__.py
@@ -1,0 +1,16 @@
+"""Fetcher subpackage for ``market.fraser``.
+
+Re-exports the abstract :class:`BaseFraserFetcher` base class and the
+concrete :class:`FOMCMinutesFetcher` introduced by PR3. Subsequent PRs
+extend this module with additional FOMC and Beige Book fetchers.
+
+See Also
+--------
+market.fraser.fetchers.base : Abstract base class.
+market.fraser.fetchers.fomc : FOMC-specific fetchers.
+"""
+
+from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+
+__all__ = ["BaseFraserFetcher", "FOMCMinutesFetcher"]

--- a/src/market/fraser/fetchers/__init__.py
+++ b/src/market/fraser/fetchers/__init__.py
@@ -1,8 +1,9 @@
 """Fetcher subpackage for ``market.fraser``.
 
 Re-exports the abstract :class:`BaseFraserFetcher` base class and the
-concrete :class:`FOMCMinutesFetcher` introduced by PR3. Subsequent PRs
-extend this module with additional FOMC and Beige Book fetchers.
+three concrete FOMC fetchers (Minutes from PR3, Statements + Press
+Conferences from PR4 前半). Subsequent PRs extend this module with the
+remaining Beige Book / Speeches / Monetary Policy Report fetchers.
 
 See Also
 --------
@@ -11,6 +12,15 @@ market.fraser.fetchers.fomc : FOMC-specific fetchers.
 """
 
 from market.fraser.fetchers.base import BaseFraserFetcher
-from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+from market.fraser.fetchers.fomc import (
+    FOMCMinutesFetcher,
+    FOMCPressConferencesFetcher,
+    FOMCStatementsFetcher,
+)
 
-__all__ = ["BaseFraserFetcher", "FOMCMinutesFetcher"]
+__all__ = [
+    "BaseFraserFetcher",
+    "FOMCMinutesFetcher",
+    "FOMCPressConferencesFetcher",
+    "FOMCStatementsFetcher",
+]

--- a/src/market/fraser/fetchers/base.py
+++ b/src/market/fraser/fetchers/base.py
@@ -33,8 +33,11 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
+from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel
 
 from market.fraser.client import FraserClient
 from market.fraser.constants import DOC_TYPE_SUBDIRS, KNOWN_TITLE_IDS
@@ -125,9 +128,13 @@ class BaseFraserFetcher(ABC):
     # Public properties
     # =========================================================================
 
-    @property
+    @cached_property
     def title_id(self) -> int:
         """Resolve the FRASER ``title_id`` for :attr:`doc_type`.
+
+        The resolution is cached per-instance: the first access hits
+        :meth:`_resolve_title_id` (which may read
+        ``fraser_titles.json`` from disk), subsequent accesses are O(1).
 
         Returns
         -------
@@ -218,6 +225,31 @@ class BaseFraserFetcher(ABC):
         """Return the on-disk subdirectory for :attr:`doc_type`."""
         return DOC_TYPE_SUBDIRS[self.doc_type.value]
 
+    @staticmethod
+    def _convert_to[M: BaseModel](item: FraserItem, model_cls: type[M]) -> M:
+        """Re-validate ``item``'s fields against the more specific ``model_cls``.
+
+        Used by concrete fetchers to upcast a generic :class:`FraserItem`
+        returned by ``list_items`` into the document-type specific Pydantic
+        model (``FOMCMeeting``, ``BeigeBookReport``, etc.). Centralising
+        the conversion here removes the three-class duplication of
+        ``_to_fomc_meeting`` that existed previously
+        (see PR review HIGH-2 / project-115 Wave4).
+
+        Parameters
+        ----------
+        item : FraserItem
+            Generic item returned by ``FraserClient.list_items``.
+        model_cls : type[M]
+            Pydantic V2 model subclass to project ``item`` into.
+
+        Returns
+        -------
+        M
+            Validated instance of ``model_cls``.
+        """
+        return model_cls.model_validate(item.model_dump(by_alias=False))
+
     # =========================================================================
     # Public fetch operations
     # =========================================================================
@@ -226,7 +258,7 @@ class BaseFraserFetcher(ABC):
         self,
         item_id: int,
         *,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
     ) -> tuple[Path, FraserItem]:
         """Fetch metadata for ``item_id`` and download the asset.
 
@@ -238,9 +270,9 @@ class BaseFraserFetcher(ABC):
         ----------
         item_id : int
             FRASER item identifier.
-        prefer : str
-            Preferred asset format (``"txt"`` or ``"pdf"``). The other
-            format is used as fallback when the preferred one is absent.
+        prefer : Literal["txt", "pdf"]
+            Preferred asset format. The other format is used as fallback
+            when the preferred one is absent.
 
         Returns
         -------
@@ -254,7 +286,13 @@ class BaseFraserFetcher(ABC):
         return asset_path, item
 
     def fetch_pdf(self, item_id: int) -> tuple[Path, FraserItem]:
-        """Convenience wrapper that forces ``prefer='pdf'`` on :meth:`fetch_text`."""
+        """Convenience wrapper that forces ``prefer='pdf'`` on :meth:`fetch_text`.
+
+        Returns
+        -------
+        tuple[Path, FraserItem]
+            ``(asset_path, item)`` — same shape as :meth:`fetch_text`.
+        """
         return self.fetch_text(item_id, prefer="pdf")
 
 

--- a/src/market/fraser/fetchers/base.py
+++ b/src/market/fraser/fetchers/base.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel
 
 from market.fraser.client import FraserClient
-from market.fraser.constants import DOC_TYPE_SUBDIRS, KNOWN_TITLE_IDS
+from market.fraser.constants import KNOWN_TITLE_IDS
 from market.fraser.downloader import FraserDownloader
 from market.fraser.errors import FraserValidationError
 from utils_core.logging import get_logger
@@ -102,8 +102,11 @@ class BaseFraserFetcher(ABC):
         self._client: FraserClient = client
 
         if downloader is None:
+            # Use the client's public ``session`` accessor instead of the
+            # private ``_session`` attribute so the dependency is on the
+            # public interface (DIP-compliant).
             downloader = FraserDownloader(
-                session=self._client._session, base_dir=base_dir
+                session=self._client.session, base_dir=base_dir
             )
         self._downloader: FraserDownloader = downloader
 
@@ -223,11 +226,11 @@ class BaseFraserFetcher(ABC):
 
     def _doc_subdir(self) -> str:
         """Return the on-disk subdirectory for :attr:`doc_type`."""
-        return DOC_TYPE_SUBDIRS[self.doc_type.value]
+        return self.doc_type.subdir
 
     @staticmethod
     def _convert_to[M: BaseModel](item: FraserItem, model_cls: type[M]) -> M:
-        """Re-validate ``item``'s fields against the more specific ``model_cls``.
+        """Project ``item`` into the more specific ``model_cls``.
 
         Used by concrete fetchers to upcast a generic :class:`FraserItem`
         returned by ``list_items`` into the document-type specific Pydantic
@@ -235,6 +238,12 @@ class BaseFraserFetcher(ABC):
         the conversion here removes the three-class duplication of
         ``_to_fomc_meeting`` that existed previously
         (see PR review HIGH-2 / project-115 Wave4).
+
+        ``model_validate`` is used (not ``model_construct``) because the
+        source ``item`` carries nested submodels (``FraserAuthor``,
+        ``FraserLocation``, ...) that need re-binding through the
+        validator chain when projected onto the target type. The
+        validation cost is small compared to the upstream HTTP round-trip.
 
         Parameters
         ----------
@@ -246,9 +255,43 @@ class BaseFraserFetcher(ABC):
         Returns
         -------
         M
-            Validated instance of ``model_cls``.
+            Instance of ``model_cls`` carrying the same field values
+            as ``item``.
         """
         return model_cls.model_validate(item.model_dump(by_alias=False))
+
+    def _fetch_filtered[DomainT: BaseModel](
+        self,
+        year_range: tuple[int, int],
+        model_cls: type[DomainT],
+        *,
+        limit: int,
+    ) -> list[DomainT]:
+        """Common ``list_items → filter → convert`` pipeline.
+
+        Centralises the three-line pattern repeated across six fetchers
+        (``list_minutes`` / ``list_statements`` / ``list_press_conferences``
+        / ``list_reports`` (Beige Book + MPR) / ``list_speeches``). Each
+        public ``list_*`` method becomes a one-liner that picks the
+        relevant ``model_cls``.
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+        model_cls : type[DomainT]
+            Pydantic V2 domain model to project into.
+        limit : int
+            Maximum number of items requested from FRASER.
+
+        Returns
+        -------
+        list[DomainT]
+            Year-filtered, type-projected items.
+        """
+        items = self._client.list_items(self.title_id, limit=limit)
+        filtered = self._filter_by_year_range(items, year_range)
+        return [self._convert_to(item, model_cls) for item in filtered]
 
     # =========================================================================
     # Public fetch operations

--- a/src/market/fraser/fetchers/base.py
+++ b/src/market/fraser/fetchers/base.py
@@ -1,0 +1,261 @@
+"""Abstract base class for FRASER document-type fetchers.
+
+:class:`BaseFraserFetcher` encapsulates the common pipeline shared by
+all FRASER document fetchers (FOMC minutes, FOMC statements, Beige
+Book, etc.):
+
+1. ``client.list_items`` / ``client.get_item`` for metadata retrieval.
+2. ``_filter_by_year_range`` for date-window filtering.
+3. ``downloader.download_with_meta`` for atomic file persistence with
+   a ``.meta.json`` sidecar.
+
+Subclasses must provide :meth:`doc_type` so that the base class can
+resolve the correct FRASER ``title_id`` (via ``KNOWN_TITLE_IDS`` and the
+``fraser_titles.json`` fallback) and pick the correct on-disk
+subdirectory (via ``DOC_TYPE_SUBDIRS``).
+
+Notes
+-----
+This base class deliberately does **not** inherit from
+``market.fred.BaseDataFetcher``: ``BaseDataFetcher`` is tailored for
+pandas ``DataFrame`` outputs, whereas FRASER returns structured JSON
+documents plus binary / text file downloads. Two distinct shapes →
+two distinct bases (per HF1 review).
+
+See Also
+--------
+market.fraser.client : :class:`FraserClient` used for metadata calls.
+market.fraser.downloader : :class:`FraserDownloader` used for asset
+    persistence.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from market.fraser.client import FraserClient
+from market.fraser.constants import DOC_TYPE_SUBDIRS, KNOWN_TITLE_IDS
+from market.fraser.downloader import FraserDownloader
+from market.fraser.errors import FraserValidationError
+from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from market.fraser.models import FraserItem
+    from market.fraser.types import DocType
+
+logger = get_logger(__name__)
+
+
+# Default location for the operator-confirmed ``title_id`` mapping.
+# Populated by ``python -m market.fraser.scripts.discover_titles``.
+DEFAULT_TITLES_JSON_PATH: Path = Path("data/config/fraser_titles.json")
+
+
+class BaseFraserFetcher(ABC):
+    """Abstract base for FRASER document-type fetchers.
+
+    Parameters
+    ----------
+    client : FraserClient | None
+        Pre-built FRASER client. When ``None``, a default client is
+        instantiated (which reads ``FRASER_API_KEY`` from the
+        environment / ``.env`` file).
+    downloader : FraserDownloader | None
+        Pre-built downloader. When ``None``, a default downloader is
+        instantiated that reuses the client's HTTP session and writes
+        under ``base_dir``.
+    base_dir : Path
+        Root directory for downloaded assets and meta-data sidecars
+        (default: ``Path('data/raw/fraser')``).
+
+    Notes
+    -----
+    Subclasses must override :meth:`doc_type` to expose the relevant
+    :class:`market.fraser.types.DocType` member. The base class uses
+    this to look up the canonical ``title_id`` and to compute the
+    on-disk subdirectory layout.
+
+    Examples
+    --------
+    >>> from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+    >>> fetcher = FOMCMinutesFetcher()  # doctest: +SKIP
+    >>> meetings = fetcher.list_minutes((2024, 2024))  # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        client: FraserClient | None = None,
+        downloader: FraserDownloader | None = None,
+        base_dir: Path = Path("data/raw/fraser"),
+    ) -> None:
+        # Lazily build the default client only when not injected so that
+        # constructor calls in test code (which inject mocks) never hit
+        # the ``FRASER_API_KEY`` env lookup.
+        if client is None:
+            client = FraserClient()
+        self._client: FraserClient = client
+
+        if downloader is None:
+            downloader = FraserDownloader(
+                session=self._client._session, base_dir=base_dir
+            )
+        self._downloader: FraserDownloader = downloader
+
+        self._base_dir: Path = Path(base_dir)
+
+        logger.debug(
+            "BaseFraserFetcher initialised",
+            base_dir=str(self._base_dir),
+            doc_type=str(self.doc_type),
+        )
+
+    # =========================================================================
+    # Abstract interface
+    # =========================================================================
+
+    @property
+    @abstractmethod
+    def doc_type(self) -> DocType:
+        """Document type identifier (e.g., ``DocType.FOMC_MINUTES``)."""
+
+    # =========================================================================
+    # Public properties
+    # =========================================================================
+
+    @property
+    def title_id(self) -> int:
+        """Resolve the FRASER ``title_id`` for :attr:`doc_type`.
+
+        Returns
+        -------
+        int
+            The numeric FRASER title identifier.
+
+        Raises
+        ------
+        FraserValidationError
+            When neither :data:`KNOWN_TITLE_IDS` nor the operator JSON
+            override provides a value for :attr:`doc_type`.
+        """
+        return self._resolve_title_id()
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _resolve_title_id(self) -> int:
+        """Resolve the FRASER ``title_id`` for the current document type.
+
+        Resolution order:
+
+        1. ``KNOWN_TITLE_IDS[self.doc_type.value]`` — the hard-coded,
+           reviewed mapping.
+        2. ``DEFAULT_TITLES_JSON_PATH`` — operator-confirmed override
+           emitted by the ``discover_titles`` CLI.
+
+        Raises
+        ------
+        FraserValidationError
+            When neither source supplies a non-``None`` integer.
+        """
+        key = self.doc_type.value
+
+        known_value = KNOWN_TITLE_IDS.get(key)
+        if isinstance(known_value, int):
+            return known_value
+
+        path = DEFAULT_TITLES_JSON_PATH
+        if path.exists():
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    "Failed to read fraser_titles.json",
+                    path=str(path),
+                    error=str(exc),
+                )
+                payload = {}
+            value = payload.get(key) if isinstance(payload, dict) else None
+            if isinstance(value, int):
+                return value
+
+        raise FraserValidationError(
+            (
+                f"title_id for {key!r} is not configured. "
+                "Set KNOWN_TITLE_IDS or run "
+                "`python -m market.fraser.scripts.discover_titles`."
+            ),
+            field="title_id",
+            value=key,
+        )
+
+    def _filter_by_year_range(
+        self,
+        items: list[FraserItem],
+        year_range: tuple[int, int],
+    ) -> list[FraserItem]:
+        """Filter ``items`` whose ``date.year`` falls within ``year_range``.
+
+        Parameters
+        ----------
+        items : list[FraserItem]
+            Source items to filter.
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+
+        Returns
+        -------
+        list[FraserItem]
+            Items whose ``date.year`` is within the window.
+        """
+        start, end = year_range
+        return [item for item in items if start <= item.date.year <= end]
+
+    def _doc_subdir(self) -> str:
+        """Return the on-disk subdirectory for :attr:`doc_type`."""
+        return DOC_TYPE_SUBDIRS[self.doc_type.value]
+
+    # =========================================================================
+    # Public fetch operations
+    # =========================================================================
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "txt",
+    ) -> tuple[Path, FraserItem]:
+        """Fetch metadata for ``item_id`` and download the asset.
+
+        The asset is written to
+        ``<base_dir>/<doc_subdir>/<YYYY-MM-DD>_<item_id>.<ext>``
+        and a ``.meta.json`` sidecar with the model dump is co-located.
+
+        Parameters
+        ----------
+        item_id : int
+            FRASER item identifier.
+        prefer : str
+            Preferred asset format (``"txt"`` or ``"pdf"``). The other
+            format is used as fallback when the preferred one is absent.
+
+        Returns
+        -------
+        tuple[Path, FraserItem]
+            ``(asset_path, item)``.
+        """
+        item = self._client.get_item(item_id)
+        asset_path, _meta_path = self._downloader.download_with_meta(
+            item, self._doc_subdir(), prefer=prefer
+        )
+        return asset_path, item
+
+    def fetch_pdf(self, item_id: int) -> tuple[Path, FraserItem]:
+        """Convenience wrapper that forces ``prefer='pdf'`` on :meth:`fetch_text`."""
+        return self.fetch_text(item_id, prefer="pdf")
+
+
+__all__ = ["DEFAULT_TITLES_JSON_PATH", "BaseFraserFetcher"]

--- a/src/market/fraser/fetchers/beige_book.py
+++ b/src/market/fraser/fetchers/beige_book.py
@@ -25,7 +25,7 @@ edgar.batch : Reference ``_run_batch`` ThreadPoolExecutor pattern.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from tqdm import tqdm
 
@@ -36,8 +36,6 @@ from utils_core.logging import get_logger
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from market.fraser.models import FraserItem
 
 logger = get_logger(__name__)
 
@@ -102,22 +100,27 @@ class BeigeBookFetcher(BaseFraserFetcher):
         """
         items = self._client.list_items(self.title_id, limit=limit)
         filtered = self._filter_by_year_range(items, year_range)
-        return [self._to_beige_book_report(item) for item in filtered]
+        return [self._convert_to(item, BeigeBookReport) for item in filtered]
 
     def fetch_text(
         self,
         item_id: int,
         *,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
     ) -> tuple[Path, BeigeBookReport]:
         """Fetch and download a single Beige Book report.
 
         See :meth:`BaseFraserFetcher.fetch_text` for the underlying
         pipeline. The return type narrows the second element to
         :class:`BeigeBookReport`.
+
+        Returns
+        -------
+        tuple[Path, BeigeBookReport]
+            ``(asset_path, report)``.
         """
         path, item = super().fetch_text(item_id, prefer=prefer)
-        report = self._to_beige_book_report(item)
+        report = self._convert_to(item, BeigeBookReport)
         return path, report
 
     def fetch_all(
@@ -125,7 +128,7 @@ class BeigeBookFetcher(BaseFraserFetcher):
         year_range: tuple[int, int],
         *,
         max_workers: int = 4,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
         limit: int = 100,
     ) -> dict[int, Path | Exception]:
         """Download every Beige Book report in ``year_range`` in parallel.
@@ -145,9 +148,9 @@ class BeigeBookFetcher(BaseFraserFetcher):
             (default ``4``). Values above :data:`MAX_WORKERS_LIMIT` are
             silently clamped to keep the worker pool within the FRASER
             30 req/min ceiling.
-        prefer : str
+        prefer : Literal["txt", "pdf"]
             Preferred asset format passed through to :meth:`fetch_text`
-            (``"txt"`` or ``"pdf"``; default ``"txt"``).
+            (default ``"txt"``).
         limit : int
             Maximum number of items requested from FRASER when listing
             reports (default: ``100``).
@@ -220,7 +223,7 @@ class BeigeBookFetcher(BaseFraserFetcher):
     # Internal helpers
     # =========================================================================
 
-    def _fetch_text_path(self, item_id: int, prefer: str) -> Path:
+    def _fetch_text_path(self, item_id: int, prefer: Literal["txt", "pdf"]) -> Path:
         """Return only the ``Path`` portion of :meth:`fetch_text`.
 
         This thin wrapper keeps :meth:`fetch_all` independent of the
@@ -231,7 +234,7 @@ class BeigeBookFetcher(BaseFraserFetcher):
         ----------
         item_id : int
             FRASER item identifier.
-        prefer : str
+        prefer : Literal["txt", "pdf"]
             Preferred asset format.
 
         Returns
@@ -241,19 +244,6 @@ class BeigeBookFetcher(BaseFraserFetcher):
         """
         path, _report = self.fetch_text(item_id, prefer=prefer)
         return path
-
-    def _to_beige_book_report(self, item: FraserItem) -> BeigeBookReport:
-        """Convert a generic :class:`FraserItem` to :class:`BeigeBookReport`.
-
-        Mirrors the ``FOMCMeeting`` conversion pattern in
-        :mod:`market.fraser.fetchers.fomc` (the future refactor will
-        lift these helpers onto :class:`BaseFraserFetcher` — out of
-        scope per project-108 plan).
-        """
-        if isinstance(item, BeigeBookReport):
-            return item
-        payload = item.model_dump(by_alias=False)
-        return BeigeBookReport.model_validate(payload)
 
 
 __all__ = [

--- a/src/market/fraser/fetchers/beige_book.py
+++ b/src/market/fraser/fetchers/beige_book.py
@@ -98,9 +98,7 @@ class BeigeBookFetcher(BaseFraserFetcher):
         list[BeigeBookReport]
             Beige Book reports covering the requested calendar window.
         """
-        items = self._client.list_items(self.title_id, limit=limit)
-        filtered = self._filter_by_year_range(items, year_range)
-        return [self._convert_to(item, BeigeBookReport) for item in filtered]
+        return self._fetch_filtered(year_range, BeigeBookReport, limit=limit)
 
     def fetch_text(
         self,

--- a/src/market/fraser/fetchers/beige_book.py
+++ b/src/market/fraser/fetchers/beige_book.py
@@ -1,0 +1,262 @@
+"""Beige Book fetcher with parallel download support.
+
+This module exposes :class:`BeigeBookFetcher`, a thin specialisation of
+:class:`BaseFraserFetcher` for FRASER Beige Book reports. It adds a
+parallel :meth:`BeigeBookFetcher.fetch_all` helper that fans out
+``fetch_text`` calls across a bounded :class:`ThreadPoolExecutor`, using
+the same partial-failure-tolerant ``dict[int, Path | Exception]``
+pattern established by :func:`edgar.batch._run_batch`.
+
+The ``max_workers=4`` default keeps the worst-case effective throughput
+well below the FRASER 30 req/min ceiling enforced by
+:class:`market.alphavantage.rate_limiter.DualWindowRateLimiter`. Each
+worker thread serialises through the shared rate limiter via the
+underlying :class:`market.fraser.session.FraserSession`, so the parallel
+pipeline is correct under contention even when the rate limit is
+saturated.
+
+See Also
+--------
+market.fraser.fetchers.base : Shared abstract base class.
+market.fraser.fetchers.fomc : FOMC-specific fetcher pattern reused here.
+edgar.batch : Reference ``_run_batch`` ThreadPoolExecutor pattern.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING
+
+from tqdm import tqdm
+
+from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.models import BeigeBookReport
+from market.fraser.types import DocType
+from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from market.fraser.models import FraserItem
+
+logger = get_logger(__name__)
+
+
+# Hard upper bound on ``max_workers`` to keep parallel ``fetch_text``
+# calls within the FRASER 30 req/min rate-limit envelope. Five concurrent
+# downloads can momentarily exceed the limiter (each ``fetch_text``
+# triggers two upstream requests: ``get_item`` + asset download), so we
+# cap at four (per project-108 plan task-6 design note).
+MAX_WORKERS_LIMIT: int = 4
+
+
+class BeigeBookFetcher(BaseFraserFetcher):
+    """Fetcher for Beige Book report documents.
+
+    Provides the standard ``list_reports`` / ``fetch_text`` surface plus
+    a :meth:`fetch_all` helper that parallelises downloads with bounded
+    concurrency and partial-failure tolerance.
+
+    Examples
+    --------
+    >>> from market.fraser import BeigeBookFetcher
+    >>> fetcher = BeigeBookFetcher()  # doctest: +SKIP
+    >>> reports = fetcher.list_reports(year_range=(2023, 2024))  # doctest: +SKIP
+    >>> results = fetcher.fetch_all((2023, 2024), max_workers=4)  # doctest: +SKIP
+    >>> for item_id, outcome in results.items():  # doctest: +SKIP
+    ...     if isinstance(outcome, Exception):
+    ...         print(f"{item_id}: failed - {outcome}")
+    ...     else:
+    ...         print(f"{item_id}: {outcome}")
+    """
+
+    @property
+    def doc_type(self) -> DocType:
+        """Return :data:`DocType.BEIGE_BOOK`."""
+        return DocType.BEIGE_BOOK
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def list_reports(
+        self,
+        year_range: tuple[int, int],
+        *,
+        limit: int = 100,
+    ) -> list[BeigeBookReport]:
+        """List Beige Book reports whose ``date.year`` is in ``year_range``.
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+        limit : int
+            Maximum number of items returned by the underlying
+            ``GET /items`` call (default: ``100``).
+
+        Returns
+        -------
+        list[BeigeBookReport]
+            Beige Book reports covering the requested calendar window.
+        """
+        items = self._client.list_items(self.title_id, limit=limit)
+        filtered = self._filter_by_year_range(items, year_range)
+        return [self._to_beige_book_report(item) for item in filtered]
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "txt",
+    ) -> tuple[Path, BeigeBookReport]:
+        """Fetch and download a single Beige Book report.
+
+        See :meth:`BaseFraserFetcher.fetch_text` for the underlying
+        pipeline. The return type narrows the second element to
+        :class:`BeigeBookReport`.
+        """
+        path, item = super().fetch_text(item_id, prefer=prefer)
+        report = self._to_beige_book_report(item)
+        return path, report
+
+    def fetch_all(
+        self,
+        year_range: tuple[int, int],
+        *,
+        max_workers: int = 4,
+        prefer: str = "txt",
+        limit: int = 100,
+    ) -> dict[int, Path | Exception]:
+        """Download every Beige Book report in ``year_range`` in parallel.
+
+        Uses :class:`concurrent.futures.ThreadPoolExecutor` to fan out
+        :meth:`fetch_text` calls, then collects the results into a
+        ``{item_id: Path | Exception}`` dict so that partial failures
+        never abort the batch. Per-future exceptions are logged at
+        ``WARNING`` level and stored in the result dict.
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+        max_workers : int
+            Maximum number of concurrent download threads
+            (default ``4``). Values above :data:`MAX_WORKERS_LIMIT` are
+            silently clamped to keep the worker pool within the FRASER
+            30 req/min ceiling.
+        prefer : str
+            Preferred asset format passed through to :meth:`fetch_text`
+            (``"txt"`` or ``"pdf"``; default ``"txt"``).
+        limit : int
+            Maximum number of items requested from FRASER when listing
+            reports (default: ``100``).
+
+        Returns
+        -------
+        dict[int, Path | Exception]
+            Mapping of ``item_id`` to downloaded asset path on success,
+            or the raised exception instance on failure.
+        """
+        if max_workers < 1:
+            raise ValueError(
+                f"max_workers must be >= 1, got {max_workers}",
+            )
+        effective_workers = min(max_workers, MAX_WORKERS_LIMIT)
+
+        reports = self.list_reports(year_range, limit=limit)
+        results: dict[int, Path | Exception] = {}
+
+        if not reports:
+            logger.info(
+                "BeigeBookFetcher.fetch_all: no reports in range",
+                year_range=year_range,
+            )
+            return results
+
+        total = len(reports)
+        logger.info(
+            "BeigeBookFetcher.fetch_all starting",
+            total=total,
+            max_workers=effective_workers,
+            prefer=prefer,
+        )
+
+        with ThreadPoolExecutor(max_workers=effective_workers) as executor:
+            future_to_id = {
+                executor.submit(self._fetch_text_path, report.item_id, prefer): (
+                    report.item_id
+                )
+                for report in reports
+            }
+
+            with tqdm(total=total, desc="Beige Book") as pbar:
+                for future in as_completed(future_to_id):
+                    item_id = future_to_id[future]
+                    try:
+                        results[item_id] = future.result()
+                    except Exception as exc:
+                        results[item_id] = exc
+                        logger.warning(
+                            "Beige Book fetch_all task failed",
+                            item_id=item_id,
+                            error=str(exc),
+                            error_type=type(exc).__name__,
+                            exc_info=True,
+                        )
+                    pbar.update(1)
+
+        success_count = sum(1 for v in results.values() if not isinstance(v, Exception))
+        failed_count = total - success_count
+        logger.info(
+            "BeigeBookFetcher.fetch_all completed",
+            total=total,
+            success=success_count,
+            failed=failed_count,
+        )
+        return results
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _fetch_text_path(self, item_id: int, prefer: str) -> Path:
+        """Return only the ``Path`` portion of :meth:`fetch_text`.
+
+        This thin wrapper keeps :meth:`fetch_all` independent of the
+        model returned by :meth:`fetch_text` (Beige Book reports) so
+        that the ``Future.result()`` payload is just a ``Path``.
+
+        Parameters
+        ----------
+        item_id : int
+            FRASER item identifier.
+        prefer : str
+            Preferred asset format.
+
+        Returns
+        -------
+        Path
+            Downloaded asset path.
+        """
+        path, _report = self.fetch_text(item_id, prefer=prefer)
+        return path
+
+    def _to_beige_book_report(self, item: FraserItem) -> BeigeBookReport:
+        """Convert a generic :class:`FraserItem` to :class:`BeigeBookReport`.
+
+        Mirrors the ``FOMCMeeting`` conversion pattern in
+        :mod:`market.fraser.fetchers.fomc` (the future refactor will
+        lift these helpers onto :class:`BaseFraserFetcher` — out of
+        scope per project-108 plan).
+        """
+        if isinstance(item, BeigeBookReport):
+            return item
+        payload = item.model_dump(by_alias=False)
+        return BeigeBookReport.model_validate(payload)
+
+
+__all__ = [
+    "MAX_WORKERS_LIMIT",
+    "BeigeBookFetcher",
+]

--- a/src/market/fraser/fetchers/fomc.py
+++ b/src/market/fraser/fetchers/fomc.py
@@ -1,9 +1,18 @@
 """FOMC document fetchers built on :class:`BaseFraserFetcher`.
 
-This module currently exposes :class:`FOMCMinutesFetcher` — the only
-FOMC fetcher introduced by PR3. :class:`FOMCStatementsFetcher` and
-:class:`FOMCPressConferencesFetcher` will be added in PR4 once their
-``title_id`` values are discovered.
+This module exposes three FOMC fetchers, each a thin specialisation of
+:class:`BaseFraserFetcher` that only differs in its :attr:`doc_type`
+(and therefore in the resolved FRASER ``title_id``):
+
+- :class:`FOMCMinutesFetcher` — FOMC meeting minutes (PR3).
+- :class:`FOMCStatementsFetcher` — FOMC policy statements (PR4 前半).
+- :class:`FOMCPressConferencesFetcher` — FOMC chair press conference
+  transcripts (PR4 前半).
+
+All three share the ``_to_fomc_meeting`` conversion helper and expose
+the same public surface (``list_*`` + ``fetch_text``). Lifting the
+helper onto :class:`BaseFraserFetcher` is deliberately deferred to a
+future refactor (out of scope for PR4 前半 per project-108 plan).
 
 See Also
 --------
@@ -111,4 +120,181 @@ class FOMCMinutesFetcher(BaseFraserFetcher):
         return FOMCMeeting.model_validate(payload)
 
 
-__all__ = ["FOMCMinutesFetcher"]
+class FOMCStatementsFetcher(BaseFraserFetcher):
+    """Fetcher for FOMC policy Statement documents.
+
+    Mirrors :class:`FOMCMinutesFetcher` 1:1 with two differences:
+
+    - :attr:`doc_type` is :data:`DocType.FOMC_STATEMENTS`.
+    - The resolved ``title_id`` therefore comes from the
+      ``"fomc_statements"`` slot of ``KNOWN_TITLE_IDS`` /
+      ``fraser_titles.json``.
+
+    Examples
+    --------
+    >>> from market.fraser import FOMCStatementsFetcher
+    >>> fetcher = FOMCStatementsFetcher()  # doctest: +SKIP
+    >>> statements = fetcher.list_statements(year_range=(2024, 2024))  # doctest: +SKIP
+    >>> for stmt in statements:  # doctest: +SKIP
+    ...     print(stmt.date, stmt.item_id)
+    """
+
+    @property
+    def doc_type(self) -> DocType:
+        """Return :data:`DocType.FOMC_STATEMENTS`."""
+        return DocType.FOMC_STATEMENTS
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def list_statements(
+        self,
+        year_range: tuple[int, int],
+        *,
+        limit: int = 100,
+    ) -> list[FOMCMeeting]:
+        """List FOMC Statements whose ``date.year`` is within ``year_range``.
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+        limit : int
+            Maximum number of items returned by the underlying
+            ``GET /items`` call (default: ``100``).
+
+        Returns
+        -------
+        list[FOMCMeeting]
+            FOMC Statements covering the requested calendar window.
+        """
+        items = self._client.list_items(self.title_id, limit=limit)
+        filtered = self._filter_by_year_range(items, year_range)
+        return [self._to_fomc_meeting(item) for item in filtered]
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "txt",
+    ) -> tuple[Path, FOMCMeeting]:
+        """Fetch and download a single FOMC Statement item.
+
+        See :meth:`BaseFraserFetcher.fetch_text` for the underlying
+        pipeline. The return type narrows the second element to
+        :class:`FOMCMeeting` for ergonomic call-site typing.
+        """
+        path, item = super().fetch_text(item_id, prefer=prefer)
+        meeting = self._to_fomc_meeting(item)
+        return path, meeting
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _to_fomc_meeting(self, item: FraserItem) -> FOMCMeeting:
+        """Convert a generic :class:`FraserItem` to :class:`FOMCMeeting`.
+
+        See :meth:`FOMCMinutesFetcher._to_fomc_meeting` for details.
+        Duplicated here intentionally (project-108 task-5 scope) — the
+        future refactor will lift this onto :class:`BaseFraserFetcher`.
+        """
+        if isinstance(item, FOMCMeeting):
+            return item
+        payload = item.model_dump(by_alias=False)
+        return FOMCMeeting.model_validate(payload)
+
+
+class FOMCPressConferencesFetcher(BaseFraserFetcher):
+    """Fetcher for FOMC chair Press Conference transcript documents.
+
+    Mirrors :class:`FOMCMinutesFetcher` 1:1 with two differences:
+
+    - :attr:`doc_type` is :data:`DocType.FOMC_PRESS_CONFERENCES`.
+    - The resolved ``title_id`` therefore comes from the
+      ``"fomc_press_conferences"`` slot of ``KNOWN_TITLE_IDS`` /
+      ``fraser_titles.json``.
+
+    Examples
+    --------
+    >>> from market.fraser import FOMCPressConferencesFetcher
+    >>> fetcher = FOMCPressConferencesFetcher()  # doctest: +SKIP
+    >>> pcs = fetcher.list_press_conferences(year_range=(2024, 2024))  # doctest: +SKIP
+    >>> for pc in pcs:  # doctest: +SKIP
+    ...     print(pc.date, pc.item_id)
+    """
+
+    @property
+    def doc_type(self) -> DocType:
+        """Return :data:`DocType.FOMC_PRESS_CONFERENCES`."""
+        return DocType.FOMC_PRESS_CONFERENCES
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def list_press_conferences(
+        self,
+        year_range: tuple[int, int],
+        *,
+        limit: int = 100,
+    ) -> list[FOMCMeeting]:
+        """List FOMC Press Conferences whose ``date.year`` is within ``year_range``.
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+        limit : int
+            Maximum number of items returned by the underlying
+            ``GET /items`` call (default: ``100``).
+
+        Returns
+        -------
+        list[FOMCMeeting]
+            FOMC Press Conference transcripts covering the requested
+            calendar window.
+        """
+        items = self._client.list_items(self.title_id, limit=limit)
+        filtered = self._filter_by_year_range(items, year_range)
+        return [self._to_fomc_meeting(item) for item in filtered]
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "txt",
+    ) -> tuple[Path, FOMCMeeting]:
+        """Fetch and download a single FOMC Press Conference item.
+
+        See :meth:`BaseFraserFetcher.fetch_text` for the underlying
+        pipeline. The return type narrows the second element to
+        :class:`FOMCMeeting` for ergonomic call-site typing.
+        """
+        path, item = super().fetch_text(item_id, prefer=prefer)
+        meeting = self._to_fomc_meeting(item)
+        return path, meeting
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _to_fomc_meeting(self, item: FraserItem) -> FOMCMeeting:
+        """Convert a generic :class:`FraserItem` to :class:`FOMCMeeting`.
+
+        See :meth:`FOMCMinutesFetcher._to_fomc_meeting` for details.
+        Duplicated here intentionally (project-108 task-5 scope) — the
+        future refactor will lift this onto :class:`BaseFraserFetcher`.
+        """
+        if isinstance(item, FOMCMeeting):
+            return item
+        payload = item.model_dump(by_alias=False)
+        return FOMCMeeting.model_validate(payload)
+
+
+__all__ = [
+    "FOMCMinutesFetcher",
+    "FOMCPressConferencesFetcher",
+    "FOMCStatementsFetcher",
+]

--- a/src/market/fraser/fetchers/fomc.py
+++ b/src/market/fraser/fetchers/fomc.py
@@ -1,0 +1,114 @@
+"""FOMC document fetchers built on :class:`BaseFraserFetcher`.
+
+This module currently exposes :class:`FOMCMinutesFetcher` — the only
+FOMC fetcher introduced by PR3. :class:`FOMCStatementsFetcher` and
+:class:`FOMCPressConferencesFetcher` will be added in PR4 once their
+``title_id`` values are discovered.
+
+See Also
+--------
+market.fraser.fetchers.base : Shared abstract base class.
+market.fraser.models : :class:`FOMCMeeting` Pydantic V2 model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.models import FOMCMeeting
+from market.fraser.types import DocType
+from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from market.fraser.models import FraserItem
+
+logger = get_logger(__name__)
+
+
+class FOMCMinutesFetcher(BaseFraserFetcher):
+    """Fetcher for FOMC Minutes documents.
+
+    Examples
+    --------
+    >>> from market.fraser import FOMCMinutesFetcher
+    >>> fetcher = FOMCMinutesFetcher()  # doctest: +SKIP
+    >>> meetings = fetcher.list_minutes(year_range=(2024, 2024))  # doctest: +SKIP
+    >>> for meeting in meetings:  # doctest: +SKIP
+    ...     print(meeting.date, meeting.item_id)
+    """
+
+    @property
+    def doc_type(self) -> DocType:
+        """Return :data:`DocType.FOMC_MINUTES`."""
+        return DocType.FOMC_MINUTES
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def list_minutes(
+        self,
+        year_range: tuple[int, int],
+        *,
+        limit: int = 100,
+    ) -> list[FOMCMeeting]:
+        """List FOMC Minutes whose ``date.year`` is within ``year_range``.
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+        limit : int
+            Maximum number of items returned by the underlying
+            ``GET /items`` call (default: ``100``).
+
+        Returns
+        -------
+        list[FOMCMeeting]
+            FOMC Minutes covering the requested calendar window.
+        """
+        items = self._client.list_items(self.title_id, limit=limit)
+        filtered = self._filter_by_year_range(items, year_range)
+        return [self._to_fomc_meeting(item) for item in filtered]
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "txt",
+    ) -> tuple[Path, FOMCMeeting]:
+        """Fetch and download a single FOMC Minutes item.
+
+        See :meth:`BaseFraserFetcher.fetch_text` for the underlying
+        pipeline. The return type narrows the second element to
+        :class:`FOMCMeeting` for ergonomic call-site typing.
+        """
+        path, item = super().fetch_text(item_id, prefer=prefer)
+        meeting = self._to_fomc_meeting(item)
+        return path, meeting
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _to_fomc_meeting(self, item: FraserItem) -> FOMCMeeting:
+        """Convert a generic :class:`FraserItem` to :class:`FOMCMeeting`.
+
+        Uses ``model_dump`` + ``model_validate`` so that the inherited
+        fields (``item_id``, ``date``, ``location`` etc.) round-trip
+        through Pydantic's validation pipeline. This preserves any
+        ``meeting_date`` / ``meeting_type`` fields that the FRASER
+        response may carry.
+        """
+        if isinstance(item, FOMCMeeting):
+            return item
+        # ``by_alias=False`` keeps the snake_case keys ``FOMCMeeting``
+        # expects on input; ``model_validate`` handles the rest.
+        payload = item.model_dump(by_alias=False)
+        return FOMCMeeting.model_validate(payload)
+
+
+__all__ = ["FOMCMinutesFetcher"]

--- a/src/market/fraser/fetchers/fomc.py
+++ b/src/market/fraser/fetchers/fomc.py
@@ -73,9 +73,7 @@ class FOMCMinutesFetcher(BaseFraserFetcher):
         list[FOMCMeeting]
             FOMC Minutes covering the requested calendar window.
         """
-        items = self._client.list_items(self.title_id, limit=limit)
-        filtered = self._filter_by_year_range(items, year_range)
-        return [self._convert_to(item, FOMCMeeting) for item in filtered]
+        return self._fetch_filtered(year_range, FOMCMeeting, limit=limit)
 
     def fetch_text(
         self,
@@ -144,9 +142,7 @@ class FOMCStatementsFetcher(BaseFraserFetcher):
         list[FOMCMeeting]
             FOMC Statements covering the requested calendar window.
         """
-        items = self._client.list_items(self.title_id, limit=limit)
-        filtered = self._filter_by_year_range(items, year_range)
-        return [self._convert_to(item, FOMCMeeting) for item in filtered]
+        return self._fetch_filtered(year_range, FOMCMeeting, limit=limit)
 
     def fetch_text(
         self,
@@ -216,9 +212,7 @@ class FOMCPressConferencesFetcher(BaseFraserFetcher):
             FOMC Press Conference transcripts covering the requested
             calendar window.
         """
-        items = self._client.list_items(self.title_id, limit=limit)
-        filtered = self._filter_by_year_range(items, year_range)
-        return [self._convert_to(item, FOMCMeeting) for item in filtered]
+        return self._fetch_filtered(year_range, FOMCMeeting, limit=limit)
 
     def fetch_text(
         self,

--- a/src/market/fraser/fetchers/fomc.py
+++ b/src/market/fraser/fetchers/fomc.py
@@ -9,10 +9,10 @@ This module exposes three FOMC fetchers, each a thin specialisation of
 - :class:`FOMCPressConferencesFetcher` — FOMC chair press conference
   transcripts (PR4 前半).
 
-All three share the ``_to_fomc_meeting`` conversion helper and expose
-the same public surface (``list_*`` + ``fetch_text``). Lifting the
-helper onto :class:`BaseFraserFetcher` is deliberately deferred to a
-future refactor (out of scope for PR4 前半 per project-108 plan).
+All three reuse :meth:`BaseFraserFetcher._convert_to` for the
+``FraserItem`` → :class:`FOMCMeeting` projection, so the previous
+three-way duplication of ``_to_fomc_meeting`` is gone
+(see PR review HIGH-2).
 
 See Also
 --------
@@ -22,7 +22,7 @@ market.fraser.models : :class:`FOMCMeeting` Pydantic V2 model.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from market.fraser.fetchers.base import BaseFraserFetcher
 from market.fraser.models import FOMCMeeting
@@ -31,8 +31,6 @@ from utils_core.logging import get_logger
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from market.fraser.models import FraserItem
 
 logger = get_logger(__name__)
 
@@ -53,10 +51,6 @@ class FOMCMinutesFetcher(BaseFraserFetcher):
     def doc_type(self) -> DocType:
         """Return :data:`DocType.FOMC_MINUTES`."""
         return DocType.FOMC_MINUTES
-
-    # =========================================================================
-    # Public API
-    # =========================================================================
 
     def list_minutes(
         self,
@@ -81,43 +75,28 @@ class FOMCMinutesFetcher(BaseFraserFetcher):
         """
         items = self._client.list_items(self.title_id, limit=limit)
         filtered = self._filter_by_year_range(items, year_range)
-        return [self._to_fomc_meeting(item) for item in filtered]
+        return [self._convert_to(item, FOMCMeeting) for item in filtered]
 
     def fetch_text(
         self,
         item_id: int,
         *,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
     ) -> tuple[Path, FOMCMeeting]:
         """Fetch and download a single FOMC Minutes item.
 
         See :meth:`BaseFraserFetcher.fetch_text` for the underlying
         pipeline. The return type narrows the second element to
         :class:`FOMCMeeting` for ergonomic call-site typing.
+
+        Returns
+        -------
+        tuple[Path, FOMCMeeting]
+            ``(asset_path, meeting)``.
         """
         path, item = super().fetch_text(item_id, prefer=prefer)
-        meeting = self._to_fomc_meeting(item)
+        meeting = self._convert_to(item, FOMCMeeting)
         return path, meeting
-
-    # =========================================================================
-    # Internal helpers
-    # =========================================================================
-
-    def _to_fomc_meeting(self, item: FraserItem) -> FOMCMeeting:
-        """Convert a generic :class:`FraserItem` to :class:`FOMCMeeting`.
-
-        Uses ``model_dump`` + ``model_validate`` so that the inherited
-        fields (``item_id``, ``date``, ``location`` etc.) round-trip
-        through Pydantic's validation pipeline. This preserves any
-        ``meeting_date`` / ``meeting_type`` fields that the FRASER
-        response may carry.
-        """
-        if isinstance(item, FOMCMeeting):
-            return item
-        # ``by_alias=False`` keeps the snake_case keys ``FOMCMeeting``
-        # expects on input; ``model_validate`` handles the rest.
-        payload = item.model_dump(by_alias=False)
-        return FOMCMeeting.model_validate(payload)
 
 
 class FOMCStatementsFetcher(BaseFraserFetcher):
@@ -144,10 +123,6 @@ class FOMCStatementsFetcher(BaseFraserFetcher):
         """Return :data:`DocType.FOMC_STATEMENTS`."""
         return DocType.FOMC_STATEMENTS
 
-    # =========================================================================
-    # Public API
-    # =========================================================================
-
     def list_statements(
         self,
         year_range: tuple[int, int],
@@ -171,39 +146,28 @@ class FOMCStatementsFetcher(BaseFraserFetcher):
         """
         items = self._client.list_items(self.title_id, limit=limit)
         filtered = self._filter_by_year_range(items, year_range)
-        return [self._to_fomc_meeting(item) for item in filtered]
+        return [self._convert_to(item, FOMCMeeting) for item in filtered]
 
     def fetch_text(
         self,
         item_id: int,
         *,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
     ) -> tuple[Path, FOMCMeeting]:
         """Fetch and download a single FOMC Statement item.
 
         See :meth:`BaseFraserFetcher.fetch_text` for the underlying
         pipeline. The return type narrows the second element to
         :class:`FOMCMeeting` for ergonomic call-site typing.
+
+        Returns
+        -------
+        tuple[Path, FOMCMeeting]
+            ``(asset_path, statement)``.
         """
         path, item = super().fetch_text(item_id, prefer=prefer)
-        meeting = self._to_fomc_meeting(item)
+        meeting = self._convert_to(item, FOMCMeeting)
         return path, meeting
-
-    # =========================================================================
-    # Internal helpers
-    # =========================================================================
-
-    def _to_fomc_meeting(self, item: FraserItem) -> FOMCMeeting:
-        """Convert a generic :class:`FraserItem` to :class:`FOMCMeeting`.
-
-        See :meth:`FOMCMinutesFetcher._to_fomc_meeting` for details.
-        Duplicated here intentionally (project-108 task-5 scope) — the
-        future refactor will lift this onto :class:`BaseFraserFetcher`.
-        """
-        if isinstance(item, FOMCMeeting):
-            return item
-        payload = item.model_dump(by_alias=False)
-        return FOMCMeeting.model_validate(payload)
 
 
 class FOMCPressConferencesFetcher(BaseFraserFetcher):
@@ -230,10 +194,6 @@ class FOMCPressConferencesFetcher(BaseFraserFetcher):
         """Return :data:`DocType.FOMC_PRESS_CONFERENCES`."""
         return DocType.FOMC_PRESS_CONFERENCES
 
-    # =========================================================================
-    # Public API
-    # =========================================================================
-
     def list_press_conferences(
         self,
         year_range: tuple[int, int],
@@ -258,39 +218,28 @@ class FOMCPressConferencesFetcher(BaseFraserFetcher):
         """
         items = self._client.list_items(self.title_id, limit=limit)
         filtered = self._filter_by_year_range(items, year_range)
-        return [self._to_fomc_meeting(item) for item in filtered]
+        return [self._convert_to(item, FOMCMeeting) for item in filtered]
 
     def fetch_text(
         self,
         item_id: int,
         *,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
     ) -> tuple[Path, FOMCMeeting]:
         """Fetch and download a single FOMC Press Conference item.
 
         See :meth:`BaseFraserFetcher.fetch_text` for the underlying
         pipeline. The return type narrows the second element to
         :class:`FOMCMeeting` for ergonomic call-site typing.
+
+        Returns
+        -------
+        tuple[Path, FOMCMeeting]
+            ``(asset_path, press_conference)``.
         """
         path, item = super().fetch_text(item_id, prefer=prefer)
-        meeting = self._to_fomc_meeting(item)
+        meeting = self._convert_to(item, FOMCMeeting)
         return path, meeting
-
-    # =========================================================================
-    # Internal helpers
-    # =========================================================================
-
-    def _to_fomc_meeting(self, item: FraserItem) -> FOMCMeeting:
-        """Convert a generic :class:`FraserItem` to :class:`FOMCMeeting`.
-
-        See :meth:`FOMCMinutesFetcher._to_fomc_meeting` for details.
-        Duplicated here intentionally (project-108 task-5 scope) — the
-        future refactor will lift this onto :class:`BaseFraserFetcher`.
-        """
-        if isinstance(item, FOMCMeeting):
-            return item
-        payload = item.model_dump(by_alias=False)
-        return FOMCMeeting.model_validate(payload)
 
 
 __all__ = [

--- a/src/market/fraser/fetchers/monetary_policy.py
+++ b/src/market/fraser/fetchers/monetary_policy.py
@@ -68,9 +68,7 @@ class MonetaryPolicyReportFetcher(BaseFraserFetcher):
             Monetary Policy Reports covering the requested calendar
             window.
         """
-        items = self._client.list_items(self.title_id, limit=limit)
-        filtered = self._filter_by_year_range(items, year_range)
-        return [self._convert_to(item, MonetaryPolicyReport) for item in filtered]
+        return self._fetch_filtered(year_range, MonetaryPolicyReport, limit=limit)
 
     def fetch_text(
         self,

--- a/src/market/fraser/fetchers/monetary_policy.py
+++ b/src/market/fraser/fetchers/monetary_policy.py
@@ -15,7 +15,7 @@ market.fraser.fetchers.fomc : Reference fetcher pattern.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from market.fraser.fetchers.base import BaseFraserFetcher
 from market.fraser.models import MonetaryPolicyReport
@@ -24,8 +24,6 @@ from utils_core.logging import get_logger
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from market.fraser.models import FraserItem
 
 logger = get_logger(__name__)
 
@@ -45,10 +43,6 @@ class MonetaryPolicyReportFetcher(BaseFraserFetcher):
     def doc_type(self) -> DocType:
         """Return :data:`DocType.MONETARY_POLICY_REPORT`."""
         return DocType.MONETARY_POLICY_REPORT
-
-    # =========================================================================
-    # Public API
-    # =========================================================================
 
     def list_reports(
         self,
@@ -76,13 +70,13 @@ class MonetaryPolicyReportFetcher(BaseFraserFetcher):
         """
         items = self._client.list_items(self.title_id, limit=limit)
         filtered = self._filter_by_year_range(items, year_range)
-        return [self._to_mpr(item) for item in filtered]
+        return [self._convert_to(item, MonetaryPolicyReport) for item in filtered]
 
     def fetch_text(
         self,
         item_id: int,
         *,
-        prefer: str = "pdf",
+        prefer: Literal["txt", "pdf"] = "pdf",
     ) -> tuple[Path, MonetaryPolicyReport]:
         """Fetch and download a single Monetary Policy Report.
 
@@ -94,26 +88,15 @@ class MonetaryPolicyReportFetcher(BaseFraserFetcher):
         See :meth:`BaseFraserFetcher.fetch_text` for the underlying
         pipeline. The return type narrows the second element to
         :class:`MonetaryPolicyReport`.
+
+        Returns
+        -------
+        tuple[Path, MonetaryPolicyReport]
+            ``(asset_path, report)``.
         """
         path, item = super().fetch_text(item_id, prefer=prefer)
-        report = self._to_mpr(item)
+        report = self._convert_to(item, MonetaryPolicyReport)
         return path, report
-
-    # =========================================================================
-    # Internal helpers
-    # =========================================================================
-
-    def _to_mpr(self, item: FraserItem) -> MonetaryPolicyReport:
-        """Convert a generic :class:`FraserItem` to :class:`MonetaryPolicyReport`.
-
-        Mirrors the ``FOMCMeeting`` conversion in
-        :mod:`market.fraser.fetchers.fomc` (the future refactor will
-        lift these helpers onto :class:`BaseFraserFetcher`).
-        """
-        if isinstance(item, MonetaryPolicyReport):
-            return item
-        payload = item.model_dump(by_alias=False)
-        return MonetaryPolicyReport.model_validate(payload)
 
 
 __all__ = ["MonetaryPolicyReportFetcher"]

--- a/src/market/fraser/fetchers/monetary_policy.py
+++ b/src/market/fraser/fetchers/monetary_policy.py
@@ -1,0 +1,119 @@
+"""Monetary Policy Report fetcher.
+
+This module exposes :class:`MonetaryPolicyReportFetcher`, a thin
+specialisation of :class:`BaseFraserFetcher` for FRASER Monetary Policy
+Reports to the Congress. The fetcher defaults to ``prefer='pdf'``
+because the historical archive (including the Humphrey-Hawkins reports
+from 1979-2000) is overwhelmingly PDF-only — preferring TXT would force
+a PDF fallback for the majority of items.
+
+See Also
+--------
+market.fraser.fetchers.base : Shared abstract base class.
+market.fraser.fetchers.fomc : Reference fetcher pattern.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.models import MonetaryPolicyReport
+from market.fraser.types import DocType
+from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from market.fraser.models import FraserItem
+
+logger = get_logger(__name__)
+
+
+class MonetaryPolicyReportFetcher(BaseFraserFetcher):
+    """Fetcher for Monetary Policy Report documents.
+
+    Examples
+    --------
+    >>> from market.fraser import MonetaryPolicyReportFetcher
+    >>> fetcher = MonetaryPolicyReportFetcher()  # doctest: +SKIP
+    >>> reports = fetcher.list_reports(year_range=(2020, 2024))  # doctest: +SKIP
+    >>> path, report = fetcher.fetch_text(reports[0].item_id)  # doctest: +SKIP
+    """
+
+    @property
+    def doc_type(self) -> DocType:
+        """Return :data:`DocType.MONETARY_POLICY_REPORT`."""
+        return DocType.MONETARY_POLICY_REPORT
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def list_reports(
+        self,
+        year_range: tuple[int, int],
+        *,
+        limit: int = 100,
+    ) -> list[MonetaryPolicyReport]:
+        """List Monetary Policy Reports in ``year_range``.
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window. Accepts
+            historical lower bounds (e.g., ``1979`` for the original
+            Humphrey-Hawkins reports).
+        limit : int
+            Maximum number of items returned by the underlying
+            ``GET /items`` call (default: ``100``).
+
+        Returns
+        -------
+        list[MonetaryPolicyReport]
+            Monetary Policy Reports covering the requested calendar
+            window.
+        """
+        items = self._client.list_items(self.title_id, limit=limit)
+        filtered = self._filter_by_year_range(items, year_range)
+        return [self._to_mpr(item) for item in filtered]
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "pdf",
+    ) -> tuple[Path, MonetaryPolicyReport]:
+        """Fetch and download a single Monetary Policy Report.
+
+        Defaults to ``prefer='pdf'`` because the historical archive
+        (1979-2000 Humphrey-Hawkins reports in particular) is almost
+        exclusively PDF-only. Override with ``prefer='txt'`` to force
+        the text-first selection path.
+
+        See :meth:`BaseFraserFetcher.fetch_text` for the underlying
+        pipeline. The return type narrows the second element to
+        :class:`MonetaryPolicyReport`.
+        """
+        path, item = super().fetch_text(item_id, prefer=prefer)
+        report = self._to_mpr(item)
+        return path, report
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _to_mpr(self, item: FraserItem) -> MonetaryPolicyReport:
+        """Convert a generic :class:`FraserItem` to :class:`MonetaryPolicyReport`.
+
+        Mirrors the ``FOMCMeeting`` conversion in
+        :mod:`market.fraser.fetchers.fomc` (the future refactor will
+        lift these helpers onto :class:`BaseFraserFetcher`).
+        """
+        if isinstance(item, MonetaryPolicyReport):
+            return item
+        payload = item.model_dump(by_alias=False)
+        return MonetaryPolicyReport.model_validate(payload)
+
+
+__all__ = ["MonetaryPolicyReportFetcher"]

--- a/src/market/fraser/fetchers/speeches.py
+++ b/src/market/fraser/fetchers/speeches.py
@@ -18,7 +18,7 @@ market.fraser.fetchers.fomc : Reference fetcher pattern.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from market.fraser.fetchers.base import BaseFraserFetcher
 from market.fraser.models import FRBSpeech
@@ -27,8 +27,6 @@ from utils_core.logging import get_logger
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from market.fraser.models import FraserItem
 
 logger = get_logger(__name__)
 
@@ -87,7 +85,7 @@ class FRBSpeechFetcher(BaseFraserFetcher):
         """
         items = self._client.list_items(self.title_id, limit=limit)
         year_filtered = self._filter_by_year_range(items, year_range)
-        speeches = [self._to_frb_speech(item) for item in year_filtered]
+        speeches = [self._convert_to(item, FRBSpeech) for item in year_filtered]
 
         if speaker is None:
             return speeches
@@ -97,16 +95,21 @@ class FRBSpeechFetcher(BaseFraserFetcher):
         self,
         item_id: int,
         *,
-        prefer: str = "txt",
+        prefer: Literal["txt", "pdf"] = "txt",
     ) -> tuple[Path, FRBSpeech]:
         """Fetch and download a single FRB speech.
 
         See :meth:`BaseFraserFetcher.fetch_text` for the underlying
         pipeline. The return type narrows the second element to
         :class:`FRBSpeech`.
+
+        Returns
+        -------
+        tuple[Path, FRBSpeech]
+            ``(asset_path, speech)``.
         """
         path, item = super().fetch_text(item_id, prefer=prefer)
-        speech = self._to_frb_speech(item)
+        speech = self._convert_to(item, FRBSpeech)
         return path, speech
 
     # =========================================================================
@@ -152,18 +155,6 @@ class FRBSpeechFetcher(BaseFraserFetcher):
             if speech.description and needle in speech.description.lower():
                 result.append(speech)
         return result
-
-    def _to_frb_speech(self, item: FraserItem) -> FRBSpeech:
-        """Convert a generic :class:`FraserItem` to :class:`FRBSpeech`.
-
-        Mirrors the ``FOMCMeeting`` conversion in
-        :mod:`market.fraser.fetchers.fomc` (the future refactor will
-        lift these helpers onto :class:`BaseFraserFetcher`).
-        """
-        if isinstance(item, FRBSpeech):
-            return item
-        payload = item.model_dump(by_alias=False)
-        return FRBSpeech.model_validate(payload)
 
 
 __all__ = ["FRBSpeechFetcher"]

--- a/src/market/fraser/fetchers/speeches.py
+++ b/src/market/fraser/fetchers/speeches.py
@@ -1,0 +1,169 @@
+"""FRB speech fetcher with optional speaker filtering.
+
+This module exposes :class:`FRBSpeechFetcher`, a thin specialisation of
+:class:`BaseFraserFetcher` for FRASER Federal Reserve Board speeches.
+The fetcher mirrors the FOMC pattern but adds case-insensitive
+``speaker`` filtering on :meth:`list_speeches`, allowing callers to
+restrict results to a single speaker (e.g., ``"Powell"``, ``"Volcker"``).
+
+The historical archive on FRASER goes back to the 1960s for major
+speakers, so the ``year_range`` parameter accepts any non-negative
+integer pair; no implicit lower bound is enforced.
+
+See Also
+--------
+market.fraser.fetchers.base : Shared abstract base class.
+market.fraser.fetchers.fomc : Reference fetcher pattern.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.models import FRBSpeech
+from market.fraser.types import DocType
+from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from market.fraser.models import FraserItem
+
+logger = get_logger(__name__)
+
+
+class FRBSpeechFetcher(BaseFraserFetcher):
+    """Fetcher for Federal Reserve Board speech documents.
+
+    Examples
+    --------
+    >>> from market.fraser import FRBSpeechFetcher
+    >>> fetcher = FRBSpeechFetcher()  # doctest: +SKIP
+    >>> powell = fetcher.list_speeches(  # doctest: +SKIP
+    ...     year_range=(2024, 2024), speaker="Powell"
+    ... )
+    """
+
+    @property
+    def doc_type(self) -> DocType:
+        """Return :data:`DocType.FRB_SPEECHES`."""
+        return DocType.FRB_SPEECHES
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def list_speeches(
+        self,
+        year_range: tuple[int, int],
+        *,
+        speaker: str | None = None,
+        limit: int = 100,
+    ) -> list[FRBSpeech]:
+        """List FRB speeches whose ``date.year`` is in ``year_range``.
+
+        When ``speaker`` is provided, the result is further filtered to
+        items whose ``authors[*].name`` (case-insensitive) contains the
+        supplied substring. Items without authors are silently dropped
+        from the speaker-filtered subset (no author info → cannot match).
+
+        Parameters
+        ----------
+        year_range : tuple[int, int]
+            Inclusive ``(start_year, end_year)`` window.
+        speaker : str | None
+            Optional speaker substring. Case-insensitive
+            (``"Powell"`` == ``"powell"`` == ``"POWELL"``). When
+            ``None``, no speaker filter is applied.
+        limit : int
+            Maximum number of items returned by the underlying
+            ``GET /items`` call (default: ``100``).
+
+        Returns
+        -------
+        list[FRBSpeech]
+            Filtered speeches.
+        """
+        items = self._client.list_items(self.title_id, limit=limit)
+        year_filtered = self._filter_by_year_range(items, year_range)
+        speeches = [self._to_frb_speech(item) for item in year_filtered]
+
+        if speaker is None:
+            return speeches
+        return self._filter_by_speaker(speeches, speaker)
+
+    def fetch_text(
+        self,
+        item_id: int,
+        *,
+        prefer: str = "txt",
+    ) -> tuple[Path, FRBSpeech]:
+        """Fetch and download a single FRB speech.
+
+        See :meth:`BaseFraserFetcher.fetch_text` for the underlying
+        pipeline. The return type narrows the second element to
+        :class:`FRBSpeech`.
+        """
+        path, item = super().fetch_text(item_id, prefer=prefer)
+        speech = self._to_frb_speech(item)
+        return path, speech
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _filter_by_speaker(
+        self,
+        speeches: list[FRBSpeech],
+        speaker: str,
+    ) -> list[FRBSpeech]:
+        """Filter ``speeches`` by case-insensitive speaker substring.
+
+        Matching is performed against three fields, in order of
+        preference: ``speech.speaker``, ``speech.authors[*].name``, and
+        ``speech.description``. A speech matches when any of those
+        fields (after ``str.lower()``) contains the lowered ``speaker``
+        substring.
+
+        Parameters
+        ----------
+        speeches : list[FRBSpeech]
+            Source speeches.
+        speaker : str
+            Speaker substring (case-insensitive).
+
+        Returns
+        -------
+        list[FRBSpeech]
+            Speeches whose speaker / author metadata mentions
+            ``speaker``.
+        """
+        needle = speaker.lower()
+        result: list[FRBSpeech] = []
+        for speech in speeches:
+            if speech.speaker and needle in speech.speaker.lower():
+                result.append(speech)
+                continue
+            authors = speech.authors or []
+            if any(a.name and needle in a.name.lower() for a in authors):
+                result.append(speech)
+                continue
+            if speech.description and needle in speech.description.lower():
+                result.append(speech)
+        return result
+
+    def _to_frb_speech(self, item: FraserItem) -> FRBSpeech:
+        """Convert a generic :class:`FraserItem` to :class:`FRBSpeech`.
+
+        Mirrors the ``FOMCMeeting`` conversion in
+        :mod:`market.fraser.fetchers.fomc` (the future refactor will
+        lift these helpers onto :class:`BaseFraserFetcher`).
+        """
+        if isinstance(item, FRBSpeech):
+            return item
+        payload = item.model_dump(by_alias=False)
+        return FRBSpeech.model_validate(payload)
+
+
+__all__ = ["FRBSpeechFetcher"]

--- a/src/market/fraser/fetchers/speeches.py
+++ b/src/market/fraser/fetchers/speeches.py
@@ -83,9 +83,7 @@ class FRBSpeechFetcher(BaseFraserFetcher):
         list[FRBSpeech]
             Filtered speeches.
         """
-        items = self._client.list_items(self.title_id, limit=limit)
-        year_filtered = self._filter_by_year_range(items, year_range)
-        speeches = [self._convert_to(item, FRBSpeech) for item in year_filtered]
+        speeches = self._fetch_filtered(year_range, FRBSpeech, limit=limit)
 
         if speaker is None:
             return speeches

--- a/src/market/fraser/models.py
+++ b/src/market/fraser/models.py
@@ -1,0 +1,478 @@
+"""Pydantic V2 response models for the FRASER REST API module.
+
+This module provides Pydantic models for validating and serialising
+FRASER REST API responses. All models use
+``ConfigDict(extra='ignore', populate_by_name=True)`` so that:
+
+- Forward compatibility is preserved when FRASER adds new fields.
+- Both API camelCase names (``itemId``, ``pdfUrl``) and Python
+  snake_case names (``item_id``, ``pdf_url``) can be used to
+  instantiate models.
+
+Required fields are intentionally minimal (``item_id``, ``title``,
+``date`` on ``FraserItem``); every other field is optional with a
+default of ``None`` so that the parser can ingest partial responses
+without crashing.
+
+Models
+------
+- FraserTitle: FRASER title (top-level collection) descriptor.
+- FraserItem: Generic FRASER item (base for domain models).
+- FraserLocation: Asset location descriptor (pdf_url / text_url).
+- FraserTocEntry: Table-of-contents entry.
+- FraserAuthor: Author / contributor descriptor.
+- FraserSubject: Subject tag.
+- FraserTheme: Theme tag.
+- FraserTimelineEvent: Timeline event entry.
+- FOMCMeeting: FOMC meeting document (minutes/statement/press conf).
+- BeigeBookReport: Beige Book report.
+- FRBSpeech: Federal Reserve Board speech.
+- MonetaryPolicyReport: Monetary Policy Report to the Congress.
+
+See Also
+--------
+market.polymarket.models : Reference implementation for
+    ``ConfigDict(extra='ignore', populate_by_name=True)`` +
+    ``Field(alias='camelCase')`` patterns.
+"""
+
+from datetime import date as date_cls
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from utils_core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Common Pydantic model config for FRASER models.
+# - ``extra='ignore'`` keeps the parser tolerant of new FRASER fields.
+# - ``populate_by_name=True`` allows both API camelCase aliases and
+#   snake_case field names to be used to instantiate models.
+_FRASER_MODEL_CONFIG: ConfigDict = ConfigDict(
+    extra="ignore",
+    populate_by_name=True,
+)
+
+
+# Accepted ``date`` input formats. Ordered from most specific to least
+# specific so that ambiguous strings (e.g., ``"2024"``) fall through to
+# the year-only parser.
+_DATE_FORMATS: tuple[str, ...] = (
+    "%Y-%m-%d",
+    "%Y-%m",
+    "%Y",
+)
+
+
+def _coerce_date(v: Any) -> Any:
+    """Coerce a date input into a ``datetime.date`` instance.
+
+    Accepts ``date`` / ``datetime`` objects, integer or string years,
+    and partial date strings (``"YYYY"``, ``"YYYY-MM"``, ``"YYYY-MM-DD"``).
+    Returns ``None`` unchanged.
+
+    Parameters
+    ----------
+    v : Any
+        Raw input from the Pydantic validator. The function intentionally
+        accepts ``Any`` because FRASER returns date fields in multiple
+        formats.
+
+    Returns
+    -------
+    Any
+        A ``datetime.date`` when the input can be parsed; the original
+        input otherwise (Pydantic will raise its standard validation
+        error for unparseable values).
+
+    Notes
+    -----
+    Partial date strings (``"YYYY"``, ``"YYYY-MM"``) are normalised to
+    the first day of the relevant period (``Jan 1`` / day ``1``).
+    """
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v.date()
+    if isinstance(v, date_cls):
+        return v
+    if isinstance(v, int):
+        # Year-only integer (e.g., 2024 -> 2024-01-01).
+        try:
+            return date_cls(v, 1, 1)
+        except (ValueError, OverflowError):
+            return v
+    if not isinstance(v, str):
+        return v
+    text = v.strip()
+    if not text:
+        return None
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return v
+
+
+# =============================================================================
+# Auxiliary models
+# =============================================================================
+
+
+class FraserLocation(BaseModel):
+    """Asset location descriptor for a FRASER item.
+
+    The FRASER API returns lists of URLs (one per page or rendition).
+    Both PDF and text URLs are optional; an item may expose neither,
+    one, or both.
+
+    Parameters
+    ----------
+    pdf_url : list[str] | None
+        URLs to PDF renditions, when available. Mapped from
+        ``pdfUrl`` in the API JSON.
+    text_url : list[str] | None
+        URLs to plain-text renditions, when available. Mapped from
+        ``textUrl`` in the API JSON.
+
+    Examples
+    --------
+    >>> loc = FraserLocation.model_validate({"pdfUrl": ["https://x/a.pdf"]})
+    >>> loc.pdf_url
+    ['https://x/a.pdf']
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    pdf_url: list[str] | None = Field(default=None, alias="pdfUrl")
+    text_url: list[str] | None = Field(default=None, alias="textUrl")
+
+
+class FraserTocEntry(BaseModel):
+    """Table-of-contents entry for a FRASER item.
+
+    Parameters
+    ----------
+    label : str | None
+        Display label.
+    page : int | None
+        Page number within the item, when applicable.
+    anchor : str | None
+        Internal anchor identifier, when applicable.
+
+    Examples
+    --------
+    >>> entry = FraserTocEntry(label="Introduction", page=1)
+    >>> entry.label
+    'Introduction'
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    label: str | None = Field(default=None)
+    page: int | None = Field(default=None)
+    anchor: str | None = Field(default=None)
+
+
+class FraserAuthor(BaseModel):
+    """Author / contributor descriptor for a FRASER item.
+
+    Parameters
+    ----------
+    name : str | None
+        Author display name.
+    role : str | None
+        Author role (e.g., ``"author"``, ``"editor"``).
+    author_id : int | None
+        FRASER internal author identifier. Mapped from ``authorId``.
+
+    Examples
+    --------
+    >>> author = FraserAuthor.model_validate({"name": "Jane", "authorId": 1})
+    >>> author.author_id
+    1
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    name: str | None = Field(default=None)
+    role: str | None = Field(default=None)
+    author_id: int | None = Field(default=None, alias="authorId")
+
+
+class FraserSubject(BaseModel):
+    """Subject tag attached to a FRASER item.
+
+    Parameters
+    ----------
+    name : str | None
+        Subject display name.
+    subject_id : int | None
+        FRASER internal subject identifier. Mapped from ``subjectId``.
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    name: str | None = Field(default=None)
+    subject_id: int | None = Field(default=None, alias="subjectId")
+
+
+class FraserTheme(BaseModel):
+    """Theme tag attached to a FRASER item.
+
+    Parameters
+    ----------
+    name : str | None
+        Theme display name.
+    theme_id : int | None
+        FRASER internal theme identifier. Mapped from ``themeId``.
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    name: str | None = Field(default=None)
+    theme_id: int | None = Field(default=None, alias="themeId")
+
+
+class FraserTimelineEvent(BaseModel):
+    """Timeline event entry for a FRASER title / item.
+
+    Parameters
+    ----------
+    label : str | None
+        Event display label.
+    event_date : date_cls | None
+        Event date (parsed from ``YYYY-MM-DD`` / ``YYYY-MM`` / ``YYYY``).
+        Mapped from ``eventDate`` in the API JSON.
+    description : str | None
+        Free-text description.
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    label: str | None = Field(default=None)
+    event_date: date_cls | None = Field(default=None, alias="eventDate")
+    description: str | None = Field(default=None)
+
+    @field_validator("event_date", mode="before")
+    @classmethod
+    def _parse_event_date(cls, v: Any) -> Any:
+        """Coerce ``event_date`` via ``_coerce_date``."""
+        return _coerce_date(v)
+
+
+# =============================================================================
+# Title model
+# =============================================================================
+
+
+class FraserTitle(BaseModel):
+    """FRASER title (top-level collection) descriptor.
+
+    A FRASER title typically aggregates many items (issues, reports,
+    transcripts). Required fields are minimal so that the parser can
+    handle partial responses; expand cautiously in future PRs.
+
+    Parameters
+    ----------
+    title_id : int
+        FRASER internal title identifier (required). Mapped from
+        ``titleId``.
+    name : str
+        Title display name (required).
+    description : str | None
+        Free-text description.
+    publisher : str | None
+        Publishing organisation.
+    item_count : int | None
+        Number of items belonging to this title. Mapped from
+        ``itemCount``.
+
+    Examples
+    --------
+    >>> title = FraserTitle.model_validate({"titleId": 677, "name": "FOMC"})
+    >>> title.title_id
+    677
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    title_id: int = Field(..., alias="titleId")
+    name: str = Field(...)
+    description: str | None = Field(default=None)
+    publisher: str | None = Field(default=None)
+    item_count: int | None = Field(default=None, alias="itemCount")
+
+
+# =============================================================================
+# Base item model
+# =============================================================================
+
+
+class FraserItem(BaseModel):
+    """Generic FRASER item (base for domain-specific models).
+
+    Required fields are intentionally minimal (``item_id``, ``title``,
+    ``date``) so that the parser remains tolerant of partial or
+    evolving FRASER schemas.
+
+    Parameters
+    ----------
+    item_id : int
+        FRASER internal item identifier (required). Mapped from
+        ``itemId``.
+    title : str
+        Item display title (required).
+    date : date
+        Primary publication / event date (required). Parsed from
+        ``YYYY-MM-DD`` / ``YYYY-MM`` / ``YYYY`` strings via
+        ``_coerce_date``.
+    title_id : int | None
+        Parent title identifier. Mapped from ``titleId``.
+    description : str | None
+        Item description / abstract.
+    location : FraserLocation | None
+        Asset location descriptor (PDF / TXT URLs).
+    toc : list[FraserTocEntry] | None
+        Table of contents entries.
+    authors : list[FraserAuthor] | None
+        Author / contributor list.
+    subjects : list[FraserSubject] | None
+        Subject tags.
+    themes : list[FraserTheme] | None
+        Theme tags.
+    timeline : list[FraserTimelineEvent] | None
+        Timeline events associated with this item.
+
+    Examples
+    --------
+    >>> item = FraserItem.model_validate({
+    ...     "itemId": 1, "title": "FOMC Minutes", "date": "2024-01-31"
+    ... })
+    >>> item.item_id
+    1
+    >>> item.date.year
+    2024
+    """
+
+    model_config = _FRASER_MODEL_CONFIG
+
+    item_id: int = Field(..., alias="itemId")
+    title: str = Field(...)
+    date: date_cls = Field(...)
+    title_id: int | None = Field(default=None, alias="titleId")
+    description: str | None = Field(default=None)
+    location: FraserLocation | None = Field(default=None)
+    toc: list[FraserTocEntry] | None = Field(default=None)
+    authors: list[FraserAuthor] | None = Field(default=None)
+    subjects: list[FraserSubject] | None = Field(default=None)
+    themes: list[FraserTheme] | None = Field(default=None)
+    timeline: list[FraserTimelineEvent] | None = Field(default=None)
+
+    @field_validator("date", mode="before")
+    @classmethod
+    def _parse_date(cls, v: Any) -> Any:
+        """Coerce ``date`` via ``_coerce_date``.
+
+        Accepts ``YYYY-MM-DD``, ``YYYY-MM``, ``YYYY`` strings as well
+        as ``date`` / ``datetime`` / ``int`` inputs.
+        """
+        return _coerce_date(v)
+
+
+# =============================================================================
+# Domain models
+# =============================================================================
+
+
+class FOMCMeeting(FraserItem):
+    """FOMC meeting document (minutes, statement, or press conference).
+
+    Inherits all fields from ``FraserItem``. The ``meeting_date`` and
+    ``meeting_type`` fields are optional metadata commonly attached
+    to FOMC documents in FRASER.
+
+    Parameters
+    ----------
+    meeting_date : date_cls | None
+        Date of the underlying FOMC meeting. Mapped from
+        ``meetingDate``.
+    meeting_type : str | None
+        Type tag (e.g., ``"regular"``, ``"intermeeting"``). Mapped
+        from ``meetingType``.
+    """
+
+    meeting_date: date_cls | None = Field(default=None, alias="meetingDate")
+    meeting_type: str | None = Field(default=None, alias="meetingType")
+
+    @field_validator("meeting_date", mode="before")
+    @classmethod
+    def _parse_meeting_date(cls, v: Any) -> Any:
+        """Coerce ``meeting_date`` via ``_coerce_date``."""
+        return _coerce_date(v)
+
+
+class BeigeBookReport(FraserItem):
+    """Beige Book report.
+
+    Inherits all fields from ``FraserItem``.
+
+    Parameters
+    ----------
+    district : str | None
+        Federal Reserve District covered by the report (or
+        ``"national"`` for the summary). Mapped from ``district``.
+    """
+
+    district: str | None = Field(default=None)
+
+
+class FRBSpeech(FraserItem):
+    """Federal Reserve Board speech.
+
+    Inherits all fields from ``FraserItem``.
+
+    Parameters
+    ----------
+    speaker : str | None
+        Speaker display name.
+    venue : str | None
+        Location / venue where the speech was delivered.
+    """
+
+    speaker: str | None = Field(default=None)
+    venue: str | None = Field(default=None)
+
+
+class MonetaryPolicyReport(FraserItem):
+    """Monetary Policy Report to the Congress.
+
+    Inherits all fields from ``FraserItem``.
+
+    Parameters
+    ----------
+    report_period : str | None
+        Reporting period label (e.g., ``"February 2024"``). Mapped
+        from ``reportPeriod``.
+    """
+
+    report_period: str | None = Field(default=None, alias="reportPeriod")
+
+
+__all__ = [
+    "BeigeBookReport",
+    "FOMCMeeting",
+    "FRBSpeech",
+    "FraserAuthor",
+    "FraserItem",
+    "FraserLocation",
+    "FraserSubject",
+    "FraserTheme",
+    "FraserTimelineEvent",
+    "FraserTitle",
+    "FraserTocEntry",
+    "MonetaryPolicyReport",
+]

--- a/src/market/fraser/models.py
+++ b/src/market/fraser/models.py
@@ -109,6 +109,26 @@ def _coerce_date(v: Any) -> Any:
     text = v.strip()
     if not text:
         return None
+    # Fast path: the FRASER API overwhelmingly returns 10-char ISO dates.
+    # Trying ``YYYY-MM-DD`` first avoids two exception round-trips per
+    # item in the common case (PR review LOW perf).
+    text_len = len(text)
+    if text_len == 10:
+        try:
+            return datetime.strptime(text, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+    elif text_len == 7:
+        try:
+            return datetime.strptime(text, "%Y-%m").date()
+        except ValueError:
+            pass
+    elif text_len == 4:
+        try:
+            return datetime.strptime(text, "%Y").date()
+        except ValueError:
+            pass
+    # Fallback: try every format (handles padded / unusual inputs).
     for fmt in _DATE_FORMATS:
         try:
             return datetime.strptime(text, fmt).date()

--- a/src/market/fraser/parser.py
+++ b/src/market/fraser/parser.py
@@ -278,7 +278,25 @@ def parse_items(data: dict[str, Any] | list[Any]) -> list[FraserItem]:
 
 
 def parse_toc(data: dict[str, Any] | list[Any]) -> list[FraserTocEntry]:
-    """Parse a table-of-contents payload into :class:`FraserTocEntry` list."""
+    """Parse a table-of-contents payload into :class:`FraserTocEntry` list.
+
+    Parameters
+    ----------
+    data : dict[str, Any] | list[Any]
+        Either a raw list of entry dicts or a payload of the form
+        ``{"toc": [...]}``.
+
+    Returns
+    -------
+    list[FraserTocEntry]
+        Validated table-of-contents entries.
+
+    Raises
+    ------
+    FraserParseError
+        If the payload shape does not resolve to a list of dicts, or if
+        any entry fails Pydantic validation.
+    """
     entries = (
         _require_list(data, container_key="toc")
         if isinstance(data, dict) and "toc" in data
@@ -288,7 +306,25 @@ def parse_toc(data: dict[str, Any] | list[Any]) -> list[FraserTocEntry]:
 
 
 def parse_authors(data: dict[str, Any] | list[Any]) -> list[FraserAuthor]:
-    """Parse an authors payload into :class:`FraserAuthor` list."""
+    """Parse an authors payload into :class:`FraserAuthor` list.
+
+    Parameters
+    ----------
+    data : dict[str, Any] | list[Any]
+        Either a raw list of author dicts or a payload of the form
+        ``{"authors": [...]}``.
+
+    Returns
+    -------
+    list[FraserAuthor]
+        Validated author records.
+
+    Raises
+    ------
+    FraserParseError
+        If the payload shape does not resolve to a list of dicts, or if
+        any entry fails Pydantic validation.
+    """
     entries = (
         _require_list(data, container_key="authors")
         if isinstance(data, dict) and "authors" in data
@@ -298,7 +334,25 @@ def parse_authors(data: dict[str, Any] | list[Any]) -> list[FraserAuthor]:
 
 
 def parse_subjects(data: dict[str, Any] | list[Any]) -> list[FraserSubject]:
-    """Parse a subjects payload into :class:`FraserSubject` list."""
+    """Parse a subjects payload into :class:`FraserSubject` list.
+
+    Parameters
+    ----------
+    data : dict[str, Any] | list[Any]
+        Either a raw list of subject dicts or a payload of the form
+        ``{"subjects": [...]}``.
+
+    Returns
+    -------
+    list[FraserSubject]
+        Validated subject records.
+
+    Raises
+    ------
+    FraserParseError
+        If the payload shape does not resolve to a list of dicts, or if
+        any entry fails Pydantic validation.
+    """
     entries = (
         _require_list(data, container_key="subjects")
         if isinstance(data, dict) and "subjects" in data
@@ -308,7 +362,25 @@ def parse_subjects(data: dict[str, Any] | list[Any]) -> list[FraserSubject]:
 
 
 def parse_themes(data: dict[str, Any] | list[Any]) -> list[FraserTheme]:
-    """Parse a themes payload into :class:`FraserTheme` list."""
+    """Parse a themes payload into :class:`FraserTheme` list.
+
+    Parameters
+    ----------
+    data : dict[str, Any] | list[Any]
+        Either a raw list of theme dicts or a payload of the form
+        ``{"themes": [...]}``.
+
+    Returns
+    -------
+    list[FraserTheme]
+        Validated theme records.
+
+    Raises
+    ------
+    FraserParseError
+        If the payload shape does not resolve to a list of dicts, or if
+        any entry fails Pydantic validation.
+    """
     entries = (
         _require_list(data, container_key="themes")
         if isinstance(data, dict) and "themes" in data
@@ -318,7 +390,25 @@ def parse_themes(data: dict[str, Any] | list[Any]) -> list[FraserTheme]:
 
 
 def parse_timeline(data: dict[str, Any] | list[Any]) -> list[FraserTimelineEvent]:
-    """Parse a timeline payload into :class:`FraserTimelineEvent` list."""
+    """Parse a timeline payload into :class:`FraserTimelineEvent` list.
+
+    Parameters
+    ----------
+    data : dict[str, Any] | list[Any]
+        Either a raw list of event dicts or a payload of the form
+        ``{"timeline": [...]}``.
+
+    Returns
+    -------
+    list[FraserTimelineEvent]
+        Validated timeline events.
+
+    Raises
+    ------
+    FraserParseError
+        If the payload shape does not resolve to a list of dicts, or if
+        any entry fails Pydantic validation.
+    """
     entries = (
         _require_list(data, container_key="timeline")
         if isinstance(data, dict) and "timeline" in data

--- a/src/market/fraser/parser.py
+++ b/src/market/fraser/parser.py
@@ -1,0 +1,341 @@
+"""Response parsing utilities for the FRASER REST API module.
+
+This module contains thin wrappers that convert raw FRASER JSON
+payloads into Pydantic V2 models. Each parser catches
+:class:`pydantic.ValidationError` and re-raises it as a
+:class:`market.fraser.errors.FraserParseError` so that the rest of the
+package can rely on a single, FRASER-specific exception hierarchy.
+
+The wrappers intentionally remain stateless and free of HTTP I/O — they
+operate solely on already-decoded JSON dictionaries provided by the
+session / client layer.
+
+See Also
+--------
+market.fraser.models : Pydantic V2 response models used as parse targets.
+market.fraser.errors : ``FraserParseError`` raised on validation failure.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from market.fraser.constants import MAX_RESPONSE_BODY_LOG
+from market.fraser.errors import FraserParseError
+from market.fraser.models import (
+    FraserAuthor,
+    FraserItem,
+    FraserSubject,
+    FraserTheme,
+    FraserTimelineEvent,
+    FraserTitle,
+    FraserTocEntry,
+)
+from utils_core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_T = TypeVar("_T", bound=BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_missing_field(exc: ValidationError) -> str:
+    """Extract the dotted-path name of the first invalid / missing field.
+
+    Pydantic's ``ValidationError.errors()`` returns a list of dicts where
+    each ``loc`` tuple identifies a problem location. This helper joins
+    the first ``loc`` into a single string for inclusion in
+    :class:`FraserParseError`.
+
+    Parameters
+    ----------
+    exc : ValidationError
+        The Pydantic validation error.
+
+    Returns
+    -------
+    str
+        Dotted-path field name (e.g., ``"items.0.item_id"``) or
+        ``"<unknown>"`` when no error details are available.
+    """
+    errors = exc.errors()
+    if not errors:
+        return "<unknown>"
+    loc = errors[0].get("loc", ())
+    if not loc:
+        return "<unknown>"
+    return ".".join(str(part) for part in loc)
+
+
+def _truncated_raw(data: Any) -> str:
+    """Serialise ``data`` to JSON, truncated to ``MAX_RESPONSE_BODY_LOG``.
+
+    Used as the ``raw_data`` payload of :class:`FraserParseError` so
+    that log files and error reports do not balloon with full FRASER
+    responses (CWE-209 / log-bloat mitigation).
+
+    Parameters
+    ----------
+    data : Any
+        Object to serialise.
+
+    Returns
+    -------
+    str
+        UTF-8-friendly JSON string truncated to
+        :data:`MAX_RESPONSE_BODY_LOG` characters.
+    """
+    try:
+        rendered = json.dumps(data, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        rendered = repr(data)
+    return rendered[:MAX_RESPONSE_BODY_LOG]
+
+
+def _parse_with_model(
+    model: type[_T],
+    data: Any,
+    *,
+    object_label: str | None = None,
+) -> _T:
+    """Validate ``data`` against ``model``, wrapping failures.
+
+    Parameters
+    ----------
+    model : type[BaseModel]
+        Pydantic model used as the validation target.
+    data : Any
+        Raw payload (typically a ``dict`` from ``response.json()``).
+    object_label : str | None
+        Optional label inserted into the error message; defaults to the
+        model class name.
+
+    Returns
+    -------
+    BaseModel
+        Validated model instance.
+
+    Raises
+    ------
+    FraserParseError
+        When ``model.model_validate`` raises ``ValidationError``.
+    """
+    label = object_label or model.__name__
+    try:
+        return model.model_validate(data)
+    except ValidationError as exc:
+        field = _extract_missing_field(exc)
+        message = f"Failed to parse {label}: {field}"
+        logger.error(
+            "FRASER parse failed",
+            target=label,
+            field=field,
+            exc_info=True,
+        )
+        raise FraserParseError(
+            message=message,
+            raw_data=_truncated_raw(data),
+            field=field,
+            cause=exc,
+        ) from exc
+
+
+def _require_list(data: Any, *, container_key: str | None = None) -> list[Any]:
+    """Return ``data`` as a list, raising :class:`FraserParseError` otherwise.
+
+    FRASER list endpoints return either a top-level JSON array or an
+    object such as ``{"items": [...]}``. Callers pass ``container_key``
+    when they expect the wrapped form; the helper unwraps it.
+
+    Parameters
+    ----------
+    data : Any
+        Raw payload.
+    container_key : str | None
+        Optional key to look up inside ``data`` (e.g., ``"items"``).
+
+    Returns
+    -------
+    list[Any]
+        The list payload.
+
+    Raises
+    ------
+    FraserParseError
+        If ``data`` is not a list (or the expected container does not
+        hold a list).
+    """
+    if container_key is not None:
+        if not isinstance(data, dict) or container_key not in data:
+            raise FraserParseError(
+                message=f"Expected '{container_key}' key in response",
+                raw_data=_truncated_raw(data),
+                field=container_key,
+                cause=None,
+            )
+        inner = data[container_key]
+        if not isinstance(inner, list):
+            raise FraserParseError(
+                message=f"Expected list under '{container_key}'",
+                raw_data=_truncated_raw(data),
+                field=container_key,
+                cause=None,
+            )
+        return inner
+
+    if not isinstance(data, list):
+        raise FraserParseError(
+            message="Expected a JSON array",
+            raw_data=_truncated_raw(data),
+            field="<root>",
+            cause=None,
+        )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Title / item parsers
+# ---------------------------------------------------------------------------
+
+
+def parse_title(data: dict[str, Any]) -> FraserTitle:
+    """Parse a FRASER title payload into :class:`FraserTitle`.
+
+    Parameters
+    ----------
+    data : dict[str, Any]
+        Decoded JSON object describing a single title.
+
+    Returns
+    -------
+    FraserTitle
+        Validated title model.
+
+    Raises
+    ------
+    FraserParseError
+        When required title fields are missing or malformed.
+    """
+    return _parse_with_model(FraserTitle, data)
+
+
+def parse_item(data: dict[str, Any]) -> FraserItem:
+    """Parse a FRASER item payload into :class:`FraserItem`.
+
+    Parameters
+    ----------
+    data : dict[str, Any]
+        Decoded JSON object describing a single item.
+
+    Returns
+    -------
+    FraserItem
+        Validated item model.
+
+    Raises
+    ------
+    FraserParseError
+        When required item fields are missing or malformed.
+    """
+    return _parse_with_model(FraserItem, data)
+
+
+def parse_items(data: dict[str, Any] | list[Any]) -> list[FraserItem]:
+    """Parse a FRASER items collection into a list of :class:`FraserItem`.
+
+    Accepts either:
+
+    - A dict containing an ``"items"`` key whose value is a list, or
+    - A bare list of item dicts.
+
+    Parameters
+    ----------
+    data : dict[str, Any] | list[Any]
+        Decoded JSON payload.
+
+    Returns
+    -------
+    list[FraserItem]
+        Parsed items in the same order as the input.
+
+    Raises
+    ------
+    FraserParseError
+        When the payload shape is unexpected or any individual item
+        fails validation.
+    """
+    items_list = (
+        _require_list(data, container_key="items")
+        if isinstance(data, dict)
+        else _require_list(data)
+    )
+    return [parse_item(entry) for entry in items_list]
+
+
+def parse_toc(data: dict[str, Any] | list[Any]) -> list[FraserTocEntry]:
+    """Parse a table-of-contents payload into :class:`FraserTocEntry` list."""
+    entries = (
+        _require_list(data, container_key="toc")
+        if isinstance(data, dict) and "toc" in data
+        else _require_list(data)
+    )
+    return [_parse_with_model(FraserTocEntry, entry) for entry in entries]
+
+
+def parse_authors(data: dict[str, Any] | list[Any]) -> list[FraserAuthor]:
+    """Parse an authors payload into :class:`FraserAuthor` list."""
+    entries = (
+        _require_list(data, container_key="authors")
+        if isinstance(data, dict) and "authors" in data
+        else _require_list(data)
+    )
+    return [_parse_with_model(FraserAuthor, entry) for entry in entries]
+
+
+def parse_subjects(data: dict[str, Any] | list[Any]) -> list[FraserSubject]:
+    """Parse a subjects payload into :class:`FraserSubject` list."""
+    entries = (
+        _require_list(data, container_key="subjects")
+        if isinstance(data, dict) and "subjects" in data
+        else _require_list(data)
+    )
+    return [_parse_with_model(FraserSubject, entry) for entry in entries]
+
+
+def parse_themes(data: dict[str, Any] | list[Any]) -> list[FraserTheme]:
+    """Parse a themes payload into :class:`FraserTheme` list."""
+    entries = (
+        _require_list(data, container_key="themes")
+        if isinstance(data, dict) and "themes" in data
+        else _require_list(data)
+    )
+    return [_parse_with_model(FraserTheme, entry) for entry in entries]
+
+
+def parse_timeline(data: dict[str, Any] | list[Any]) -> list[FraserTimelineEvent]:
+    """Parse a timeline payload into :class:`FraserTimelineEvent` list."""
+    entries = (
+        _require_list(data, container_key="timeline")
+        if isinstance(data, dict) and "timeline" in data
+        else _require_list(data)
+    )
+    return [_parse_with_model(FraserTimelineEvent, entry) for entry in entries]
+
+
+__all__ = [
+    "parse_authors",
+    "parse_item",
+    "parse_items",
+    "parse_subjects",
+    "parse_themes",
+    "parse_timeline",
+    "parse_title",
+    "parse_toc",
+]

--- a/src/market/fraser/parser.py
+++ b/src/market/fraser/parser.py
@@ -19,7 +19,7 @@ market.fraser.errors : ``FraserParseError`` raised on validation failure.
 from __future__ import annotations
 
 import json
-from typing import Any, TypeVar
+from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
@@ -37,8 +37,6 @@ from market.fraser.models import (
 from utils_core.logging import get_logger
 
 logger = get_logger(__name__)
-
-_T = TypeVar("_T", bound=BaseModel)
 
 
 # ---------------------------------------------------------------------------
@@ -99,12 +97,12 @@ def _truncated_raw(data: Any) -> str:
     return rendered[:MAX_RESPONSE_BODY_LOG]
 
 
-def _parse_with_model(
-    model: type[_T],
+def _parse_with_model[T: BaseModel](
+    model: type[T],
     data: Any,
     *,
     object_label: str | None = None,
-) -> _T:
+) -> T:
     """Validate ``data`` against ``model``, wrapping failures.
 
     Parameters

--- a/src/market/fraser/rate_limiter.py
+++ b/src/market/fraser/rate_limiter.py
@@ -1,0 +1,64 @@
+"""Rate limiter for the FRASER REST API module.
+
+This module re-exports ``DualWindowRateLimiter`` from
+``market.alphavantage.rate_limiter`` to avoid duplicating the
+dual-window sliding-window implementation. The
+``get_fraser_rate_limiter`` factory constructs a limiter using values
+from a ``FraserConfig`` instance, which keeps callers from having to
+thread the per-minute / per-hour limits separately.
+
+Notes
+-----
+The FRASER limiter is intentionally implemented as a thin wrapper
+around the Alpha Vantage implementation. New token-bucket or
+sliding-window code is not added here (HF1 confirmed re-use over
+re-implementation).
+
+See Also
+--------
+market.alphavantage.rate_limiter : Underlying ``DualWindowRateLimiter``
+    implementation (timestamp-deque based, thread-safe).
+market.fraser.types : ``FraserConfig`` definition referenced by the
+    factory function.
+"""
+
+from market.alphavantage.rate_limiter import (
+    AsyncDualWindowRateLimiter,
+    DualWindowRateLimiter,
+)
+from market.fraser.types import FraserConfig
+
+
+def get_fraser_rate_limiter(config: FraserConfig) -> DualWindowRateLimiter:
+    """Construct a ``DualWindowRateLimiter`` from a ``FraserConfig``.
+
+    Parameters
+    ----------
+    config : FraserConfig
+        FRASER configuration carrying the per-minute and per-hour
+        request limits.
+
+    Returns
+    -------
+    DualWindowRateLimiter
+        Limiter initialised with ``config.requests_per_minute`` and
+        ``config.requests_per_hour``.
+
+    Examples
+    --------
+    >>> from market.fraser.types import FraserConfig
+    >>> limiter = get_fraser_rate_limiter(FraserConfig(api_key="x"))
+    >>> limiter.available_minute
+    30
+    """
+    return DualWindowRateLimiter(
+        requests_per_minute=config.requests_per_minute,
+        requests_per_hour=config.requests_per_hour,
+    )
+
+
+__all__ = [
+    "AsyncDualWindowRateLimiter",
+    "DualWindowRateLimiter",
+    "get_fraser_rate_limiter",
+]

--- a/src/market/fraser/rate_limiter.py
+++ b/src/market/fraser/rate_limiter.py
@@ -23,7 +23,7 @@ market.fraser.types : ``FraserConfig`` definition referenced by the
 """
 
 from market.alphavantage.rate_limiter import (
-    AsyncDualWindowRateLimiter,
+    AsyncDualWindowRateLimiter,  # reserved for future async fetchers
     DualWindowRateLimiter,
 )
 from market.fraser.types import FraserConfig
@@ -57,8 +57,11 @@ def get_fraser_rate_limiter(config: FraserConfig) -> DualWindowRateLimiter:
     )
 
 
+# ``AsyncDualWindowRateLimiter`` is import-only for now; it stays
+# accessible through ``from market.fraser.rate_limiter import
+# AsyncDualWindowRateLimiter`` but is not part of the curated public
+# surface until an async fetcher actually consumes it.
 __all__ = [
-    "AsyncDualWindowRateLimiter",
     "DualWindowRateLimiter",
     "get_fraser_rate_limiter",
 ]

--- a/src/market/fraser/scripts/__init__.py
+++ b/src/market/fraser/scripts/__init__.py
@@ -1,0 +1,6 @@
+"""CLI scripts for the ``market.fraser`` package.
+
+This sub-package hosts command-line entry points for FRASER REST API
+maintenance tasks such as discovering ``title_id`` values for the
+supported document types.
+"""

--- a/src/market/fraser/scripts/discover_titles.py
+++ b/src/market/fraser/scripts/discover_titles.py
@@ -1,0 +1,466 @@
+"""CLI to discover FRASER ``title_id`` values for the supported document types.
+
+This script queries the FRASER REST API for subjects matching a list of
+keywords (e.g. ``"Federal Open Market Committee"``, ``"Beige Book"``)
+and, for each match, lists the candidate titles so the operator can
+manually confirm the correct ``title_id``. The confirmed mapping is
+written to a JSON file (default: ``data/config/fraser_titles.json``)
+which is then manually copied into
+``src/market/fraser/constants.py:KNOWN_TITLE_IDS`` (HF1 decision — no
+automatic AST rewriting).
+
+Examples
+--------
+Run in interactive mode, writing to the default location::
+
+    $ uv run python -m market.fraser.scripts.discover_titles \\
+        --output data/config/fraser_titles.json \\
+        --interactive
+
+Run with a custom keyword set::
+
+    $ uv run python -m market.fraser.scripts.discover_titles \\
+        --keywords "Beige Book" "Monetary Policy Report"
+
+See Also
+--------
+market.fraser.session : :class:`FraserSession` used for HTTP calls.
+market.fraser.constants : ``KNOWN_TITLE_IDS`` target mapping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from market.fraser.constants import KNOWN_TITLE_IDS
+from market.fraser.errors import FraserError
+from market.fraser.session import FraserSession
+from market.fraser.types import FraserConfig
+from utils_core.logging import get_logger
+
+logger = get_logger(__name__, module="discover_titles")
+
+# Default output path (relative to repository root) for the discovered mapping.
+DEFAULT_OUTPUT_PATH: Path = Path("data/config/fraser_titles.json")
+
+# Default keyword list — one entry per :data:`KNOWN_TITLE_IDS` key (six total).
+DEFAULT_KEYWORDS: list[str] = [
+    "Federal Open Market Committee",
+    "FOMC Statements",
+    "FOMC Press Conferences",
+    "Beige Book",
+    "Monetary Policy Report",
+    "Federal Reserve Board Speeches",
+]
+
+# Mapping from keyword to KNOWN_TITLE_IDS key. Aligned with DEFAULT_KEYWORDS
+# index-by-index so callers passing the default list get the canonical six
+# slots populated.
+_KEYWORD_TO_KEY: dict[str, str] = {
+    "Federal Open Market Committee": "fomc_minutes",
+    "FOMC Statements": "fomc_statements",
+    "FOMC Press Conferences": "fomc_press_conferences",
+    "Beige Book": "beige_book",
+    "Monetary Policy Report": "monetary_policy_report",
+    "Federal Reserve Board Speeches": "frb_speeches",
+}
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Parameters
+    ----------
+    args : list[str] | None
+        Argument list. When ``None`` (default), :data:`sys.argv` is used.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments with ``output``, ``interactive`` and
+        ``keywords`` attributes.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Discover FRASER title_id values for the supported document "
+            "types and write the mapping to a JSON file."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  Interactive run (default output path):
+    %(prog)s --interactive
+
+  Non-interactive run with custom keywords:
+    %(prog)s --keywords "Beige Book" "Monetary Policy Report"
+
+  Custom output path:
+    %(prog)s --output /tmp/fraser_titles.json --interactive
+""",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        metavar="PATH",
+        help=(
+            "Destination JSON file (default: %(default)s). "
+            "Existing values are preserved when not re-discovered."
+        ),
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help=(
+            "Prompt the operator to pick the correct title from the "
+            "candidate list for each keyword. When omitted, the first "
+            "matching title is selected automatically."
+        ),
+    )
+    parser.add_argument(
+        "--keywords",
+        nargs="+",
+        default=DEFAULT_KEYWORDS,
+        metavar="KEYWORD",
+        help=(
+            "Subject keywords to search (default: the six canonical "
+            "FRASER document categories)."
+        ),
+    )
+    return parser.parse_args(args)
+
+
+def fetch_subjects(session: FraserSession) -> list[dict[str, Any]]:
+    """Fetch the full list of FRASER subjects.
+
+    Parameters
+    ----------
+    session : FraserSession
+        Authenticated session used to hit ``GET /subjects``.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Parsed ``subjects`` array (each element typically has ``id`` and
+        ``name`` keys). Returns an empty list when the API responds with
+        a body that does not contain a ``subjects`` key.
+    """
+    logger.info("Fetching FRASER subjects")
+    response = session.get_with_retry("/subjects", params={"fields": "name!id"})
+    payload = response.json()
+    if isinstance(payload, dict):
+        subjects = payload.get("subjects", [])
+        if isinstance(subjects, list):
+            return [s for s in subjects if isinstance(s, dict)]
+    logger.warning(
+        "Unexpected /subjects payload shape", payload_type=type(payload).__name__
+    )
+    return []
+
+
+def find_matching_subjects(
+    subjects: list[dict[str, Any]],
+    keyword: str,
+) -> list[dict[str, Any]]:
+    """Filter ``subjects`` to those whose ``name`` contains ``keyword``.
+
+    Matching is case-insensitive.
+
+    Parameters
+    ----------
+    subjects : list[dict[str, Any]]
+        Subjects returned by :func:`fetch_subjects`.
+    keyword : str
+        Substring to look for in each subject's ``name`` field.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Subjects whose ``name`` field contains the keyword.
+    """
+    keyword_lower = keyword.lower()
+    return [
+        s
+        for s in subjects
+        if isinstance(s.get("name"), str) and keyword_lower in s["name"].lower()
+    ]
+
+
+def fetch_titles_for_subject(
+    session: FraserSession,
+    subject_id: int,
+) -> list[dict[str, Any]]:
+    """Fetch the list of titles associated with a subject.
+
+    Parameters
+    ----------
+    session : FraserSession
+        Authenticated session used to hit ``GET /subject/{id}/titles``.
+    subject_id : int
+        Subject identifier as returned by ``/subjects``.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Parsed ``titles`` array. Returns an empty list when the API
+        responds with a body that does not contain a ``titles`` key.
+    """
+    logger.info("Fetching titles for subject", subject_id=subject_id)
+    response = session.get_with_retry(
+        f"/subject/{subject_id}/titles",
+        params={"fields": "name!id"},
+    )
+    payload = response.json()
+    if isinstance(payload, dict):
+        titles = payload.get("titles", [])
+        if isinstance(titles, list):
+            return [t for t in titles if isinstance(t, dict)]
+    logger.warning(
+        "Unexpected /subject/{id}/titles payload shape",
+        subject_id=subject_id,
+        payload_type=type(payload).__name__,
+    )
+    return []
+
+
+def _select_title(
+    titles: list[dict[str, Any]],
+    keyword: str,
+    interactive: bool,
+) -> int | None:
+    """Choose a ``title_id`` from ``titles``, optionally prompting the user.
+
+    Parameters
+    ----------
+    titles : list[dict[str, Any]]
+        Candidate titles (each typically containing ``id`` and ``name``).
+    keyword : str
+        Keyword used to discover the titles (shown in interactive
+        prompts for context).
+    interactive : bool
+        When ``True``, prompt the operator. When ``False``, pick the
+        first candidate automatically.
+
+    Returns
+    -------
+    int | None
+        The selected ``title_id``, or ``None`` when no titles are
+        available or the operator skipped the prompt.
+    """
+    if not titles:
+        print(f"  [WARN] no candidate titles for '{keyword}'", file=sys.stderr)
+        return None
+
+    if not interactive:
+        first = titles[0]
+        title_id = first.get("id")
+        if isinstance(title_id, int):
+            return title_id
+        return None
+
+    print(f"\nCandidates for '{keyword}':")
+    for idx, title in enumerate(titles, start=1):
+        title_id = title.get("id", "?")
+        name = title.get("name", "?")
+        print(f"  [{idx}] id={title_id} | name={name}")
+
+    while True:
+        choice = input(f"Select 1-{len(titles)} (or 's' to skip): ").strip().lower()
+        if choice == "s":
+            return None
+        try:
+            idx = int(choice)
+        except ValueError:
+            print("  Invalid input. Enter a number or 's'.", file=sys.stderr)
+            continue
+        if 1 <= idx <= len(titles):
+            chosen = titles[idx - 1].get("id")
+            if isinstance(chosen, int):
+                return chosen
+            print("  Selected entry has no integer id; pick another.", file=sys.stderr)
+        else:
+            print(f"  Out of range. Enter 1-{len(titles)} or 's'.", file=sys.stderr)
+
+
+def discover_title_ids(
+    session: FraserSession,
+    keywords: list[str],
+    interactive: bool,
+) -> dict[str, int]:
+    """Discover ``title_id`` values for each keyword.
+
+    Parameters
+    ----------
+    session : FraserSession
+        Authenticated session.
+    keywords : list[str]
+        Keywords to match against subject names.
+    interactive : bool
+        Whether to prompt the operator when multiple titles match.
+
+    Returns
+    -------
+    dict[str, int]
+        Mapping from :data:`KNOWN_TITLE_IDS` key to confirmed
+        ``title_id``. Only keys for which a title was confirmed are
+        included.
+    """
+    subjects = fetch_subjects(session)
+    if not subjects:
+        logger.warning("No subjects returned by FRASER API")
+        return {}
+
+    discovered: dict[str, int] = {}
+    for keyword in keywords:
+        target_key = _KEYWORD_TO_KEY.get(keyword)
+        if target_key is None:
+            logger.warning(
+                "Keyword not mapped to a KNOWN_TITLE_IDS slot, skipping",
+                keyword=keyword,
+            )
+            continue
+
+        matches = find_matching_subjects(subjects, keyword)
+        if not matches:
+            print(f"  [WARN] no subjects matched '{keyword}'", file=sys.stderr)
+            continue
+
+        # Collect candidate titles across all matching subjects.
+        candidates: list[dict[str, Any]] = []
+        seen_ids: set[int] = set()
+        for subject in matches:
+            subject_id = subject.get("id")
+            if not isinstance(subject_id, int):
+                continue
+            try:
+                titles = fetch_titles_for_subject(session, subject_id)
+            except FraserError as exc:
+                logger.warning(
+                    "Failed to fetch titles for subject",
+                    subject_id=subject_id,
+                    error=str(exc),
+                )
+                continue
+            for title in titles:
+                title_id = title.get("id")
+                if isinstance(title_id, int) and title_id not in seen_ids:
+                    seen_ids.add(title_id)
+                    candidates.append(title)
+
+        chosen_id = _select_title(candidates, keyword, interactive)
+        if chosen_id is not None:
+            discovered[target_key] = chosen_id
+            print(f"  [OK] {target_key} = {chosen_id}")
+
+    return discovered
+
+
+def write_titles_json(
+    output_path: Path,
+    discovered: dict[str, int],
+) -> None:
+    """Merge ``discovered`` with existing data and write to ``output_path``.
+
+    Existing values in the file (if any) are preserved unless overridden
+    by a newly discovered title_id. Confirmed FOMC Minutes (677) is also
+    backfilled from :data:`KNOWN_TITLE_IDS` when missing so the produced
+    file contains all six canonical keys.
+
+    Parameters
+    ----------
+    output_path : Path
+        Destination file path. Parent directories are created when
+        needed.
+    discovered : dict[str, int]
+        Newly discovered title_id values.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict[str, Any] = {}
+    if output_path.exists():
+        try:
+            loaded = json.loads(output_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                existing = loaded
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Failed to read existing output, will overwrite",
+                output_path=str(output_path),
+                error=str(exc),
+            )
+            existing = {}
+
+    # Backfill known canonical IDs (e.g. fomc_minutes=677) when not present.
+    merged: dict[str, int | None] = dict(existing)
+    for key, known_value in KNOWN_TITLE_IDS.items():
+        if key not in merged and known_value is not None:
+            merged[key] = known_value
+
+    # Apply discovered overrides.
+    for key, value in discovered.items():
+        merged[key] = value
+
+    output_path.write_text(
+        json.dumps(merged, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    logger.info(
+        "Wrote FRASER title_id mapping",
+        output_path=str(output_path),
+        key_count=len(merged),
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the discovery workflow.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed CLI arguments.
+
+    Returns
+    -------
+    int
+        Process exit code (0 on success, 1 on failure).
+    """
+    config = FraserConfig()
+    try:
+        with FraserSession(config=config) as session:
+            discovered = discover_title_ids(
+                session=session,
+                keywords=args.keywords,
+                interactive=args.interactive,
+            )
+    except FraserError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        logger.error("Discovery failed", error=str(exc))
+        return 1
+
+    write_titles_json(args.output, discovered)
+    print(f"\nWrote {len(discovered)} discovered title_id(s) to {args.output}")
+    print(
+        "Reminder: manually copy these values into "
+        "src/market/fraser/constants.py:KNOWN_TITLE_IDS (HF1 confirmed)."
+    )
+    return 0
+
+
+def main() -> int:
+    """CLI entry point.
+
+    Returns
+    -------
+    int
+        Process exit code.
+    """
+    args = parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/market/fraser/session.py
+++ b/src/market/fraser/session.py
@@ -29,8 +29,9 @@ from __future__ import annotations
 import os
 import random
 import time
-from typing import Any
-from urllib.parse import urlparse
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse, urlsplit
 
 import httpx
 
@@ -50,6 +51,9 @@ from market.fraser.errors import (
 from market.fraser.rate_limiter import DualWindowRateLimiter
 from market.fraser.types import FraserConfig, RetryConfig
 from utils_core.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = get_logger(__name__)
 
@@ -289,9 +293,12 @@ class FraserSession:
 
                 last_error = e
 
+                # Drop the query string before logging — paths embed item_id
+                # or future PII; only the routing path is useful here (CWE-532).
+                safe_path = urlsplit(path).path
                 logger.warning(
                     "Request failed, will retry",
-                    path=path,
+                    path=safe_path,
                     attempt=attempt + 1,
                     max_attempts=self._retry_config.max_attempts,
                     error=str(e),
@@ -299,14 +306,16 @@ class FraserSession:
 
                 # If this is not the last attempt, apply backoff.
                 if attempt < self._retry_config.max_attempts - 1:
-                    # Prefer server-suggested Retry-After when present.
+                    # Prefer server-suggested Retry-After when present, but
+                    # cap by max_wait so a hostile server cannot lock the
+                    # process up with ``Retry-After: 999999`` (CWE-400).
                     retry_after: float | None = (
                         e.retry_after
                         if isinstance(e, FraserRateLimitError) and e.retry_after
                         else None
                     )
                     delay = (
-                        retry_after
+                        min(retry_after, self._retry_config.max_wait)
                         if retry_after is not None
                         else self._calculate_backoff_delay(attempt)
                     )
@@ -355,6 +364,40 @@ class FraserSession:
     ) -> None:
         """Close session on context exit."""
         self.close()
+
+    # =========================================================================
+    # Streaming (used by FraserDownloader)
+    # =========================================================================
+
+    @contextmanager
+    def stream(self, url: str) -> Iterator[httpx.Response]:
+        """Open a streaming GET response after enforcing SSRF guards.
+
+        Wraps :meth:`httpx.Client.stream` so that downloaders share the same
+        host whitelist and HTTPS enforcement as regular API calls
+        (CWE-918). Polite delays and rate limiting are intentionally **not**
+        applied here because streaming downloads of multi-megabyte PDFs
+        should not be billed against the 30 req/min budget for JSON calls.
+
+        Parameters
+        ----------
+        url : str
+            Absolute URL to stream. Validated by :meth:`_validate_url`.
+
+        Yields
+        ------
+        httpx.Response
+            Streaming response. The caller is responsible for iterating
+            ``response.iter_bytes`` inside the ``with`` block.
+
+        Raises
+        ------
+        FraserValidationError
+            When the URL fails SSRF / HTTPS validation.
+        """
+        self._validate_url(url)
+        with self._client.stream("GET", url) as response:
+            yield response
 
     # =========================================================================
     # Internal Methods
@@ -432,7 +475,10 @@ class FraserSession:
                 field="url.scheme",
                 value=parsed.scheme,
             )
-        parsed_host = parsed.netloc
+        # ``hostname`` strips the optional ``:port`` so that
+        # ``https://fraser.stlouisfed.org:443/...`` (explicit port form)
+        # is treated as the same host as the allow-listed bare name.
+        parsed_host = parsed.hostname or ""
         if parsed_host not in ALLOWED_HOSTS:
             logger.warning(
                 "Request blocked: host not in allowed hosts",

--- a/src/market/fraser/session.py
+++ b/src/market/fraser/session.py
@@ -137,6 +137,12 @@ class FraserSession:
             )
         )
 
+        # Resolve the API key once per session so repeated requests do
+        # not hit ``os.environ.get`` on every call (PR review LOW perf).
+        # ``_resolve_api_key`` raises ``FraserAuthError`` when missing,
+        # turning a hot-path error into a clear startup failure.
+        self._resolved_api_key: str = self._resolve_api_key()
+
         # Create httpx client with timeout and explicit SSL verification
         self._client: httpx.Client = httpx.Client(
             timeout=httpx.Timeout(self._config.timeout),
@@ -206,9 +212,8 @@ class FraserSession:
         # 1. URL whitelist + HTTPS validation (SSRF prevention, CWE-918).
         self._validate_url(url)
 
-        # 2. Resolve API key and inject into headers (X-API-Key).
-        api_key = self._resolve_api_key()
-        headers = {"X-API-Key": api_key}
+        # 2. Inject API key (resolved once in __init__) into headers.
+        headers = {"X-API-Key": self._resolved_api_key}
 
         # 3. Acquire rate limiter slot.
         self._rate_limiter.acquire()

--- a/src/market/fraser/session.py
+++ b/src/market/fraser/session.py
@@ -1,0 +1,611 @@
+"""HTTP session abstraction for FRASER REST API access.
+
+This module provides the :class:`FraserSession` class, an httpx-based HTTP
+session with X-API-Key header authentication, polite delays
+(monotonic-clock-based), SSRF prevention via host whitelist, rate limiter
+integration, and exponential backoff retry logic.
+
+Unlike Alpha Vantage, FRASER uses standard HTTP status codes to signal
+errors (no HTTP 200 + JSON error body pattern). The HTTP 429 response is
+expected to include a ``Retry-After`` header whose value is parsed and
+attached to the raised :class:`FraserRateLimitError`.
+
+See Also
+--------
+market.alphavantage.session : Reference implementation (1:1 adapted with
+    three FRASER-specific modifications applied).
+market.fraser.constants : Default values, allowed hosts.
+market.fraser.types : :class:`FraserConfig`, :class:`RetryConfig`
+    dataclasses.
+market.fraser.errors : :class:`FraserAuthError`, :class:`FraserAPIError`,
+    :class:`FraserRateLimitError`, :class:`FraserNotFoundError`,
+    :class:`FraserValidationError` exceptions.
+market.fraser.rate_limiter : :class:`DualWindowRateLimiter` for request
+    throttling.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from market.fraser.constants import (
+    ALLOWED_HOSTS,
+    BASE_URL,
+    FRASER_API_KEY_ENV,
+    MAX_RESPONSE_BODY_LOG,
+)
+from market.fraser.errors import (
+    FraserAPIError,
+    FraserAuthError,
+    FraserNotFoundError,
+    FraserRateLimitError,
+    FraserValidationError,
+)
+from market.fraser.rate_limiter import DualWindowRateLimiter
+from market.fraser.types import FraserConfig, RetryConfig
+from utils_core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# HTTP status code indicating rate limiting
+_RATE_LIMIT_STATUS_CODE = 429
+# HTTP status codes indicating authentication / authorisation failure
+_AUTH_ERROR_STATUS_CODES = frozenset({401, 403})
+# HTTP status code indicating resource not found
+_NOT_FOUND_STATUS_CODE = 404
+
+# Default polite delay (seconds) — FRASER does not document a minimum, so we
+# use a conservative value compatible with 30 req/min (2 s/request).
+_DEFAULT_POLITE_DELAY = 2.0
+# Default jitter (seconds) — small random offset to avoid synchronised bursts.
+_DEFAULT_DELAY_JITTER = 0.5
+
+
+class FraserSession:
+    """httpx-based HTTP session for the FRASER REST API.
+
+    Provides X-API-Key header authentication, SSRF prevention via host
+    whitelist (``fraser.stlouisfed.org`` only), HTTPS enforcement, polite
+    delays between requests (using :func:`time.monotonic`),
+    :class:`DualWindowRateLimiter` integration (30 req/min default), 429
+    ``Retry-After`` honouring, and exponential backoff retry logic.
+
+    Parameters
+    ----------
+    config : FraserConfig | None
+        FRASER configuration. If ``None``, :class:`FraserConfig` defaults
+        are used. The API key falls back to ``FRASER_API_KEY``
+        environment variable when ``config.api_key`` is empty.
+    rate_limiter : DualWindowRateLimiter | None
+        Dual-window rate limiter. If ``None``, a fresh limiter is
+        constructed from ``config.requests_per_minute`` and
+        ``config.requests_per_hour``.
+    retry_config : RetryConfig | None
+        Retry configuration. If ``None``, ``config.retry_config`` is used.
+
+    Examples
+    --------
+    >>> with FraserSession() as session:  # doctest: +SKIP
+    ...     response = session.get_with_retry(
+    ...         "/items",
+    ...         params={"titleId": 677, "limit": 1},
+    ...     )
+    ...     data = response.json()
+    """
+
+    def __init__(
+        self,
+        config: FraserConfig | None = None,
+        rate_limiter: DualWindowRateLimiter | None = None,
+        retry_config: RetryConfig | None = None,
+    ) -> None:
+        """Initialise :class:`FraserSession` with configuration.
+
+        Parameters
+        ----------
+        config : FraserConfig | None
+            FRASER configuration. Defaults to ``FraserConfig()``.
+        rate_limiter : DualWindowRateLimiter | None
+            Optional pre-built rate limiter. When ``None``, a fresh
+            limiter is constructed from ``config.requests_per_minute``
+            and ``config.requests_per_hour``.
+        retry_config : RetryConfig | None
+            Optional retry configuration. When ``None``, the value of
+            ``config.retry_config`` is used.
+        """
+        self._config: FraserConfig = config or FraserConfig()
+        self._retry_config: RetryConfig = retry_config or self._config.retry_config
+        self._last_request_time: float = 0.0
+
+        # Initialize rate limiter with config values (or accept injected one)
+        self._rate_limiter: DualWindowRateLimiter = (
+            rate_limiter
+            if rate_limiter is not None
+            else DualWindowRateLimiter(
+                requests_per_minute=self._config.requests_per_minute,
+                requests_per_hour=self._config.requests_per_hour,
+            )
+        )
+
+        # Create httpx client with timeout and explicit SSL verification
+        self._client: httpx.Client = httpx.Client(
+            timeout=httpx.Timeout(self._config.timeout),
+            verify=True,
+        )
+
+        logger.info(
+            "FraserSession initialized",
+            timeout=self._config.timeout,
+            requests_per_minute=self._config.requests_per_minute,
+            requests_per_hour=self._config.requests_per_hour,
+            max_retry_attempts=self._retry_config.max_attempts,
+            base_url=self._config.base_url,
+        )
+
+    # =========================================================================
+    # Public API
+    # =========================================================================
+
+    def get(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Send a GET request with X-API-Key header injection.
+
+        Applies the following before each request:
+
+        1. URL construction (``base_url + path`` when ``path`` is relative).
+        2. URL whitelist + HTTPS validation (SSRF prevention, CWE-918).
+        3. API key resolution and X-API-Key header injection.
+        4. Rate limiter acquisition.
+        5. Polite delay (monotonic-clock-based interval control).
+        6. HTTP request execution.
+        7. Response status code error mapping.
+
+        Parameters
+        ----------
+        path : str
+            API endpoint path (e.g. ``"/items"``) or absolute URL.
+            Relative paths are joined to ``config.base_url``.
+        params : dict[str, Any] | None
+            Optional query parameters for the request.
+
+        Returns
+        -------
+        httpx.Response
+            The HTTP response object.
+
+        Raises
+        ------
+        FraserValidationError
+            If the URL host is not in :data:`ALLOWED_HOSTS` or the scheme
+            is not ``https``.
+        FraserAuthError
+            If the API key is missing or the API returns 401 / 403.
+        FraserNotFoundError
+            If the API returns HTTP 404.
+        FraserRateLimitError
+            If the API returns HTTP 429.
+        FraserAPIError
+            If the API returns any other 4xx or 5xx response.
+        """
+        # 0. Build absolute URL (support both relative paths and absolute URLs).
+        url = self._build_url(path)
+
+        # 1. URL whitelist + HTTPS validation (SSRF prevention, CWE-918).
+        self._validate_url(url)
+
+        # 2. Resolve API key and inject into headers (X-API-Key).
+        api_key = self._resolve_api_key()
+        headers = {"X-API-Key": api_key}
+
+        # 3. Acquire rate limiter slot.
+        self._rate_limiter.acquire()
+
+        # 4. Apply polite delay (monotonic-clock-based).
+        self._polite_delay()
+
+        logger.debug("Sending GET request", url=url)
+
+        # 5. Execute request.
+        response: httpx.Response = self._client.get(
+            url,
+            params=params,
+            headers=headers,
+        )
+
+        # 6. Handle response status codes.
+        self._handle_response_status(response, url)
+
+        logger.debug(
+            "GET request completed",
+            url=url,
+            status_code=response.status_code,
+        )
+        return response
+
+    def get_with_retry(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Send a GET request with exponential backoff retry.
+
+        Retries on rate-limit (HTTP 429) and server-side (HTTP 5xx)
+        errors. Client errors other than 429 are *not* retried.
+
+        When the server returns 429 with a ``Retry-After`` header, the
+        parsed delay is preferred over the computed exponential backoff
+        for the following attempt.
+
+        Parameters
+        ----------
+        path : str
+            API endpoint path (e.g. ``"/items"``) or absolute URL.
+        params : dict[str, Any] | None
+            Optional query parameters for the request.
+
+        Returns
+        -------
+        httpx.Response
+            The HTTP response object on success.
+
+        Raises
+        ------
+        FraserRateLimitError
+            If all retry attempts fail due to rate limiting.
+        FraserAPIError
+            If all retry attempts fail due to server errors.
+        """
+        last_error: FraserRateLimitError | FraserAPIError | None = None
+
+        for attempt in range(self._retry_config.max_attempts):
+            try:
+                response = self.get(path, params=params)
+
+                if attempt > 0:
+                    logger.info(
+                        "Request succeeded after retry",
+                        path=path,
+                        attempt=attempt + 1,
+                    )
+                return response
+
+            except (FraserRateLimitError, FraserAPIError) as e:
+                # 4xx (except 429) should not be retried.
+                if (
+                    isinstance(e, FraserAPIError)
+                    and 400 <= e.status_code < 500
+                    and e.status_code != _RATE_LIMIT_STATUS_CODE
+                ):
+                    raise
+
+                last_error = e
+
+                logger.warning(
+                    "Request failed, will retry",
+                    path=path,
+                    attempt=attempt + 1,
+                    max_attempts=self._retry_config.max_attempts,
+                    error=str(e),
+                )
+
+                # If this is not the last attempt, apply backoff.
+                if attempt < self._retry_config.max_attempts - 1:
+                    # Prefer server-suggested Retry-After when present.
+                    retry_after: float | None = (
+                        e.retry_after
+                        if isinstance(e, FraserRateLimitError) and e.retry_after
+                        else None
+                    )
+                    delay = (
+                        retry_after
+                        if retry_after is not None
+                        else self._calculate_backoff_delay(attempt)
+                    )
+                    logger.debug(
+                        "Backoff before retry",
+                        delay_seconds=delay,
+                        next_attempt=attempt + 2,
+                        used_retry_after=retry_after is not None,
+                    )
+                    time.sleep(delay)
+
+        # All attempts exhausted.
+        logger.error(
+            "All retry attempts failed",
+            path=path,
+            max_attempts=self._retry_config.max_attempts,
+        )
+        if last_error is None:
+            raise RuntimeError("Unexpected: no error recorded after exhausting retries")
+        raise last_error
+
+    # =========================================================================
+    # Context Manager
+    # =========================================================================
+
+    def close(self) -> None:
+        """Close the session and release underlying HTTP resources."""
+        self._client.close()
+        logger.debug("FraserSession closed")
+
+    def __enter__(self) -> FraserSession:
+        """Support the context manager protocol.
+
+        Returns
+        -------
+        FraserSession
+            ``self`` for use in ``with`` statements.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Close session on context exit."""
+        self.close()
+
+    # =========================================================================
+    # Internal Methods
+    # =========================================================================
+
+    def _build_url(self, path: str) -> str:
+        """Build an absolute URL from a relative path or pass through absolute URLs.
+
+        Any input containing a ``"://"`` separator is treated as an
+        already-absolute URL and passed through unchanged so that scheme
+        validation (e.g. for ``http://``, ``ftp://``) is performed on
+        the URL the caller actually supplied.
+
+        Parameters
+        ----------
+        path : str
+            Path (e.g. ``"/items"``) or already-absolute URL.
+
+        Returns
+        -------
+        str
+            Absolute URL.
+        """
+        if "://" in path:
+            return path
+        # Strip trailing '/' from base_url and leading '/' duplication from
+        # path to avoid producing ``//``.
+        base = self._config.base_url.rstrip("/")
+        suffix = path if path.startswith("/") else "/" + path
+        return base + suffix
+
+    def _resolve_api_key(self) -> str:
+        """Resolve the API key from config or environment variable.
+
+        Returns
+        -------
+        str
+            The resolved API key.
+
+        Raises
+        ------
+        FraserAuthError
+            If no API key is configured.
+        """
+        api_key = self._config.api_key or os.environ.get(FRASER_API_KEY_ENV, "")
+
+        if not api_key:
+            raise FraserAuthError(
+                f"FRASER API key not provided. "
+                f"Set {FRASER_API_KEY_ENV} environment variable "
+                f"or pass it via FraserConfig(api_key=...)."
+            )
+
+        return api_key
+
+    def _validate_url(self, url: str) -> None:
+        """Validate URL against the allowed hosts whitelist (SSRF prevention).
+
+        Parameters
+        ----------
+        url : str
+            The URL to validate.
+
+        Raises
+        ------
+        FraserValidationError
+            If the URL scheme is not ``https`` or the host is not in
+            :data:`ALLOWED_HOSTS` (CWE-918).
+        """
+        parsed = urlparse(url)
+        if parsed.scheme != "https":
+            raise FraserValidationError(
+                f"URL scheme must be 'https', got '{parsed.scheme}'. "
+                "FRASER API requires HTTPS.",
+                field="url.scheme",
+                value=parsed.scheme,
+            )
+        parsed_host = parsed.netloc
+        if parsed_host not in ALLOWED_HOSTS:
+            logger.warning(
+                "Request blocked: host not in allowed hosts",
+                url=url,
+                host=parsed_host,
+                allowed_hosts=list(ALLOWED_HOSTS),
+            )
+            raise FraserValidationError(
+                f"Host '{parsed_host}' is not in allowed hosts: "
+                f"{sorted(ALLOWED_HOSTS)}",
+                field="url.host",
+                value=parsed_host,
+            )
+
+    def _polite_delay(self) -> None:
+        """Apply polite delay between consecutive requests.
+
+        Uses :func:`time.monotonic` to measure elapsed time since the
+        last request and sleeps for the remaining delay if not enough
+        time has passed. Adds random jitter to avoid thundering herd.
+        """
+        now = time.monotonic()
+
+        if self._last_request_time > 0:
+            elapsed = now - self._last_request_time
+            required_delay = _DEFAULT_POLITE_DELAY + random.uniform(  # nosec B311
+                0, _DEFAULT_DELAY_JITTER
+            )
+            remaining = required_delay - elapsed
+            if remaining > 0:
+                time.sleep(remaining)
+                logger.debug("Polite delay applied", delay_seconds=remaining)
+
+        self._last_request_time = time.monotonic()
+
+    def _handle_response_status(self, response: httpx.Response, url: str) -> None:
+        """Inspect HTTP status code and raise the appropriate FRASER exception.
+
+        Parameters
+        ----------
+        response : httpx.Response
+            The HTTP response to check.
+        url : str
+            The request URL (used for error context).
+
+        Raises
+        ------
+        FraserRateLimitError
+            On HTTP 429. ``retry_after`` is populated from the
+            ``Retry-After`` header when present.
+        FraserAuthError
+            On HTTP 401 / 403.
+        FraserNotFoundError
+            On HTTP 404.
+        FraserAPIError
+            On any other 4xx or 5xx response.
+        """
+        status = response.status_code
+
+        # 429: rate limit (honour Retry-After header).
+        if status == _RATE_LIMIT_STATUS_CODE:
+            retry_after_seconds = self._parse_retry_after(
+                response.headers.get("Retry-After")
+            )
+            logger.warning(
+                "Rate limit detected (HTTP 429)",
+                url=url,
+                status_code=status,
+                retry_after=retry_after_seconds,
+            )
+            raise FraserRateLimitError(
+                message=f"Rate limit exceeded: HTTP {status}",
+                retry_after=retry_after_seconds,
+            )
+
+        # 401 / 403: authentication / authorisation failure.
+        if status in _AUTH_ERROR_STATUS_CODES:
+            logger.warning(
+                "Authentication / authorisation error",
+                url=url,
+                status_code=status,
+            )
+            raise FraserAuthError(f"Authentication failed: HTTP {status} for {url}")
+
+        # 404: resource not found.
+        if status == _NOT_FOUND_STATUS_CODE:
+            logger.warning(
+                "Resource not found",
+                url=url,
+                status_code=status,
+            )
+            raise FraserNotFoundError(f"Resource not found: HTTP {status} for {url}")
+
+        # Other 4xx: client error.
+        if 400 <= status < 500:
+            logger.warning(
+                "Client error",
+                url=url,
+                status_code=status,
+            )
+            raise FraserAPIError(
+                message=f"Client error: HTTP {status}",
+                url=url,
+                status_code=status,
+                response_body=response.text[:MAX_RESPONSE_BODY_LOG],
+            )
+
+        # 5xx: server error.
+        if status >= 500:
+            logger.warning(
+                "Server error",
+                url=url,
+                status_code=status,
+            )
+            raise FraserAPIError(
+                message=f"Server error: HTTP {status}",
+                url=url,
+                status_code=status,
+                response_body=response.text[:MAX_RESPONSE_BODY_LOG],
+            )
+
+    @staticmethod
+    def _parse_retry_after(header_value: str | None) -> float | None:
+        """Parse a ``Retry-After`` header value into seconds.
+
+        Supports the integer "delta-seconds" form. The HTTP-date form is
+        intentionally not supported because FRASER's API documentation
+        specifies the integer form, and parsing dates without a reliable
+        clock skew adjustment is brittle.
+
+        Parameters
+        ----------
+        header_value : str | None
+            Raw ``Retry-After`` header value (e.g. ``"5"``).
+
+        Returns
+        -------
+        float | None
+            Parsed delay in seconds, or ``None`` when the header is
+            missing or cannot be parsed.
+        """
+        if not header_value:
+            return None
+        try:
+            return float(header_value.strip())
+        except (TypeError, ValueError):
+            logger.debug(
+                "Failed to parse Retry-After header as integer seconds",
+                header_value=header_value,
+            )
+            return None
+
+    def _calculate_backoff_delay(self, attempt: int) -> float:
+        """Calculate exponential backoff delay with optional jitter.
+
+        Parameters
+        ----------
+        attempt : int
+            Current attempt number (0-indexed).
+
+        Returns
+        -------
+        float
+            Delay in seconds, bounded by ``retry_config.max_wait``.
+        """
+        # Exponential growth: base_wait * 2 ** attempt, capped at max_wait.
+        delay = min(
+            self._retry_config.base_wait * (2.0**attempt),
+            self._retry_config.max_wait,
+        )
+        # Jitter: scale by [0.5, 1.5) to spread retries.
+        delay *= 0.5 + random.random()  # nosec B311
+        return delay
+
+
+__all__ = ["FraserSession"]

--- a/src/market/fraser/types.py
+++ b/src/market/fraser/types.py
@@ -177,8 +177,10 @@ class DocType(str, Enum):
     """FRASER document type identifier.
 
     Inherits from ``str`` so members may be used directly as dictionary
-    keys (e.g., into ``KNOWN_TITLE_IDS`` / ``DOC_TYPE_SUBDIRS``) and
-    serialised without manual conversion.
+    keys (e.g., into ``KNOWN_TITLE_IDS``) and serialised without manual
+    conversion. The associated on-disk subdirectory is exposed via the
+    :attr:`subdir` property so adding a new ``DocType`` only requires
+    edits to this enum (OCP-friendly).
 
     Members
     -------
@@ -199,6 +201,8 @@ class DocType(str, Enum):
     --------
     >>> DocType.FOMC_MINUTES.value
     'fomc_minutes'
+    >>> DocType.FOMC_MINUTES.subdir
+    'fomc/minutes'
     >>> DocType.FOMC_MINUTES == "fomc_minutes"
     True
     """
@@ -210,14 +214,35 @@ class DocType(str, Enum):
     FRB_SPEECHES = "frb_speeches"
     MONETARY_POLICY_REPORT = "monetary_policy_report"
 
+    @property
+    def subdir(self) -> str:
+        """On-disk subdirectory under ``data/raw/fraser`` for this document type."""
+        return _DOC_TYPE_SUBDIR_MAP[self.value]
+
+
+# Internal map kept private; exposed via :pyattr:`DocType.subdir` to keep
+# the subdir owner inside the ``DocType`` boundary.
+_DOC_TYPE_SUBDIR_MAP: dict[str, str] = {
+    "fomc_minutes": "fomc/minutes",
+    "fomc_statements": "fomc/statements",
+    "fomc_press_conferences": "fomc/press_conferences",
+    "beige_book": "beige_book",
+    "frb_speeches": "speeches",
+    "monetary_policy_report": "monetary_policy",
+}
+
 
 # =============================================================================
 # Module exports
 # =============================================================================
 
+# ``FetchOptions`` is intentionally omitted from ``__all__``: it has no
+# consumer in the current FRASER surface. The class stays importable
+# (``from market.fraser.types import FetchOptions``) for forward
+# compatibility, but is not advertised to ``import *`` users.
 __all__ = [
     "DocType",
-    "FetchOptions",
     "FraserConfig",
+    "PreferFormat",
     "RetryConfig",
 ]

--- a/src/market/fraser/types.py
+++ b/src/market/fraser/types.py
@@ -1,0 +1,217 @@
+"""Type definitions for the market.fraser module.
+
+This module provides type definitions for FRASER REST API data retrieval
+including:
+
+- Configuration dataclasses (``FraserConfig``, ``RetryConfig``,
+  ``FetchOptions``).
+- Document type Enum (``DocType``).
+
+All dataclasses use ``frozen=True`` to ensure immutability.
+``FraserConfig.api_key`` uses ``repr=False`` to prevent the API key
+from leaking into log messages or stack traces (CWE-532).
+
+See Also
+--------
+market.alphavantage.types : Similar frozen-dataclass + ``__post_init__``
+    validation pattern for the Alpha Vantage module.
+market.fraser.constants : Default values referenced by ``FraserConfig``.
+market.fraser.errors : ``FraserValidationError`` raised by
+    ``FraserConfig.__post_init__``.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+from market.fraser.constants import (
+    BASE_URL,
+    DEFAULT_REQUESTS_PER_HOUR,
+    DEFAULT_REQUESTS_PER_MINUTE,
+    DEFAULT_TIMEOUT,
+)
+from market.fraser.errors import FraserValidationError
+
+# =============================================================================
+# Configuration Dataclasses
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    """Configuration for retry behaviour with exponential backoff.
+
+    Parameters
+    ----------
+    max_attempts : int
+        Maximum number of retry attempts (default: 5).
+    base_wait : float
+        Initial wait between retries in seconds (default: 1.0).
+    max_wait : float
+        Maximum wait between retries in seconds (default: 60.0).
+
+    Examples
+    --------
+    >>> config = RetryConfig(max_attempts=3, base_wait=2.0)
+    >>> config.max_attempts
+    3
+    """
+
+    max_attempts: int = 5
+    base_wait: float = 1.0
+    max_wait: float = 60.0
+
+
+@dataclass(frozen=True)
+class FraserConfig:
+    """Configuration for FRASER REST API client.
+
+    Controls authentication credentials, HTTP behaviour, rate limiting,
+    and retry policy.
+
+    Parameters
+    ----------
+    api_key : str
+        FRASER API key. If empty, read from ``FRASER_API_KEY``
+        environment variable at runtime. Excluded from ``repr`` output
+        for security (CWE-532).
+    base_url : str
+        Base URL for the FRASER REST API (default: ``BASE_URL``).
+    timeout : float
+        HTTP request timeout in seconds (default: ``DEFAULT_TIMEOUT``
+        = 30.0). Must be ``> 0``.
+    requests_per_minute : int
+        Maximum number of API requests per minute (default:
+        ``DEFAULT_REQUESTS_PER_MINUTE`` = 30). Must be ``>= 1``.
+    requests_per_hour : int
+        Maximum number of API requests per hour (default:
+        ``DEFAULT_REQUESTS_PER_HOUR`` = 1800).
+    retry_config : RetryConfig
+        Retry policy for transient failures.
+
+    Raises
+    ------
+    FraserValidationError
+        If ``timeout <= 0`` or ``requests_per_minute < 1``.
+
+    Examples
+    --------
+    >>> config = FraserConfig(api_key="demo")
+    >>> config.timeout
+    30.0
+    >>> "demo" not in repr(config)  # api_key is hidden (CWE-532)
+    True
+    """
+
+    api_key: str = field(default="", repr=False)
+    base_url: str = BASE_URL
+    timeout: float = DEFAULT_TIMEOUT
+    requests_per_minute: int = DEFAULT_REQUESTS_PER_MINUTE
+    requests_per_hour: int = DEFAULT_REQUESTS_PER_HOUR
+    retry_config: RetryConfig = field(default_factory=RetryConfig)
+
+    def __post_init__(self) -> None:
+        """Validate configuration value ranges.
+
+        Raises
+        ------
+        FraserValidationError
+            If ``timeout <= 0`` or ``requests_per_minute < 1``.
+        """
+        if self.timeout <= 0:
+            raise FraserValidationError(
+                f"timeout must be positive, got {self.timeout}",
+                field="timeout",
+                value=self.timeout,
+            )
+        if self.requests_per_minute < 1:
+            raise FraserValidationError(
+                f"requests_per_minute must be >= 1, got {self.requests_per_minute}",
+                field="requests_per_minute",
+                value=self.requests_per_minute,
+            )
+
+
+@dataclass(frozen=True)
+class FetchOptions:
+    """Options for FRASER API fetch requests.
+
+    Parameters
+    ----------
+    use_cache : bool
+        Whether to use cached data if available (default: True).
+    prefer : str
+        Preferred asset format when both PDF and text are available
+        (default: ``"txt"``).
+    download_dir : Path | None
+        Optional override for the download destination directory.
+        When ``None``, the collector's default download directory is
+        used.
+
+    Examples
+    --------
+    >>> options = FetchOptions(use_cache=False, prefer="pdf")
+    >>> options.use_cache
+    False
+    >>> options.prefer
+    'pdf'
+    """
+
+    use_cache: bool = True
+    prefer: str = "txt"
+    download_dir: Path | None = None
+
+
+# =============================================================================
+# Document Type Enum
+# =============================================================================
+
+
+class DocType(str, Enum):
+    """FRASER document type identifier.
+
+    Inherits from ``str`` so members may be used directly as dictionary
+    keys (e.g., into ``KNOWN_TITLE_IDS`` / ``DOC_TYPE_SUBDIRS``) and
+    serialised without manual conversion.
+
+    Members
+    -------
+    FOMC_MINUTES
+        Federal Open Market Committee minutes.
+    FOMC_STATEMENTS
+        FOMC policy statements.
+    FOMC_PRESS_CONFERENCES
+        FOMC chair press conference transcripts.
+    BEIGE_BOOK
+        Federal Reserve Beige Book.
+    FRB_SPEECHES
+        Federal Reserve Board speeches.
+    MONETARY_POLICY_REPORT
+        Monetary Policy Report to the Congress.
+
+    Examples
+    --------
+    >>> DocType.FOMC_MINUTES.value
+    'fomc_minutes'
+    >>> DocType.FOMC_MINUTES == "fomc_minutes"
+    True
+    """
+
+    FOMC_MINUTES = "fomc_minutes"
+    FOMC_STATEMENTS = "fomc_statements"
+    FOMC_PRESS_CONFERENCES = "fomc_press_conferences"
+    BEIGE_BOOK = "beige_book"
+    FRB_SPEECHES = "frb_speeches"
+    MONETARY_POLICY_REPORT = "monetary_policy_report"
+
+
+# =============================================================================
+# Module exports
+# =============================================================================
+
+__all__ = [
+    "DocType",
+    "FetchOptions",
+    "FraserConfig",
+    "RetryConfig",
+]

--- a/src/market/fraser/types.py
+++ b/src/market/fraser/types.py
@@ -23,6 +23,7 @@ market.fraser.errors : ``FraserValidationError`` raised by
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 from market.fraser.constants import (
     BASE_URL,
@@ -31,6 +32,11 @@ from market.fraser.constants import (
     DEFAULT_TIMEOUT,
 )
 from market.fraser.errors import FraserValidationError
+
+# Allowed values for asset format selection. Used as a single source of
+# truth across ``FetchOptions``, ``FraserDownloader``, and fetcher APIs
+# so a typo (e.g. ``"PDF"``) is caught at type-check time.
+PreferFormat = Literal["txt", "pdf"]
 
 # =============================================================================
 # Configuration Dataclasses
@@ -158,7 +164,7 @@ class FetchOptions:
     """
 
     use_cache: bool = True
-    prefer: str = "txt"
+    prefer: PreferFormat = "txt"
     download_dir: Path | None = None
 
 

--- a/tests/market/fraser/conftest.py
+++ b/tests/market/fraser/conftest.py
@@ -405,3 +405,32 @@ def fraser_env_key(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatch fixture.
     """
     monkeypatch.setenv("FRASER_API_KEY", "dummy_test_key")
+
+
+# =============================================================================
+# Cache fixture (PR review MEDIUM follow-up)
+# =============================================================================
+
+
+@pytest.fixture
+def fraser_cache() -> Any:
+    """Yield a per-test :class:`market.cache.cache.SQLiteCache` and close it.
+
+    Centralises the ``try / finally: cache.close()`` boilerplate that
+    used to live in every ``test_client.py`` test (PR review MEDIUM
+    follow-up). The default backing store is in-memory so each test gets
+    an isolated cache without leaking state.
+
+    Yields
+    ------
+    SQLiteCache
+        Freshly-constructed cache instance. Pytest's teardown closes
+        the cache automatically.
+    """
+    from market.cache.cache import SQLiteCache
+
+    cache = SQLiteCache()
+    try:
+        yield cache
+    finally:
+        cache.close()

--- a/tests/market/fraser/conftest.py
+++ b/tests/market/fraser/conftest.py
@@ -65,6 +65,196 @@ def sample_fraser_config() -> FraserConfig:
 
 
 @pytest.fixture
+def sample_beige_book_items_response() -> dict[str, object]:
+    """Sample FRASER Beige Book ``/title/.../items`` style response.
+
+    Provides 4 items spanning 2023-2024 plus 1 historical 1995 entry
+    so that year-range filtering can be exercised. The 2024 items
+    include both PDF-only and PDF+TXT location variants.
+
+    Returns
+    -------
+    dict[str, object]
+        Mock JSON response containing 5 Beige Book items.
+    """
+    return {
+        "titleId": 1234,
+        "name": "Beige Book",
+        "items": [
+            {
+                "itemId": 2001,
+                "titleId": 1234,
+                "title": "Beige Book, January 2023",
+                "date": "2023-01-18",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/2001.pdf"],
+                    "textUrl": ["https://fraser.stlouisfed.org/files/doc/2001.txt"],
+                },
+            },
+            {
+                "itemId": 2002,
+                "titleId": 1234,
+                "title": "Beige Book, October 2023",
+                "date": "2023-10-18",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/2002.pdf"],
+                },
+            },
+            {
+                "itemId": 2003,
+                "titleId": 1234,
+                "title": "Beige Book, March 2024",
+                "date": "2024-03-06",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/2003.pdf"],
+                    "textUrl": ["https://fraser.stlouisfed.org/files/doc/2003.txt"],
+                },
+            },
+            {
+                "itemId": 2004,
+                "titleId": 1234,
+                "title": "Beige Book, September 2024",
+                "date": "2024-09-04",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/2004.pdf"],
+                },
+            },
+            {
+                "itemId": 2099,
+                "titleId": 1234,
+                "title": "Historical Beige Book Document",
+                "date": "1995",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_speech_items_response() -> dict[str, object]:
+    """Sample FRASER FRB Speeches ``/title/.../items`` style response.
+
+    Includes speeches from multiple speakers (Powell, Volcker) in both
+    modern (2024) and historical (1980) years so that speaker filtering
+    and historical-archive year ranges can be exercised. Speaker
+    metadata is attached via the ``authors[]`` field.
+
+    Returns
+    -------
+    dict[str, object]
+        Mock JSON response containing 5 speech items.
+    """
+    return {
+        "titleId": 5678,
+        "name": "Speeches and Statements",
+        "items": [
+            {
+                "itemId": 3001,
+                "titleId": 5678,
+                "title": "Economic Outlook",
+                "date": "2024-02-07",
+                "authors": [{"name": "Jerome H. Powell", "role": "speaker"}],
+                "location": {
+                    "textUrl": ["https://fraser.stlouisfed.org/files/doc/3001.txt"],
+                },
+            },
+            {
+                "itemId": 3002,
+                "titleId": 5678,
+                "title": "Monetary Policy and Inflation",
+                "date": "2024-05-15",
+                "authors": [{"name": "Jerome H. Powell", "role": "speaker"}],
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/3002.pdf"],
+                },
+            },
+            {
+                "itemId": 3003,
+                "titleId": 5678,
+                "title": "Financial Stability",
+                "date": "2024-09-21",
+                "authors": [{"name": "Lisa D. Cook", "role": "speaker"}],
+            },
+            {
+                "itemId": 3004,
+                "titleId": 5678,
+                "title": "Anti-Inflation Strategy",
+                "date": "1980-10-09",
+                "authors": [{"name": "Paul A. Volcker", "role": "speaker"}],
+            },
+            {
+                "itemId": 3005,
+                "titleId": 5678,
+                "title": "Speech without author metadata",
+                "date": "2024-06-01",
+                "description": "Delivered by Powell at the Jackson Hole symposium",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_mpr_items_response() -> dict[str, object]:
+    """Sample FRASER Monetary Policy Report ``/title/.../items`` response.
+
+    Includes modern semi-annual reports (2024 Feb / Jul) plus a
+    Humphrey-Hawkins-era report (1979 Jul) and a 2000 report so that
+    historical archive lookups can be exercised. All items are
+    PDF-only because the legacy archive rarely exposes TXT renditions.
+
+    Returns
+    -------
+    dict[str, object]
+        Mock JSON response containing 4 Monetary Policy Report items.
+    """
+    return {
+        "titleId": 9012,
+        "name": "Monetary Policy Report to the Congress",
+        "items": [
+            {
+                "itemId": 4001,
+                "titleId": 9012,
+                "title": "Monetary Policy Report - February 2024",
+                "date": "2024-02-09",
+                "reportPeriod": "February 2024",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/4001.pdf"],
+                },
+            },
+            {
+                "itemId": 4002,
+                "titleId": 9012,
+                "title": "Monetary Policy Report - July 2024",
+                "date": "2024-07-05",
+                "reportPeriod": "July 2024",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/4002.pdf"],
+                },
+            },
+            {
+                "itemId": 4099,
+                "titleId": 9012,
+                "title": "Monetary Policy Report - July 1979 (Humphrey-Hawkins)",
+                "date": "1979-07-17",
+                "reportPeriod": "July 1979",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/4099.pdf"],
+                },
+            },
+            {
+                "itemId": 4100,
+                "titleId": 9012,
+                "title": "Monetary Policy Report - July 2000",
+                "date": "2000-07-20",
+                "reportPeriod": "July 2000",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/4100.pdf"],
+                },
+            },
+        ],
+    }
+
+
+@pytest.fixture
 def sample_fomc_items_response() -> dict[str, object]:
     """Sample FRASER ``/title/677/items`` style response with 5 items.
 

--- a/tests/market/fraser/conftest.py
+++ b/tests/market/fraser/conftest.py
@@ -1,0 +1,217 @@
+"""Pytest configuration and shared fixtures for ``market.fraser`` tests.
+
+This module provides reusable fixtures for testing the FRASER REST API
+client module, including a test-friendly ``FraserConfig``, mock HTTP
+responses, a sample FOMC items JSON payload, an isolated download
+directory, and ``FRASER_API_KEY`` injection via ``monkeypatch``.
+
+Fixtures
+--------
+sample_fraser_config : FraserConfig
+    Test-friendly ``FraserConfig`` with short timeout.
+sample_fomc_items_response : dict[str, object]
+    Sample FRASER ``/title/677/items`` style response with 5 items
+    covering the camelCase ↔ snake_case alias path.
+mock_httpx_response_factory : Callable[..., MagicMock]
+    Factory producing ``MagicMock(spec=httpx.Response)`` instances with
+    configurable ``status_code`` / ``json_data`` / ``headers`` /
+    ``chunks``.
+fraser_data_dir : Path
+    Isolated download directory rooted at ``tmp_path``.
+fraser_env_key (autouse) : None
+    Sets ``FRASER_API_KEY=dummy_test_key`` for the duration of each
+    test via ``monkeypatch.setenv``.
+
+See Also
+--------
+tests.market.alphavantage.conftest : Reference fixture template
+    (``sample_alphavantage_config``, ``mock_alphavantage_session``).
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from market.fraser.types import FraserConfig
+
+# =============================================================================
+# Configuration fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_fraser_config() -> FraserConfig:
+    """Create a test-friendly ``FraserConfig`` with short timeout.
+
+    Returns
+    -------
+    FraserConfig
+        ``FraserConfig`` with ``api_key="dummy_test_key"``,
+        ``timeout=5.0`` and default rate limits.
+    """
+    return FraserConfig(
+        api_key="dummy_test_key",
+        timeout=5.0,
+    )
+
+
+# =============================================================================
+# API response fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_fomc_items_response() -> dict[str, object]:
+    """Sample FRASER ``/title/677/items`` style response with 5 items.
+
+    The payload deliberately mixes:
+
+    - All three accepted ``date`` formats (``YYYY-MM-DD``, ``YYYY-MM``,
+      ``YYYY``).
+    - camelCase aliases (``itemId``, ``titleId``, ``pdfUrl``,
+      ``textUrl``) so that ``populate_by_name=True`` is exercised.
+    - Items both with and without an embedded ``location`` block.
+
+    Returns
+    -------
+    dict[str, object]
+        Mock JSON response containing 5 items under the ``items`` key
+        plus minimal title metadata.
+    """
+    return {
+        "titleId": 677,
+        "name": "Federal Open Market Committee",
+        "items": [
+            {
+                "itemId": 1001,
+                "titleId": 677,
+                "title": "Minutes of the Federal Open Market Committee, January 2024",
+                "date": "2024-01-31",
+                "description": "FOMC Minutes January 2024 meeting",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/1001.pdf"],
+                    "textUrl": ["https://fraser.stlouisfed.org/files/doc/1001.txt"],
+                },
+            },
+            {
+                "itemId": 1002,
+                "titleId": 677,
+                "title": "Minutes of the Federal Open Market Committee, March 2024",
+                "date": "2024-03-20",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/1002.pdf"],
+                },
+            },
+            {
+                "itemId": 1003,
+                "titleId": 677,
+                "title": "Minutes of the Federal Open Market Committee, April 2024",
+                "date": "2024-04",
+            },
+            {
+                "itemId": 1004,
+                "titleId": 677,
+                "title": "Historical FOMC Document",
+                "date": "1995",
+            },
+            {
+                "itemId": 1005,
+                "titleId": 677,
+                "title": "Minutes of the Federal Open Market Committee, June 2024",
+                "date": "2024-06-12",
+                "location": {
+                    "pdfUrl": ["https://fraser.stlouisfed.org/files/doc/1005.pdf"],
+                    "textUrl": ["https://fraser.stlouisfed.org/files/doc/1005.txt"],
+                },
+            },
+        ],
+    }
+
+
+# =============================================================================
+# Mock object fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_httpx_response_factory() -> Callable[..., MagicMock]:
+    """Factory producing ``MagicMock(spec=httpx.Response)`` instances.
+
+    Returns
+    -------
+    Callable[..., MagicMock]
+        Function with signature ``(status_code, json_data, headers=None,
+        chunks=None)`` returning a configured ``MagicMock``. The mock
+        exposes ``status_code``, ``headers``, ``json()`` (returning
+        ``json_data``), ``text`` (JSON-serialised ``json_data``), and
+        ``iter_bytes()`` (yielding ``chunks`` when provided).
+    """
+
+    def _factory(
+        status_code: int,
+        json_data: dict[str, Any] | None,
+        headers: dict[str, str] | None = None,
+        chunks: list[bytes] | None = None,
+    ) -> MagicMock:
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = status_code
+        response.headers = headers or {}
+        response.json.return_value = json_data
+        # Provide a ``text`` attribute mirroring the JSON-encoded body.
+        if json_data is not None:
+            import json as _json
+
+            response.text = _json.dumps(json_data)
+        else:
+            response.text = ""
+        if chunks is not None:
+            response.iter_bytes.return_value = iter(chunks)
+        return response
+
+    return _factory
+
+
+# =============================================================================
+# Filesystem fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def fraser_data_dir(tmp_path: Path) -> Path:
+    """Isolated download directory for FRASER tests.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Pytest-provided temporary directory.
+
+    Returns
+    -------
+    Path
+        Path to a freshly-created ``fraser/`` directory under
+        ``tmp_path``.
+    """
+    target = tmp_path / "fraser"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+# =============================================================================
+# Environment fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def fraser_env_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject ``FRASER_API_KEY=dummy_test_key`` for every test.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("FRASER_API_KEY", "dummy_test_key")

--- a/tests/market/fraser/integration/__init__.py
+++ b/tests/market/fraser/integration/__init__.py
@@ -1,0 +1,12 @@
+"""Integration tests for the ``market.fraser`` package.
+
+These tests exercise the real FRASER REST API and require the
+``FRASER_API_KEY`` environment variable to be set. They are tagged with
+``pytest.mark.integration`` so that the default ``make test`` run skips
+them.
+
+See Also
+--------
+tests.market.alphavantage.integration : Reference layout for live API
+    integration tests.
+"""

--- a/tests/market/fraser/integration/test_fraser_integration.py
+++ b/tests/market/fraser/integration/test_fraser_integration.py
@@ -1,0 +1,153 @@
+"""Integration tests for the FRASER REST API client (live HTTP).
+
+These tests hit the real FRASER endpoints and are gated by the
+``FRASER_API_KEY`` environment variable — the module is skipped when the
+key is absent. The ``FraserClient`` fixture is module-scoped so that the
+30 req/min rate limiter state is shared across all tests, ensuring the
+entire file completes within a single rate-limit window.
+
+Coverage
+--------
+- ``FraserClient.list_items(title_id=677)`` returns ``FraserItem`` models.
+- ``FOMCMinutesFetcher.list_minutes((2024, 2024))`` returns at least
+  6 ``FOMCMeeting`` entries (calendar year 2024 has 8 FOMC meetings).
+- ``FOMCMinutesFetcher.fetch_text`` writes ``<YYYY-MM-DD>_<itemId>.txt``
+  (> 1 KB) and a ``.meta.json`` sidecar.
+
+Run with::
+
+    FRASER_API_KEY=<key> uv run pytest \\
+        tests/market/fraser/integration/ -m integration -v
+
+See Also
+--------
+tests.market.alphavantage.integration.test_alphavantage_integration :
+    Reference live-API integration test pattern
+    (``pytestmark`` + ``_has_api_key`` + ``scope='module'`` fixture).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from market.fraser.client import FraserClient
+from market.fraser.downloader import FraserDownloader
+from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+from market.fraser.models import FOMCMeeting, FraserItem
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Module-level markers
+# ---------------------------------------------------------------------------
+
+
+def _has_api_key() -> bool:
+    """Return ``True`` when the FRASER API key is available."""
+    return bool(os.environ.get("FRASER_API_KEY"))
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _has_api_key(),
+        reason="FRASER_API_KEY not set -- skipping live API tests",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def fraser_client() -> Generator[FraserClient]:
+    """Build a module-scoped :class:`FraserClient` reading the env key.
+
+    Module scope is essential so that the underlying ``DualWindowRateLimiter``
+    state is shared between tests — otherwise the 30 req/min cap could be
+    breached if a fresh limiter were instantiated per test.
+
+    Yields
+    ------
+    FraserClient
+        A live client using the ``FRASER_API_KEY`` environment variable.
+    """
+    client = FraserClient()
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFraserClientListItems:
+    """E2E coverage for :meth:`FraserClient.list_items`."""
+
+    def test_E2E_FraserClient_list_items_titleId_677(
+        self, fraser_client: FraserClient
+    ) -> None:
+        items = fraser_client.list_items(title_id=677, limit=10)
+        assert len(items) >= 1
+        assert all(isinstance(i, FraserItem) for i in items)
+
+
+class TestFOMCMinutesFetcherListMinutes:
+    """E2E coverage for :meth:`FOMCMinutesFetcher.list_minutes`."""
+
+    def test_E2E_FOMCMinutesFetcher_list_minutes_2024(
+        self, fraser_client: FraserClient
+    ) -> None:
+        fetcher = FOMCMinutesFetcher(client=fraser_client)
+        meetings = fetcher.list_minutes(year_range=(2024, 2024))
+        # Calendar year 2024 should expose at least 6 of the 8 FOMC meetings.
+        assert len(meetings) >= 6
+        assert all(isinstance(m, FOMCMeeting) for m in meetings)
+        assert all(m.date.year == 2024 for m in meetings)
+
+
+class TestFOMCMinutesFetcherFetchText:
+    """E2E coverage for :meth:`FOMCMinutesFetcher.fetch_text`."""
+
+    def test_E2E_fetch_text_txt_size_over_1KB(
+        self, fraser_client: FraserClient, tmp_path: Path
+    ) -> None:
+        fetcher = FOMCMinutesFetcher(
+            client=fraser_client,
+            downloader=FraserDownloader(
+                session=fraser_client._session, base_dir=tmp_path
+            ),
+        )
+        meetings = fetcher.list_minutes(year_range=(2024, 2024))
+        assert meetings, "No 2024 FOMC meetings returned"
+
+        # Pick the first item that exposes either txt or pdf URLs.
+        item_id = next(
+            (
+                m.item_id
+                for m in meetings
+                if m.location is not None
+                and (m.location.text_url or m.location.pdf_url)
+            ),
+            None,
+        )
+        if item_id is None:
+            pytest.skip("No 2024 FOMC item exposes downloadable URLs")
+
+        path, meeting = fetcher.fetch_text(item_id, prefer="txt")
+
+        assert path.exists()
+        assert path.stat().st_size > 1024
+        meta_path = path.with_suffix(".meta.json")
+        assert meta_path.exists()
+        assert isinstance(meeting, FOMCMeeting)

--- a/tests/market/fraser/integration/test_fraser_integration.py
+++ b/tests/market/fraser/integration/test_fraser_integration.py
@@ -34,8 +34,13 @@ from typing import TYPE_CHECKING
 import pytest
 
 from market.fraser.client import FraserClient
+from market.fraser.constants import KNOWN_TITLE_IDS
 from market.fraser.downloader import FraserDownloader
-from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+from market.fraser.fetchers.fomc import (
+    FOMCMinutesFetcher,
+    FOMCPressConferencesFetcher,
+    FOMCStatementsFetcher,
+)
 from market.fraser.models import FOMCMeeting, FraserItem
 
 if TYPE_CHECKING:
@@ -151,3 +156,52 @@ class TestFOMCMinutesFetcherFetchText:
         meta_path = path.with_suffix(".meta.json")
         assert meta_path.exists()
         assert isinstance(meeting, FOMCMeeting)
+
+
+# ---------------------------------------------------------------------------
+# FOMCStatementsFetcher / FOMCPressConferencesFetcher E2E smoke tests
+# ---------------------------------------------------------------------------
+
+# These two fetchers depend on FRASER ``title_id`` values that are not
+# yet hard-coded in :data:`KNOWN_TITLE_IDS`. The integration tests are
+# skipped automatically when the title_id is unknown so that the E2E
+# suite remains green until task-2 (discover_titles) populates the
+# mapping (per project-108 plan).
+
+
+class TestFOMCStatementsFetcherE2E:
+    """E2E smoke coverage for :class:`FOMCStatementsFetcher`."""
+
+    def test_E2E_FOMCStatementsFetcher_list_statements_2024(
+        self, fraser_client: FraserClient
+    ) -> None:
+        if KNOWN_TITLE_IDS.get("fomc_statements") is None:
+            pytest.skip(
+                "title_id for 'fomc_statements' is not yet configured "
+                "(run discover_titles to populate)"
+            )
+        fetcher = FOMCStatementsFetcher(client=fraser_client)
+        statements = fetcher.list_statements(year_range=(2024, 2024))
+        # Calendar year 2024 has 8 FOMC meetings; accept >= 1 to keep
+        # the smoke test tolerant of partial coverage in FRASER.
+        assert len(statements) >= 1
+        assert all(isinstance(m, FOMCMeeting) for m in statements)
+        assert all(m.date.year == 2024 for m in statements)
+
+
+class TestFOMCPressConferencesFetcherE2E:
+    """E2E smoke coverage for :class:`FOMCPressConferencesFetcher`."""
+
+    def test_E2E_FOMCPressConferencesFetcher_list_press_conferences_2024(
+        self, fraser_client: FraserClient
+    ) -> None:
+        if KNOWN_TITLE_IDS.get("fomc_press_conferences") is None:
+            pytest.skip(
+                "title_id for 'fomc_press_conferences' is not yet configured "
+                "(run discover_titles to populate)"
+            )
+        fetcher = FOMCPressConferencesFetcher(client=fraser_client)
+        press_confs = fetcher.list_press_conferences(year_range=(2024, 2024))
+        assert len(press_confs) >= 1
+        assert all(isinstance(m, FOMCMeeting) for m in press_confs)
+        assert all(m.date.year == 2024 for m in press_confs)

--- a/tests/market/fraser/integration/test_fraser_integration.py
+++ b/tests/market/fraser/integration/test_fraser_integration.py
@@ -36,12 +36,21 @@ import pytest
 from market.fraser.client import FraserClient
 from market.fraser.constants import KNOWN_TITLE_IDS
 from market.fraser.downloader import FraserDownloader
+from market.fraser.fetchers.beige_book import BeigeBookFetcher
 from market.fraser.fetchers.fomc import (
     FOMCMinutesFetcher,
     FOMCPressConferencesFetcher,
     FOMCStatementsFetcher,
 )
-from market.fraser.models import FOMCMeeting, FraserItem
+from market.fraser.fetchers.monetary_policy import MonetaryPolicyReportFetcher
+from market.fraser.fetchers.speeches import FRBSpeechFetcher
+from market.fraser.models import (
+    BeigeBookReport,
+    FOMCMeeting,
+    FraserItem,
+    FRBSpeech,
+    MonetaryPolicyReport,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -205,3 +214,69 @@ class TestFOMCPressConferencesFetcherE2E:
         assert len(press_confs) >= 1
         assert all(isinstance(m, FOMCMeeting) for m in press_confs)
         assert all(m.date.year == 2024 for m in press_confs)
+
+
+# ---------------------------------------------------------------------------
+# PR4 後半: Beige Book / FRB Speeches / Monetary Policy Report E2E smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestBeigeBookFetcherE2E:
+    """E2E smoke coverage for :class:`BeigeBookFetcher`."""
+
+    def test_E2E_BeigeBookFetcher_list_reports_2024(
+        self, fraser_client: FraserClient
+    ) -> None:
+        if KNOWN_TITLE_IDS.get("beige_book") is None:
+            pytest.skip(
+                "title_id for 'beige_book' is not yet configured "
+                "(run discover_titles to populate)"
+            )
+        fetcher = BeigeBookFetcher(client=fraser_client)
+        reports = fetcher.list_reports(year_range=(2024, 2024))
+        # Calendar year 2024 has 8 Beige Book releases; accept >= 1 to keep
+        # the smoke test tolerant of partial coverage in FRASER.
+        assert len(reports) >= 1
+        assert all(isinstance(r, BeigeBookReport) for r in reports)
+        assert all(r.date.year == 2024 for r in reports)
+
+
+class TestFRBSpeechFetcherE2E:
+    """E2E smoke coverage for :class:`FRBSpeechFetcher`."""
+
+    def test_E2E_FRBSpeechFetcher_list_speeches_Powell_2024(
+        self, fraser_client: FraserClient
+    ) -> None:
+        if KNOWN_TITLE_IDS.get("frb_speeches") is None:
+            pytest.skip(
+                "title_id for 'frb_speeches' is not yet configured "
+                "(run discover_titles to populate)"
+            )
+        fetcher = FRBSpeechFetcher(client=fraser_client)
+        powell_speeches = fetcher.list_speeches(
+            year_range=(2024, 2024), speaker="Powell"
+        )
+        # Powell delivers several speeches per year; accept >= 1 to be
+        # tolerant of partial coverage.
+        assert len(powell_speeches) >= 1
+        assert all(isinstance(s, FRBSpeech) for s in powell_speeches)
+        assert all(s.date.year == 2024 for s in powell_speeches)
+
+
+class TestMonetaryPolicyReportFetcherE2E:
+    """E2E smoke coverage for :class:`MonetaryPolicyReportFetcher`."""
+
+    def test_E2E_MonetaryPolicyReportFetcher_list_reports_2024(
+        self, fraser_client: FraserClient
+    ) -> None:
+        if KNOWN_TITLE_IDS.get("monetary_policy_report") is None:
+            pytest.skip(
+                "title_id for 'monetary_policy_report' is not yet configured "
+                "(run discover_titles to populate)"
+            )
+        fetcher = MonetaryPolicyReportFetcher(client=fraser_client)
+        reports = fetcher.list_reports(year_range=(2024, 2024))
+        # MPR is semi-annual: 2 reports per calendar year.
+        assert len(reports) >= 1
+        assert all(isinstance(r, MonetaryPolicyReport) for r in reports)
+        assert all(r.date.year == 2024 for r in reports)

--- a/tests/market/fraser/property/test_downloader_property.py
+++ b/tests/market/fraser/property/test_downloader_property.py
@@ -1,0 +1,250 @@
+"""Property-based tests for ``market.fraser.downloader``.
+
+Verifies the atomic-rename invariant that underpins
+:meth:`FraserDownloader.download`:
+
+- On success, ``target_path`` exists and equals the full concatenation
+  of all streamed chunks.
+- On failure, ``target_path`` does **not** exist and no ``*.tmp``
+  residue is left in the destination directory.
+
+Together these properties prove that callers never observe a partially
+written file at the target location.
+
+See Also
+--------
+market.fraser.downloader : Module under test.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from market.fraser.downloader import FraserDownloader
+from market.fraser.errors import FraserDownloadError
+
+
+def _unique_subdir(tmp_path: Path) -> Path:
+    """Return a fresh, isolated sub-directory under ``tmp_path``.
+
+    Hypothesis reuses the same ``tmp_path`` for every generated example
+    (function-scoped fixtures are not reset between draws). Using a
+    UUID-named sub-directory per call gives each example its own
+    isolated workspace so leftover ``*.tmp`` glob scans never see
+    files written by an earlier example.
+    """
+    sub = tmp_path / f"hyp_{uuid.uuid4().hex}"
+    sub.mkdir(parents=True, exist_ok=True)
+    return sub
+
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+class _FakeStreamContext:
+    """Minimal context manager mimicking ``httpx.Client.stream``."""
+
+    def __init__(self, chunks: list[bytes], raise_at: int | None) -> None:
+        self._chunks = chunks
+        self._raise_at = raise_at
+
+    def __enter__(self) -> "_FakeStreamContext":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_bytes(self, chunk_size: int = 8192) -> Any:
+        for index, chunk in enumerate(self._chunks):
+            if self._raise_at is not None and index >= self._raise_at:
+                raise httpx.ReadError("simulated mid-stream failure")
+            yield chunk
+
+
+def _make_downloader(
+    chunks: list[bytes],
+    *,
+    raise_at: int | None = None,
+) -> FraserDownloader:
+    """Build a :class:`FraserDownloader` with a stub session."""
+    session = MagicMock()
+    client = MagicMock()
+    client.stream.return_value = _FakeStreamContext(chunks, raise_at)
+    session._client = client
+    return FraserDownloader(session=session)
+
+
+def _residual_tmp_files(directory: Path, stem: str) -> list[Path]:
+    """Return any ``*.tmp`` files matching the temp-file naming pattern."""
+    return list(directory.glob(f"{stem}_*.tmp"))
+
+
+# =============================================================================
+# Property tests
+# =============================================================================
+
+
+class TestDownloadAtomicRenameProperty:
+    """Atomic-rename invariant under varied chunk streams."""
+
+    @given(
+        chunks=st.lists(
+            st.binary(min_size=1, max_size=1024),
+            min_size=1,
+            max_size=8,
+        ),
+    )
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_プロパティ_成功時_target_pathが完全な内容を持つ(
+        self,
+        tmp_path: Path,
+        chunks: list[bytes],
+    ) -> None:
+        """Successful download writes the exact concatenation of all chunks."""
+        workspace = _unique_subdir(tmp_path)
+        downloader = _make_downloader(chunks)
+        target = workspace / "ok.bin"
+
+        result = downloader.download(
+            "https://fraser.stlouisfed.org/files/doc/x.bin", target
+        )
+
+        assert result == target
+        assert target.exists()
+        assert target.read_bytes() == b"".join(chunks)
+        # No tmp residue lingers in the destination directory.
+        assert _residual_tmp_files(workspace, target.stem) == []
+
+    @given(
+        chunks=st.lists(
+            st.binary(min_size=1, max_size=1024),
+            min_size=2,
+            max_size=8,
+        ),
+    )
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_プロパティ_途中失敗時_target_pathが存在しない(
+        self,
+        tmp_path: Path,
+        chunks: list[bytes],
+    ) -> None:
+        """A mid-stream failure leaves no target file and no tmp residue."""
+        workspace = _unique_subdir(tmp_path)
+        # Raise mid-stream so the rename never happens.
+        raise_at = max(1, len(chunks) // 2)
+        downloader = _make_downloader(chunks, raise_at=raise_at)
+        target = workspace / "broken.bin"
+
+        with pytest.raises(FraserDownloadError):
+            downloader.download("https://fraser.stlouisfed.org/files/doc/x.bin", target)
+
+        assert not target.exists()
+        # No partial ``*.tmp`` residue in the destination directory.
+        assert _residual_tmp_files(workspace, target.stem) == []
+
+
+class TestDownloadSkipExistingProperty:
+    """``force=False`` should skip download whenever target already exists."""
+
+    @given(
+        existing_bytes=st.binary(min_size=0, max_size=64),
+        chunks=st.lists(st.binary(min_size=1, max_size=32), min_size=1, max_size=4),
+    )
+    @settings(
+        max_examples=30,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_プロパティ_既存ファイル_force_Falseで書き換えなし(
+        self,
+        tmp_path: Path,
+        existing_bytes: bytes,
+        chunks: list[bytes],
+    ) -> None:
+        workspace = _unique_subdir(tmp_path)
+        target = workspace / "preexisting.bin"
+        target.write_bytes(existing_bytes)
+
+        client = MagicMock()
+        client.stream = MagicMock(
+            side_effect=AssertionError("should not be called when force=False"),
+        )
+        session = MagicMock()
+        session._client = client
+        downloader = FraserDownloader(session=session)
+
+        result = downloader.download(
+            "https://fraser.stlouisfed.org/files/doc/x.bin",
+            target,
+            force=False,
+        )
+
+        assert result == target
+        assert target.read_bytes() == existing_bytes
+        # The mocked client must NEVER have been touched.
+        client.stream.assert_not_called()
+
+
+# =============================================================================
+# Mid-stream-failure cleanup property (additional safety guard)
+# =============================================================================
+
+
+class TestDownloadCleanupOnUnlinkErrorProperty:
+    """Even when ``unlink`` fails, the call still raises FraserDownloadError."""
+
+    @given(
+        chunks=st.lists(st.binary(min_size=1, max_size=32), min_size=2, max_size=4),
+    )
+    @settings(
+        max_examples=20,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_プロパティ_途中失敗_unlink失敗でもFraserDownloadError(
+        self,
+        tmp_path: Path,
+        chunks: list[bytes],
+    ) -> None:
+        """A unlink() OSError in finally must not mask the FraserDownloadError."""
+        workspace = _unique_subdir(tmp_path)
+        downloader = _make_downloader(chunks, raise_at=1)
+        target = workspace / "broken.bin"
+
+        original_unlink = Path.unlink
+
+        def _flaky_unlink(self: Path, missing_ok: bool = False) -> None:
+            # Only break temp files; keep regular unlinks working.
+            if self.suffix == ".tmp":
+                raise OSError("simulated unlink failure")
+            original_unlink(self, missing_ok=missing_ok)
+
+        with (
+            patch.object(Path, "unlink", _flaky_unlink),
+            pytest.raises(FraserDownloadError),
+        ):
+            downloader.download("https://fraser.stlouisfed.org/files/doc/x.bin", target)
+
+        # target_path still must not exist (rename never happened).
+        assert not target.exists()

--- a/tests/market/fraser/property/test_downloader_property.py
+++ b/tests/market/fraser/property/test_downloader_property.py
@@ -57,6 +57,9 @@ class _FakeStreamContext:
     def __init__(self, chunks: list[bytes], raise_at: int | None) -> None:
         self._chunks = chunks
         self._raise_at = raise_at
+        # Empty integrity-header dict so ``_stream_to`` can call
+        # ``response.headers.get(...)`` without tripping ``AttributeError``.
+        self.headers: dict[str, str] = {}
 
     def __enter__(self) -> "_FakeStreamContext":
         return self

--- a/tests/market/fraser/property/test_downloader_property.py
+++ b/tests/market/fraser/property/test_downloader_property.py
@@ -52,7 +52,7 @@ def _unique_subdir(tmp_path: Path) -> Path:
 
 
 class _FakeStreamContext:
-    """Minimal context manager mimicking ``httpx.Client.stream``."""
+    """Minimal context manager mimicking the response yielded by ``stream``."""
 
     def __init__(self, chunks: list[bytes], raise_at: int | None) -> None:
         self._chunks = chunks
@@ -79,11 +79,14 @@ def _make_downloader(
     *,
     raise_at: int | None = None,
 ) -> FraserDownloader:
-    """Build a :class:`FraserDownloader` with a stub session."""
+    """Build a :class:`FraserDownloader` with a stub session.
+
+    Mocks :meth:`FraserSession.stream` (the public context manager) — the
+    downloader now invokes ``self._session.stream(url)`` rather than poking
+    ``self._session._client.stream`` directly (see PR #3967 HIGH-1 fix).
+    """
     session = MagicMock()
-    client = MagicMock()
-    client.stream.return_value = _FakeStreamContext(chunks, raise_at)
-    session._client = client
+    session.stream.return_value = _FakeStreamContext(chunks, raise_at)
     return FraserDownloader(session=session)
 
 
@@ -186,12 +189,10 @@ class TestDownloadSkipExistingProperty:
         target = workspace / "preexisting.bin"
         target.write_bytes(existing_bytes)
 
-        client = MagicMock()
-        client.stream = MagicMock(
+        session = MagicMock()
+        session.stream = MagicMock(
             side_effect=AssertionError("should not be called when force=False"),
         )
-        session = MagicMock()
-        session._client = client
         downloader = FraserDownloader(session=session)
 
         result = downloader.download(
@@ -202,8 +203,8 @@ class TestDownloadSkipExistingProperty:
 
         assert result == target
         assert target.read_bytes() == existing_bytes
-        # The mocked client must NEVER have been touched.
-        client.stream.assert_not_called()
+        # The session.stream context manager must NEVER have been touched.
+        session.stream.assert_not_called()
 
 
 # =============================================================================

--- a/tests/market/fraser/property/test_fetchers_base_property.py
+++ b/tests/market/fraser/property/test_fetchers_base_property.py
@@ -1,0 +1,123 @@
+"""Property tests for ``BaseFraserFetcher._filter_by_year_range``.
+
+The filter is a small but central helper used by every concrete fetcher
+to narrow ``list_items`` results to a calendar window. The invariants
+below guarantee that:
+
+1. Every returned item's ``date.year`` falls within ``[start, end]``.
+2. Reversed windows (``start > end``) return an empty list.
+3. The function always returns ``list`` — never ``None`` or raises.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.models import FraserItem
+from market.fraser.types import DocType
+
+
+class _DummyFetcher(BaseFraserFetcher):
+    """Minimal concrete fetcher exposing the protected filter for tests."""
+
+    @property
+    def doc_type(self) -> DocType:
+        return DocType.FOMC_MINUTES
+
+    def __init__(self) -> None:
+        # Bypass the real client / downloader wiring: property tests only
+        # call ``_filter_by_year_range`` which has no dependencies on
+        # those collaborators.
+        self._client = None
+        self._downloader = None
+
+
+_FETCHER = _DummyFetcher()
+
+
+def _make_item(year: int) -> FraserItem:
+    """Construct a minimal FraserItem with the given year."""
+    return FraserItem(
+        item_id=year * 1000,
+        title=f"item-{year}",
+        date=_dt.date(year, 1, 1),
+    )
+
+
+class TestFilterByYearRangeProperty:
+    """Property tests for the year-range filter."""
+
+    @given(
+        years=st.lists(
+            st.integers(min_value=1900, max_value=2100),
+            min_size=0,
+            max_size=50,
+        ),
+        start=st.integers(min_value=1900, max_value=2100),
+        end=st.integers(min_value=1900, max_value=2100),
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_戻り値のyearは全てwindow内(
+        self,
+        years: list[int],
+        start: int,
+        end: int,
+    ) -> None:
+        items = [_make_item(y) for y in years]
+
+        filtered = _FETCHER._filter_by_year_range(items, (start, end))
+
+        for item in filtered:
+            assert start <= item.date.year <= end
+
+    @given(
+        years=st.lists(
+            st.integers(min_value=1900, max_value=2100),
+            min_size=1,
+            max_size=20,
+        ),
+        start=st.integers(min_value=2050, max_value=2100),
+        end=st.integers(min_value=1900, max_value=2049),
+    )
+    @settings(max_examples=50)
+    def test_プロパティ_反転windowで空リスト(
+        self,
+        years: list[int],
+        start: int,
+        end: int,
+    ) -> None:
+        # By construction start > end → no year can satisfy
+        # ``start <= y <= end`` so the result must be empty.
+        items = [_make_item(y) for y in years]
+
+        filtered = _FETCHER._filter_by_year_range(items, (start, end))
+
+        assert filtered == []
+
+    @given(
+        years=st.lists(
+            st.integers(min_value=1900, max_value=2100),
+            min_size=0,
+            max_size=20,
+        ),
+        start=st.integers(min_value=1900, max_value=2100),
+        end=st.integers(min_value=1900, max_value=2100),
+    )
+    @settings(max_examples=50)
+    def test_プロパティ_常にlistを返す(
+        self,
+        years: list[int],
+        start: int,
+        end: int,
+    ) -> None:
+        items = [_make_item(y) for y in years]
+
+        filtered = _FETCHER._filter_by_year_range(items, (start, end))
+
+        assert isinstance(filtered, list)
+        # All elements (if any) are FraserItem instances.
+        assert all(isinstance(i, FraserItem) for i in filtered)

--- a/tests/market/fraser/property/test_parser_property.py
+++ b/tests/market/fraser/property/test_parser_property.py
@@ -1,0 +1,173 @@
+"""Property-based tests for ``market.fraser.parser``.
+
+Verifies the central invariant that the parser only ever raises
+:class:`FraserParseError` for invalid inputs — Pydantic
+``ValidationError`` instances must never leak out to callers. This
+matches the design contract that the rest of the package relies on
+when handling failures.
+
+Coverage
+--------
+- ``parse_items`` on arbitrary single-item payloads either returns a
+  ``list[FraserItem]`` or raises :class:`FraserParseError`. No other
+  exception type is permitted.
+- ``parse_item`` on arbitrary dict inputs has the same invariant.
+- :class:`FraserParseError` instances always carry non-empty
+  ``raw_data`` and ``field`` attributes (regression guard for the
+  error contract documented in :mod:`market.fraser.errors`).
+
+See Also
+--------
+market.fraser.parser : Module under test.
+market.fraser.errors : :class:`FraserParseError` definition.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from market.fraser.errors import FraserParseError
+from market.fraser.models import FraserItem
+from market.fraser.parser import parse_item, parse_items
+
+# =============================================================================
+# Strategies
+# =============================================================================
+
+# Reusable strategy for "any JSON-serialisable scalar".
+_json_scalar: st.SearchStrategy[Any] = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-(10**9), max_value=10**9),
+    st.floats(allow_nan=False, allow_infinity=False, width=32),
+    st.text(max_size=32),
+)
+
+# Arbitrary item-like payload: dict whose keys are short strings and
+# values are JSON scalars. Most of these payloads will fail Pydantic
+# validation (no ``itemId`` / ``title`` / ``date``) and must surface as
+# ``FraserParseError`` — never ``ValidationError``.
+_arbitrary_item_payload: st.SearchStrategy[dict[str, Any]] = st.dictionaries(
+    keys=st.text(min_size=1, max_size=12),
+    values=_json_scalar,
+    min_size=0,
+    max_size=8,
+)
+
+
+# =============================================================================
+# Property tests for parse_items
+# =============================================================================
+
+
+class TestParseItemsProperty:
+    """``parse_items`` must never raise ``ValidationError`` directly."""
+
+    @given(payload=_arbitrary_item_payload)
+    @settings(max_examples=100)
+    def test_プロパティ_parse_items単一辞書はFraserItemかFraserParseError(
+        self,
+        payload: dict[str, Any],
+    ) -> None:
+        """``parse_items({'items': [arbitrary]})`` either parses or raises FraserParseError."""
+        wrapped = {"items": [payload]}
+        try:
+            result = parse_items(wrapped)
+        except FraserParseError as exc:
+            # ``FraserParseError`` carries diagnostic metadata.
+            assert isinstance(exc.raw_data, str)
+            assert exc.raw_data != ""
+            assert isinstance(exc.field, str)
+            assert exc.field != ""
+        except ValidationError:
+            # Pydantic errors must NOT leak out of the parser.
+            msg = (
+                "ValidationError leaked from parse_items — should be wrapped "
+                "as FraserParseError"
+            )
+            raise AssertionError(msg) from None
+        else:
+            assert isinstance(result, list)
+            assert all(isinstance(item, FraserItem) for item in result)
+
+    @given(
+        payloads=st.lists(_arbitrary_item_payload, min_size=0, max_size=5),
+    )
+    @settings(max_examples=50)
+    def test_プロパティ_parse_items複数辞書はlistまたはFraserParseError(
+        self,
+        payloads: list[dict[str, Any]],
+    ) -> None:
+        wrapped = {"items": payloads}
+        try:
+            result = parse_items(wrapped)
+        except FraserParseError as exc:
+            assert isinstance(exc.raw_data, str)
+            assert exc.raw_data != ""
+            assert isinstance(exc.field, str)
+        except ValidationError:
+            msg = "ValidationError leaked from parse_items"
+            raise AssertionError(msg) from None
+        else:
+            assert isinstance(result, list)
+            assert len(result) == len(payloads)
+            assert all(isinstance(item, FraserItem) for item in result)
+
+    @given(payload=_arbitrary_item_payload)
+    @settings(max_examples=100)
+    def test_プロパティ_parse_item任意辞書はFraserItemかFraserParseError(
+        self,
+        payload: dict[str, Any],
+    ) -> None:
+        """``parse_item`` mirrors the same contract on a single payload."""
+        try:
+            result = parse_item(payload)
+        except FraserParseError as exc:
+            assert isinstance(exc.raw_data, str)
+            assert exc.raw_data != ""
+            assert isinstance(exc.field, str)
+            assert exc.field != ""
+        except ValidationError:
+            msg = "ValidationError leaked from parse_item"
+            raise AssertionError(msg) from None
+        else:
+            assert isinstance(result, FraserItem)
+
+
+# =============================================================================
+# Property tests for the well-formed-item path
+# =============================================================================
+
+
+class TestParseItemsWellFormedProperty:
+    """Well-formed items always round-trip cleanly."""
+
+    @given(
+        item_id=st.integers(min_value=1, max_value=10**9),
+        title=st.text(min_size=1, max_size=120),
+        year=st.integers(min_value=1900, max_value=2099),
+        month=st.integers(min_value=1, max_value=12),
+        day=st.integers(min_value=1, max_value=28),
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_最小限フィールドで常にFraserItem返却(
+        self,
+        item_id: int,
+        title: str,
+        year: int,
+        month: int,
+        day: int,
+    ) -> None:
+        """A payload with just ``itemId``, ``title``, ``date`` always parses."""
+        date_str = f"{year:04d}-{month:02d}-{day:02d}"
+        payload = {"itemId": item_id, "title": title, "date": date_str}
+        result = parse_items({"items": [payload]})
+        assert len(result) == 1
+        item = result[0]
+        assert item.item_id == item_id
+        assert item.title == title
+        assert item.date.year == year

--- a/tests/market/fraser/property/test_rate_limiter_property.py
+++ b/tests/market/fraser/property/test_rate_limiter_property.py
@@ -1,0 +1,150 @@
+"""Property-based tests for ``market.fraser.rate_limiter``.
+
+The FRASER rate limiter re-exports
+:class:`market.alphavantage.rate_limiter.DualWindowRateLimiter`, which
+implements a sliding-window algorithm. These property tests assert two
+invariants that callers depend on:
+
+1. After at most ``requests_per_minute`` acquisitions, the deque length
+   never exceeds ``requests_per_minute`` and
+   ``available_minute >= 0``.
+2. The :func:`get_fraser_rate_limiter` factory honours the limits set
+   on a :class:`FraserConfig`.
+
+See Also
+--------
+market.fraser.rate_limiter : Module under test.
+market.alphavantage.rate_limiter : Underlying implementation.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from market.fraser.rate_limiter import (
+    DualWindowRateLimiter,
+    get_fraser_rate_limiter,
+)
+from market.fraser.types import FraserConfig
+
+# =============================================================================
+# Strategies
+# =============================================================================
+
+minute_limits = st.integers(min_value=1, max_value=30)
+hour_limits = st.integers(min_value=1, max_value=300)
+acquire_counts = st.integers(min_value=0, max_value=20)
+
+
+# =============================================================================
+# Property tests on the re-exported limiter
+# =============================================================================
+
+
+class TestSlidingWindowInvariantProperty:
+    """Sliding-window upper-bound invariants under bounded contention."""
+
+    @given(
+        per_minute=minute_limits,
+        per_hour=hour_limits,
+        n=acquire_counts,
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_acquireのタイムスタンプ数がper_minute以下(
+        self,
+        per_minute: int,
+        per_hour: int,
+        n: int,
+    ) -> None:
+        per_hour = max(per_hour, per_minute)
+        # Cap ``n`` so we never block waiting for a slot (tests must be fast).
+        safe_n = min(n, per_minute, per_hour)
+
+        limiter = DualWindowRateLimiter(
+            requests_per_minute=per_minute,
+            requests_per_hour=per_hour,
+        )
+        for _ in range(safe_n):
+            limiter.acquire()
+
+        # Sliding-window invariant: stored timestamps cannot exceed the
+        # per-minute budget that has been consumed.
+        assert len(limiter._timestamps) <= per_minute
+        # Available capacity stays in ``[0, requests_per_minute]``.
+        assert 0 <= limiter.available_minute <= per_minute
+
+    @given(
+        per_minute=minute_limits,
+        per_hour=hour_limits,
+        n=acquire_counts,
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_使用済み数_available_minuteの和が制限数(
+        self,
+        per_minute: int,
+        per_hour: int,
+        n: int,
+    ) -> None:
+        per_hour = max(per_hour, per_minute)
+        safe_n = min(n, per_minute, per_hour)
+
+        limiter = DualWindowRateLimiter(
+            requests_per_minute=per_minute,
+            requests_per_hour=per_hour,
+        )
+        for _ in range(safe_n):
+            limiter.acquire()
+
+        # Since the test executes in well under 60 seconds, all
+        # timestamps still fall inside the minute window.
+        assert limiter.available_minute + safe_n == per_minute
+
+
+class TestFactoryProperty:
+    """``get_fraser_rate_limiter`` honours config-supplied limits."""
+
+    @given(
+        per_minute=minute_limits,
+        per_hour=hour_limits,
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_factoryが設定値の上限を継承(
+        self,
+        per_minute: int,
+        per_hour: int,
+    ) -> None:
+        per_hour = max(per_hour, per_minute)
+        config = FraserConfig(
+            api_key="dummy",
+            requests_per_minute=per_minute,
+            requests_per_hour=per_hour,
+        )
+        limiter = get_fraser_rate_limiter(config)
+
+        # Fresh limiter -> available counts equal the configured caps.
+        assert limiter.available_minute == per_minute
+        assert limiter.available_hour == per_hour
+
+
+class TestNonNegativeWaitProperty:
+    """``acquire()`` always returns a non-negative wait time."""
+
+    @given(
+        per_minute=minute_limits,
+        per_hour=hour_limits,
+    )
+    @settings(max_examples=50)
+    def test_プロパティ_acquire返り値は常に非負float(
+        self,
+        per_minute: int,
+        per_hour: int,
+    ) -> None:
+        per_hour = max(per_hour, per_minute)
+        limiter = DualWindowRateLimiter(
+            requests_per_minute=per_minute,
+            requests_per_hour=per_hour,
+        )
+        waited = limiter.acquire()
+        assert isinstance(waited, float)
+        assert waited >= 0.0

--- a/tests/market/fraser/property/test_session_property.py
+++ b/tests/market/fraser/property/test_session_property.py
@@ -1,0 +1,84 @@
+"""Property tests for ``FraserSession._calculate_backoff_delay``.
+
+Asserts the two invariants the production retry path relies on:
+
+1. ``delay >= 0`` — never schedules a sleep with a negative wait.
+2. ``delay <= max_wait * 1.5`` — the jitter scale (`[0.5, 1.5)`) keeps
+   the post-jitter delay bounded by 1.5 * the configured max_wait.
+
+Together these prevent both negative sleeps (would raise on ``time.sleep``)
+and runaway waits that exceed the retry config envelope.
+"""
+
+from __future__ import annotations
+
+import random
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from market.fraser.session import FraserSession
+from market.fraser.types import FraserConfig, RetryConfig
+
+
+def _make_session(base_wait: float, max_wait: float) -> FraserSession:
+    config = FraserConfig(
+        api_key="dummy",
+        retry_config=RetryConfig(
+            max_attempts=5,
+            base_wait=base_wait,
+            max_wait=max_wait,
+        ),
+    )
+    return FraserSession(config=config)
+
+
+class TestCalculateBackoffDelayProperty:
+    """Property tests for the exponential-backoff + jitter formula."""
+
+    @given(
+        attempt=st.integers(min_value=0, max_value=20),
+        base_wait=st.floats(min_value=0.01, max_value=10.0, allow_nan=False),
+        max_wait=st.floats(min_value=0.1, max_value=120.0, allow_nan=False),
+        seed=st.integers(min_value=0, max_value=10_000),
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_delayは常に非負(
+        self,
+        attempt: int,
+        base_wait: float,
+        max_wait: float,
+        seed: int,
+    ) -> None:
+        random.seed(seed)
+        session = _make_session(base_wait=base_wait, max_wait=max_wait)
+
+        delay = session._calculate_backoff_delay(attempt)
+
+        assert delay >= 0.0
+        session.close()
+
+    @given(
+        attempt=st.integers(min_value=0, max_value=20),
+        base_wait=st.floats(min_value=0.01, max_value=10.0, allow_nan=False),
+        max_wait=st.floats(min_value=0.1, max_value=120.0, allow_nan=False),
+        seed=st.integers(min_value=0, max_value=10_000),
+    )
+    @settings(max_examples=100)
+    def test_プロパティ_delayはmax_waitの1_5倍以下(
+        self,
+        attempt: int,
+        base_wait: float,
+        max_wait: float,
+        seed: int,
+    ) -> None:
+        random.seed(seed)
+        session = _make_session(base_wait=base_wait, max_wait=max_wait)
+
+        delay = session._calculate_backoff_delay(attempt)
+
+        # Jitter scales the capped value by [0.5, 1.5); the upper bound is
+        # therefore < max_wait * 1.5. We compare against <= to tolerate
+        # floating-point rounding.
+        assert delay <= max_wait * 1.5 + 1e-9
+        session.close()

--- a/tests/market/fraser/unit/test_cache.py
+++ b/tests/market/fraser/unit/test_cache.py
@@ -1,0 +1,148 @@
+"""Tests for ``market.fraser.cache`` module.
+
+Verifies TTL constants, the :func:`get_fraser_cache` factory,
+:func:`make_fraser_cache_key` (SHA-256 based key construction with
+collision avoidance), and that ``cache.py`` does **not** define its own
+``SQLiteCache`` subclass (HF1 confirmation).
+
+See Also
+--------
+market.fraser.cache : Module under test.
+market.alphavantage.cache : Reference implementation pattern.
+market.cache.cache : Shared ``SQLiteCache`` base.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import market.fraser.cache as cache_module
+from market.cache.cache import SQLiteCache
+from market.fraser.cache import (
+    AUTHOR_SUBJECT_THEME_TTL,
+    ITEM_METADATA_TTL,
+    ITEMS_LIST_TTL,
+    TIMELINE_TTL,
+    TITLE_METADATA_TTL,
+    get_fraser_cache,
+    make_fraser_cache_key,
+)
+
+
+class TestTTLConstants:
+    """Verify each FRASER TTL constant has the documented value."""
+
+    def test_正常系_TITLE_METADATA_TTLが30日(self) -> None:
+        assert TITLE_METADATA_TTL == 2592000
+
+    def test_正常系_ITEMS_LIST_TTLが7日(self) -> None:
+        assert ITEMS_LIST_TTL == 604800
+
+    def test_正常系_ITEM_METADATA_TTLが30日(self) -> None:
+        assert ITEM_METADATA_TTL == 2592000
+
+    def test_正常系_AUTHOR_SUBJECT_THEME_TTLが30日(self) -> None:
+        assert AUTHOR_SUBJECT_THEME_TTL == 2592000
+
+    def test_正常系_TIMELINE_TTLが7日(self) -> None:
+        assert TIMELINE_TTL == 604800
+
+    def test_正常系_全TTL定数が正の整数(self) -> None:
+        ttl_values = [
+            TITLE_METADATA_TTL,
+            ITEMS_LIST_TTL,
+            ITEM_METADATA_TTL,
+            AUTHOR_SUBJECT_THEME_TTL,
+            TIMELINE_TTL,
+        ]
+        for ttl in ttl_values:
+            assert isinstance(ttl, int)
+            assert ttl > 0
+
+
+class TestGetFraserCache:
+    """Verify :func:`get_fraser_cache` returns a configured SQLiteCache."""
+
+    def test_正常系_返り値がSQLiteCacheインスタンス(self) -> None:
+        cache = get_fraser_cache()
+        try:
+            assert isinstance(cache, SQLiteCache)
+        finally:
+            cache.close()
+
+    def test_正常系_キャッシュが有効化されている(self) -> None:
+        cache = get_fraser_cache()
+        try:
+            assert cache.config.enabled is True
+        finally:
+            cache.close()
+
+    def test_正常系_デフォルトTTLがITEM_METADATA_TTL(self) -> None:
+        cache = get_fraser_cache()
+        try:
+            assert cache.config.ttl_seconds == ITEM_METADATA_TTL
+        finally:
+            cache.close()
+
+    def test_正常系_ttl引数を渡すと反映される(self) -> None:
+        cache = get_fraser_cache(ttl=600)
+        try:
+            assert cache.config.ttl_seconds == 600
+        finally:
+            cache.close()
+
+    def test_正常系_max_entriesが10000(self) -> None:
+        cache = get_fraser_cache()
+        try:
+            assert cache.config.max_entries == 10000
+        finally:
+            cache.close()
+
+
+class TestMakeFraserCacheKey:
+    """Verify :func:`make_fraser_cache_key` builds collision-safe keys."""
+
+    def test_正常系_fraserプレフィックス付き(self) -> None:
+        key = make_fraser_cache_key("/items", {"titleId": 677})
+        assert key.startswith("fraser:")
+
+    def test_正常系_SHA256ダイジェスト長(self) -> None:
+        key = make_fraser_cache_key("/items", {"titleId": 677})
+        # ``"fraser:"`` (7) + SHA-256 hex (64) == 71 chars total.
+        assert len(key) == 7 + 64
+
+    def test_正常系_paramsの順序差で同じキー(self) -> None:
+        key_a = make_fraser_cache_key("/items", {"titleId": 677, "limit": 10})
+        key_b = make_fraser_cache_key("/items", {"limit": 10, "titleId": 677})
+        assert key_a == key_b
+
+    def test_正常系_endpoint違いで別キー(self) -> None:
+        key_a = make_fraser_cache_key("/items", {"titleId": 677})
+        key_b = make_fraser_cache_key("/title/677", {})
+        assert key_a != key_b
+
+    def test_正常系_params違いで別キー(self) -> None:
+        key_a = make_fraser_cache_key("/items", {"titleId": 677})
+        key_b = make_fraser_cache_key("/items", {"titleId": 678})
+        assert key_a != key_b
+
+    def test_正常系_空paramsでもキー生成(self) -> None:
+        key = make_fraser_cache_key("/authors", {})
+        assert key.startswith("fraser:")
+        assert len(key) == 7 + 64
+
+
+class TestNoOwnSQLiteCache:
+    """HF1: ``cache.py`` must reuse ``SQLiteCache``, not subclass it."""
+
+    def test_正常系_FraserSQLiteCacheクラスが存在しない(self) -> None:
+        # The module must not define its own SQLiteCache subclass.
+        assert not hasattr(cache_module, "FraserSQLiteCache")
+
+    def test_正常系_モジュール内にSQLiteCache継承クラスがない(self) -> None:
+        for _, obj in inspect.getmembers(cache_module, inspect.isclass):
+            if obj is SQLiteCache:
+                continue
+            assert not issubclass(obj, SQLiteCache), (
+                f"{obj.__name__} unexpectedly subclasses SQLiteCache"
+            )

--- a/tests/market/fraser/unit/test_client.py
+++ b/tests/market/fraser/unit/test_client.py
@@ -250,3 +250,70 @@ class TestMasterTables:
             )
         finally:
             cache.close()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_json branch coverage (PR review MEDIUM follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchJsonBranches:
+    """Cover the cache-hit (non-str) and json.dumps-failure paths."""
+
+    def test_正常系_cacheヒット時にnon_strがそのまま返る(self) -> None:
+        """When the cache backend returns a non-str object, ``_fetch_json``
+        returns it directly without calling ``json.loads`` (else branch).
+        """
+        # Pre-populate the cache backend so the next call short-circuits.
+        cache = SQLiteCache()
+        try:
+            client, session, _ = _build_client(
+                session_payload={"unused": True}, cache=cache
+            )
+            cached_obj: dict[str, Any] = {
+                "items": [{"itemId": 1, "title": "x", "date": "2024"}]
+            }
+            with patch.object(cache, "get", return_value=cached_obj):
+                items = client.list_items(title_id=99, limit=5)
+            # Session must not be hit because the cache returned a non-None
+            # value through the non-str branch.
+            session.get_with_retry.assert_not_called()
+            assert items[0].item_id == 1
+        finally:
+            cache.close()
+
+    def test_正常系_json_dumpsが失敗してもsetをスキップして結果を返す(self) -> None:
+        """When ``json.dumps`` raises TypeError during the cache-write
+        step, ``cache.set`` is skipped but parsing still succeeds so the
+        caller receives the parsed result.
+
+        The mock is intermittent: the first ``dumps`` invocation (cache
+        key) returns the real string, the second (cache write) raises.
+        """
+        import market.fraser.client as client_module
+
+        cache = SQLiteCache()
+        try:
+            payload = {"items": [{"itemId": 1, "title": "x", "date": "2024"}]}
+            client, _, _ = _build_client(session_payload=payload, cache=cache)
+
+            real_dumps = client_module.json.dumps
+            call_count = {"value": 0}
+
+            def _intermittent_dumps(*args: Any, **kwargs: Any) -> Any:
+                call_count["value"] += 1
+                if call_count["value"] == 1:
+                    return real_dumps(*args, **kwargs)
+                raise TypeError("simulated serialisation failure")
+
+            with (
+                patch.object(cache, "set") as cache_set,
+                patch.object(
+                    client_module.json, "dumps", side_effect=_intermittent_dumps
+                ),
+            ):
+                items = client.list_items(title_id=99, limit=5)
+            cache_set.assert_not_called()
+            assert items[0].item_id == 1
+        finally:
+            cache.close()

--- a/tests/market/fraser/unit/test_client.py
+++ b/tests/market/fraser/unit/test_client.py
@@ -1,0 +1,252 @@
+"""Tests for ``market.fraser.client`` module.
+
+Verifies the high-level :class:`FraserClient` integration:
+
+- Initialisation with explicit / env-var-backed / missing API keys.
+- Each of the 8 endpoint methods executes the cache-hit and cache-miss
+  pipelines correctly (session called on miss, skipped on hit).
+- ``use_cache=False`` bypasses cache reads but still populates the cache
+  on success.
+- Context manager protocol closes the underlying session.
+
+See Also
+--------
+market.fraser.client : Module under test.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from market.cache.cache import SQLiteCache
+from market.fraser.client import FraserClient
+from market.fraser.errors import FraserAuthError
+from market.fraser.types import FraserConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(payload: Any) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = payload
+    response.text = json.dumps(payload, default=str)
+    response.headers = {}
+    return response
+
+
+def _build_client(
+    *,
+    session_payload: Any = None,
+    cache: SQLiteCache | None = None,
+) -> tuple[FraserClient, MagicMock, SQLiteCache]:
+    session = MagicMock()
+    session.get_with_retry.return_value = _make_response(session_payload)
+    cache = cache or SQLiteCache()
+    client = FraserClient(
+        config=FraserConfig(api_key="dummy"),
+        session=session,
+        cache=cache,
+    )
+    return client, session, cache
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestFraserClientInit:
+    def test_正常系_明示configで初期化(self) -> None:
+        cache = SQLiteCache()
+        try:
+            client = FraserClient(
+                config=FraserConfig(api_key="dummy"),
+                session=MagicMock(),
+                cache=cache,
+            )
+            assert client._config.api_key == "dummy"
+        finally:
+            cache.close()
+
+    def test_正常系_環境変数からAPIキー取得(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FRASER_API_KEY", "env_key")
+        with patch("market.fraser.client.FraserSession") as mock_session_cls:
+            mock_session_cls.return_value = MagicMock()
+            cache = SQLiteCache()
+            try:
+                client = FraserClient(cache=cache)
+                assert client._config.api_key == "env_key"
+            finally:
+                cache.close()
+
+    def test_異常系_APIキーがないと_FraserAuthError(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FRASER_API_KEY", raising=False)
+        with pytest.raises(FraserAuthError):
+            FraserClient()
+
+    def test_正常系_contextマネージャでcloseされる(self) -> None:
+        cache = SQLiteCache()
+        session = MagicMock()
+        try:
+            with FraserClient(
+                config=FraserConfig(api_key="dummy"),
+                session=session,
+                cache=cache,
+            ):
+                pass
+            session.close.assert_called_once()
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# list_items
+# ---------------------------------------------------------------------------
+
+
+class TestListItems:
+    def test_正常系_cache_missで_session呼び出し(
+        self, sample_fomc_items_response: dict[str, Any]
+    ) -> None:
+        client, session, cache = _build_client(
+            session_payload=sample_fomc_items_response
+        )
+        try:
+            items = client.list_items(title_id=677, limit=10)
+            assert len(items) == 5
+            session.get_with_retry.assert_called_once_with(
+                "/items",
+                params={"titleId": 677, "limit": 10, "page": 1},
+            )
+        finally:
+            cache.close()
+
+    def test_正常系_cache_hitで_sessionが呼ばれない(
+        self, sample_fomc_items_response: dict[str, Any]
+    ) -> None:
+        client, session, cache = _build_client(
+            session_payload=sample_fomc_items_response
+        )
+        try:
+            client.list_items(title_id=677, limit=10)
+            session.get_with_retry.reset_mock()
+
+            # Second call should hit the cache.
+            items = client.list_items(title_id=677, limit=10)
+            assert len(items) == 5
+            session.get_with_retry.assert_not_called()
+        finally:
+            cache.close()
+
+    def test_正常系_use_cache_Falseはキャッシュバイパス(
+        self, sample_fomc_items_response: dict[str, Any]
+    ) -> None:
+        client, session, cache = _build_client(
+            session_payload=sample_fomc_items_response
+        )
+        try:
+            client.list_items(title_id=677, limit=10)
+            session.get_with_retry.reset_mock()
+
+            client.list_items(title_id=677, limit=10, use_cache=False)
+            session.get_with_retry.assert_called_once()
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# get_item / get_title / get_toc
+# ---------------------------------------------------------------------------
+
+
+class TestGetItem:
+    def test_正常系_単一itemをパース(self) -> None:
+        payload = {"itemId": 42, "title": "X", "date": "2024-05-01"}
+        client, session, cache = _build_client(session_payload=payload)
+        try:
+            item = client.get_item(42)
+            assert item.item_id == 42
+            session.get_with_retry.assert_called_once_with("/item/42", params={})
+        finally:
+            cache.close()
+
+
+class TestGetTitle:
+    def test_正常系_titleをパース(self) -> None:
+        payload = {"titleId": 677, "name": "FOMC"}
+        client, _session, cache = _build_client(session_payload=payload)
+        try:
+            title = client.get_title(677)
+            assert title.title_id == 677
+        finally:
+            cache.close()
+
+
+class TestGetToc:
+    def test_正常系_tocリスト(self) -> None:
+        payload = [{"label": "Intro", "page": 1}]
+        client, _session, cache = _build_client(session_payload=payload)
+        try:
+            toc = client.get_toc(42)
+            assert len(toc) == 1
+            assert toc[0].label == "Intro"
+        finally:
+            cache.close()
+
+
+# ---------------------------------------------------------------------------
+# get_authors / subjects / themes / timeline
+# ---------------------------------------------------------------------------
+
+
+class TestMasterTables:
+    def test_正常系_authors(self) -> None:
+        payload = [{"name": "Alice", "authorId": 1}]
+        client, _, cache = _build_client(session_payload=payload)
+        try:
+            authors = client.get_authors()
+            assert authors[0].author_id == 1
+        finally:
+            cache.close()
+
+    def test_正常系_subjects(self) -> None:
+        payload = [{"name": "macro", "subjectId": 7}]
+        client, _, cache = _build_client(session_payload=payload)
+        try:
+            subjects = client.get_subjects()
+            assert subjects[0].subject_id == 7
+        finally:
+            cache.close()
+
+    def test_正常系_themes(self) -> None:
+        payload = [{"name": "policy", "themeId": 9}]
+        client, _, cache = _build_client(session_payload=payload)
+        try:
+            themes = client.get_themes()
+            assert themes[0].theme_id == 9
+        finally:
+            cache.close()
+
+    def test_正常系_timeline(self) -> None:
+        payload = [{"label": "Founded", "eventDate": "1913"}]
+        client, session, cache = _build_client(session_payload=payload)
+        try:
+            events = client.get_timeline(677)
+            assert events[0].label == "Founded"
+            session.get_with_retry.assert_called_once_with(
+                "/title/677/timeline", params={}
+            )
+        finally:
+            cache.close()

--- a/tests/market/fraser/unit/test_constants.py
+++ b/tests/market/fraser/unit/test_constants.py
@@ -1,0 +1,184 @@
+"""Tests for ``market.fraser.constants`` module."""
+
+from typing import Final, get_type_hints
+
+from market.fraser import constants
+from market.fraser.constants import (
+    ALLOWED_HOSTS,
+    BASE_URL,
+    DEFAULT_REQUESTS_PER_HOUR,
+    DEFAULT_REQUESTS_PER_MINUTE,
+    DEFAULT_TIMEOUT,
+    DOC_TYPE_SUBDIRS,
+    FRASER_API_KEY_ENV,
+    KNOWN_TITLE_IDS,
+    MAX_RESPONSE_BODY_LOG,
+)
+
+
+class TestBaseUrl:
+    """Tests for ``BASE_URL``."""
+
+    def test_正常系_URLが正しい値(self) -> None:
+        assert BASE_URL == "https://fraser.stlouisfed.org/api"
+
+    def test_正常系_httpsスキーム(self) -> None:
+        assert BASE_URL.startswith("https://")
+
+
+class TestAllowedHosts:
+    """Tests for ``ALLOWED_HOSTS``."""
+
+    def test_正常系_frozensetである(self) -> None:
+        assert isinstance(ALLOWED_HOSTS, frozenset)
+
+    def test_正常系_fraserホストを含む(self) -> None:
+        assert "fraser.stlouisfed.org" in ALLOWED_HOSTS
+
+    def test_正常系_他のホストを含まない(self) -> None:
+        assert "evil.example.com" not in ALLOWED_HOSTS
+        assert "www.alphavantage.co" not in ALLOWED_HOSTS
+
+    def test_正常系_要素数が1(self) -> None:
+        assert len(ALLOWED_HOSTS) == 1
+
+
+class TestEnvironmentVariableNames:
+    """Tests for environment variable name constants."""
+
+    def test_正常系_APIキー環境変数名(self) -> None:
+        assert FRASER_API_KEY_ENV == "FRASER_API_KEY"
+
+
+class TestSecurityConstants:
+    """Tests for security-related constants."""
+
+    def test_正常系_レスポンスボディログ最大値(self) -> None:
+        assert MAX_RESPONSE_BODY_LOG == 2048
+
+    def test_正常系_レスポンスボディログ最大値は正の値(self) -> None:
+        assert MAX_RESPONSE_BODY_LOG > 0
+
+
+class TestRateLimitDefaults:
+    """Tests for rate limit default constants."""
+
+    def test_正常系_デフォルト毎分リクエスト数(self) -> None:
+        assert DEFAULT_REQUESTS_PER_MINUTE == 30
+
+    def test_正常系_デフォルト毎時リクエスト数(self) -> None:
+        assert DEFAULT_REQUESTS_PER_HOUR == 1800
+
+    def test_正常系_毎時は毎分の60倍(self) -> None:
+        assert DEFAULT_REQUESTS_PER_HOUR == DEFAULT_REQUESTS_PER_MINUTE * 60
+
+
+class TestHttpDefaults:
+    """Tests for HTTP default configuration constants."""
+
+    def test_正常系_デフォルトタイムアウト(self) -> None:
+        assert DEFAULT_TIMEOUT == 30.0
+
+    def test_正常系_タイムアウトは正の値(self) -> None:
+        assert DEFAULT_TIMEOUT > 0
+
+
+class TestKnownTitleIds:
+    """Tests for ``KNOWN_TITLE_IDS``."""
+
+    def test_正常系_FOMCMinutesのIDは677(self) -> None:
+        assert KNOWN_TITLE_IDS["fomc_minutes"] == 677
+
+    def test_正常系_6キーを持つ(self) -> None:
+        assert len(KNOWN_TITLE_IDS) == 6
+        assert set(KNOWN_TITLE_IDS.keys()) == {
+            "fomc_minutes",
+            "fomc_statements",
+            "fomc_press_conferences",
+            "beige_book",
+            "monetary_policy_report",
+            "frb_speeches",
+        }
+
+    def test_正常系_未確定キーはNone(self) -> None:
+        for key in (
+            "fomc_statements",
+            "fomc_press_conferences",
+            "beige_book",
+            "monetary_policy_report",
+            "frb_speeches",
+        ):
+            assert KNOWN_TITLE_IDS[key] is None
+
+
+class TestDocTypeSubdirs:
+    """Tests for ``DOC_TYPE_SUBDIRS``."""
+
+    def test_正常系_6キーを持つ(self) -> None:
+        assert len(DOC_TYPE_SUBDIRS) == 6
+
+    def test_正常系_キーがKNOWN_TITLE_IDSと一致(self) -> None:
+        assert set(DOC_TYPE_SUBDIRS.keys()) == set(KNOWN_TITLE_IDS.keys())
+
+    def test_正常系_FOMCMinutesのサブディレクトリ(self) -> None:
+        assert DOC_TYPE_SUBDIRS["fomc_minutes"] == "fomc/minutes"
+
+    def test_正常系_BeigeBookのサブディレクトリ(self) -> None:
+        assert DOC_TYPE_SUBDIRS["beige_book"] == "beige_book"
+
+    def test_正常系_全サブディレクトリが空でない文字列(self) -> None:
+        for value in DOC_TYPE_SUBDIRS.values():
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+
+class TestFinalAnnotations:
+    """Tests that all module constants are annotated with ``Final``."""
+
+    def test_正常系_全定数がFinal宣言(self) -> None:
+        """Verify each public constant uses ``typing.Final`` in its annotation.
+
+        ``typing.get_type_hints(include_extras=True)`` returns the
+        evaluated annotation expressions. For ``Final[X]`` the typing
+        origin is ``Final``. Asserting on the origin catches the
+        regression where someone strips the ``Final`` wrapper.
+        """
+        hints = get_type_hints(constants, include_extras=True)
+        expected_names = {
+            "BASE_URL",
+            "ALLOWED_HOSTS",
+            "MAX_RESPONSE_BODY_LOG",
+            "FRASER_API_KEY_ENV",
+            "DEFAULT_REQUESTS_PER_MINUTE",
+            "DEFAULT_REQUESTS_PER_HOUR",
+            "DEFAULT_TIMEOUT",
+            "KNOWN_TITLE_IDS",
+            "DOC_TYPE_SUBDIRS",
+        }
+        for name in expected_names:
+            assert name in hints, f"{name} missing from module hints"
+            hint = hints[name]
+            # ``Final[X]`` exposes its parametrisation via __origin__.
+            origin = getattr(hint, "__origin__", None)
+            assert origin is Final, f"{name} is not annotated as Final, got {hint!r}"
+
+
+class TestAllExports:
+    """Tests for ``__all__`` completeness."""
+
+    def test_正常系_allが定義されている(self) -> None:
+        assert hasattr(constants, "__all__")
+
+    def test_正常系_全定数がallに含まれる(self) -> None:
+        expected = {
+            "ALLOWED_HOSTS",
+            "BASE_URL",
+            "DEFAULT_REQUESTS_PER_HOUR",
+            "DEFAULT_REQUESTS_PER_MINUTE",
+            "DEFAULT_TIMEOUT",
+            "DOC_TYPE_SUBDIRS",
+            "FRASER_API_KEY_ENV",
+            "KNOWN_TITLE_IDS",
+            "MAX_RESPONSE_BODY_LOG",
+        }
+        assert set(constants.__all__) == expected

--- a/tests/market/fraser/unit/test_downloader.py
+++ b/tests/market/fraser/unit/test_downloader.py
@@ -1,0 +1,308 @@
+"""Tests for ``market.fraser.downloader`` module.
+
+Verifies :class:`FraserDownloader` behaviour:
+
+- ``tempfile.NamedTemporaryFile`` + ``Path.replace()`` atomic publish.
+- Failed downloads do not leave ``*.tmp`` residue.
+- ``item_id``-keyed ``threading.Lock`` prevents duplicate concurrent
+  downloads of the same item (single HTTP call observed).
+- ``download_with_meta`` writes both the asset file and the JSON
+  metadata sidecar.
+
+See Also
+--------
+market.fraser.downloader : Module under test.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from market.fraser.downloader import FraserDownloader
+from market.fraser.errors import FraserDownloadError
+from market.fraser.models import FraserItem
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_session_with_stream(
+    *,
+    chunks: list[bytes] | None = None,
+    status_code: int = 200,
+    raise_http_status: bool = False,
+) -> MagicMock:
+    """Return a MagicMock FraserSession whose ``_client.stream`` is controlled.
+
+    ``_client`` is exposed as a private attribute on the real session;
+    the downloader accesses it via ``session._client``.
+    """
+    session = MagicMock()
+    client = MagicMock()
+    session._client = client
+
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.iter_bytes.return_value = iter(chunks or [])
+    if raise_http_status:
+        # Simulate ``response.raise_for_status()`` raising on 4xx/5xx.
+        request = httpx.Request("GET", "https://fraser.stlouisfed.org/x")
+        real_response = httpx.Response(status_code, request=request)
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=request, response=real_response
+        )
+    else:
+        response.raise_for_status.return_value = None
+
+    @contextmanager
+    def _stream(method: str, url: str, **_: Any) -> Any:
+        yield response
+
+    client.stream.side_effect = _stream
+    return session
+
+
+def _make_item(
+    item_id: int = 1001,
+    *,
+    pdf: bool = True,
+    txt: bool = True,
+) -> FraserItem:
+    location: dict[str, list[str]] = {}
+    if pdf:
+        location["pdfUrl"] = [f"https://fraser.stlouisfed.org/files/{item_id}.pdf"]
+    if txt:
+        location["textUrl"] = [f"https://fraser.stlouisfed.org/files/{item_id}.txt"]
+    payload: dict[str, Any] = {
+        "itemId": item_id,
+        "titleId": 677,
+        "title": f"Item {item_id}",
+        "date": "2024-01-31",
+    }
+    if location:
+        payload["location"] = location
+    return FraserItem.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestFraserDownloaderInit:
+    def test_正常系_デフォルトbase_dir(self) -> None:
+        session = MagicMock()
+        dl = FraserDownloader(session)
+        assert dl.base_dir == Path("data/raw/fraser")
+
+    def test_正常系_カスタムbase_dir(self, tmp_path: Path) -> None:
+        session = MagicMock()
+        dl = FraserDownloader(session, base_dir=tmp_path / "fraser")
+        assert dl.base_dir == tmp_path / "fraser"
+
+
+# ---------------------------------------------------------------------------
+# download() - atomic rename
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadAtomic:
+    def test_正常系_tempfileとPathReplaceでatomic書き込み(self, tmp_path: Path) -> None:
+        chunks = [b"hello ", b"world"]
+        session = _build_session_with_stream(chunks=chunks)
+        dl = FraserDownloader(session, base_dir=tmp_path)
+
+        target = tmp_path / "out" / "doc.txt"
+        result = dl.download("https://fraser.stlouisfed.org/x.txt", target)
+
+        assert result == target
+        assert target.exists()
+        assert target.read_bytes() == b"hello world"
+        # No leftover .tmp files in the target directory.
+        residual = list(target.parent.glob("*.tmp"))
+        assert residual == []
+
+    def test_正常系_targetが既存ならスキップ(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(chunks=[b"new"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+
+        target = tmp_path / "exists.txt"
+        target.write_bytes(b"original")
+
+        result = dl.download("https://fraser.stlouisfed.org/x.txt", target)
+        assert result == target
+        # Content remains unchanged.
+        assert target.read_bytes() == b"original"
+        # Streaming client was never called.
+        session._client.stream.assert_not_called()
+
+    def test_正常系_force_Trueで上書き(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(chunks=[b"new"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+
+        target = tmp_path / "exists.txt"
+        target.write_bytes(b"original")
+
+        dl.download("https://fraser.stlouisfed.org/x.txt", target, force=True)
+        assert target.read_bytes() == b"new"
+
+    def test_異常系_HTTP500でtmpファイルが残らない(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(
+            chunks=[b"err"], status_code=500, raise_http_status=True
+        )
+        dl = FraserDownloader(session, base_dir=tmp_path)
+
+        target = tmp_path / "out" / "doc.txt"
+        with pytest.raises(FraserDownloadError):
+            dl.download("https://fraser.stlouisfed.org/x.txt", target)
+
+        # Target was never created and the .tmp file was cleaned up.
+        assert not target.exists()
+        residual = list((tmp_path / "out").glob("*.tmp"))
+        assert residual == []
+
+    def test_異常系_httpx_NetworkErrorでtmp清掃(self, tmp_path: Path) -> None:
+        session = MagicMock()
+        client = MagicMock()
+        session._client = client
+
+        @contextmanager
+        def _stream(method: str, url: str, **_: Any) -> Any:
+            raise httpx.ConnectError("network down")
+            yield  # pragma: no cover
+
+        client.stream.side_effect = _stream
+        dl = FraserDownloader(session, base_dir=tmp_path)
+
+        target = tmp_path / "out" / "doc.txt"
+        with pytest.raises(FraserDownloadError):
+            dl.download("https://fraser.stlouisfed.org/x.txt", target)
+        assert not target.exists()
+        residual = (
+            list((tmp_path / "out").glob("*.tmp"))
+            if (tmp_path / "out").exists()
+            else []
+        )
+        assert residual == []
+
+
+# ---------------------------------------------------------------------------
+# Lock-based deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestParallelDeduplication:
+    def test_正常系_同一item_idの並列DLでhttp呼び出しが1回(
+        self, tmp_path: Path
+    ) -> None:
+        # Configure the mock session so each ``stream`` call returns a
+        # fresh response with the same bytes. We count how many times
+        # ``stream`` is invoked across two threads using the same item.
+        call_count = {"value": 0}
+        call_lock = threading.Lock()
+
+        session = MagicMock()
+        client = MagicMock()
+        session._client = client
+
+        @contextmanager
+        def _stream(method: str, url: str, **_: Any) -> Any:
+            with call_lock:
+                call_count["value"] += 1
+            response = MagicMock(spec=httpx.Response)
+            response.status_code = 200
+            response.iter_bytes.return_value = iter([b"payload"])
+            response.raise_for_status.return_value = None
+            yield response
+
+        client.stream.side_effect = _stream
+
+        dl = FraserDownloader(session, base_dir=tmp_path)
+        item = _make_item(item_id=1001, txt=True, pdf=False)
+
+        def _worker() -> None:
+            dl.download_with_meta(item, "fomc/minutes", prefer="txt")
+
+        threads = [threading.Thread(target=_worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # The second download must skip because the file exists after
+        # the first call → exactly one HTTP stream invocation.
+        assert call_count["value"] == 1
+
+        target = (
+            tmp_path
+            / "fomc"
+            / "minutes"
+            / f"{item.date.isoformat()}_{item.item_id}.txt"
+        )
+        assert target.exists()
+
+    def test_正常系_異なるitem_idは別ロック(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(chunks=[b"data"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+        lock_a = dl._get_or_create_lock(1001)
+        lock_b = dl._get_or_create_lock(1002)
+        assert lock_a is not lock_b
+
+    def test_正常系_同一item_idは同じロックを返す(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(chunks=[b"data"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+        first = dl._get_or_create_lock(2002)
+        second = dl._get_or_create_lock(2002)
+        assert first is second
+
+
+# ---------------------------------------------------------------------------
+# download_with_meta
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadWithMeta:
+    def test_正常系_metaサイドカーが書き出される(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(chunks=[b"body"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+        item = _make_item(item_id=3003)
+
+        asset_path, meta_path = dl.download_with_meta(
+            item, "fomc/minutes", prefer="txt"
+        )
+        assert asset_path.exists()
+        assert asset_path.suffix == ".txt"
+        assert meta_path.exists()
+        assert meta_path.suffix == ".json"
+        meta_text = meta_path.read_text(encoding="utf-8")
+        assert "3003" in meta_text
+
+    def test_正常系_preferpdfで拡張子pdf(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(chunks=[b"pdf bytes"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+        item = _make_item(item_id=4004)
+        asset_path, _ = dl.download_with_meta(item, "fomc/minutes", prefer="pdf")
+        assert asset_path.suffix == ".pdf"
+
+    def test_正常系_preferが欠落しているとフォールバック(self, tmp_path: Path) -> None:
+        # prefer='txt' but only pdf is available -> falls back to pdf.
+        session = _build_session_with_stream(chunks=[b"pdf only"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+        item = _make_item(item_id=5005, txt=False, pdf=True)
+        asset_path, _ = dl.download_with_meta(item, "fomc/minutes", prefer="txt")
+        assert asset_path.suffix == ".pdf"
+
+    def test_異常系_locationなしで例外(self, tmp_path: Path) -> None:
+        session = _build_session_with_stream(chunks=[b"x"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+        item = _make_item(item_id=6006, txt=False, pdf=False)
+        with pytest.raises(FraserDownloadError):
+            dl.download_with_meta(item, "fomc/minutes", prefer="txt")

--- a/tests/market/fraser/unit/test_downloader.py
+++ b/tests/market/fraser/unit/test_downloader.py
@@ -40,14 +40,14 @@ def _build_session_with_stream(
     status_code: int = 200,
     raise_http_status: bool = False,
 ) -> MagicMock:
-    """Return a MagicMock FraserSession whose ``_client.stream`` is controlled.
+    """Return a MagicMock FraserSession whose ``stream(url)`` is controlled.
 
-    ``_client`` is exposed as a private attribute on the real session;
-    the downloader accesses it via ``session._client``.
+    Mocks the public :meth:`FraserSession.stream` context manager — the
+    downloader now invokes ``self._session.stream(url)`` (which internally
+    enforces SSRF / HTTPS guards via ``_validate_url``) instead of poking
+    ``self._session._client.stream`` directly (see PR #3967 HIGH-1 fix).
     """
     session = MagicMock()
-    client = MagicMock()
-    session._client = client
 
     response = MagicMock(spec=httpx.Response)
     response.status_code = status_code
@@ -63,10 +63,10 @@ def _build_session_with_stream(
         response.raise_for_status.return_value = None
 
     @contextmanager
-    def _stream(method: str, url: str, **_: Any) -> Any:
+    def _stream(url: str, **_: Any) -> Any:
         yield response
 
-    client.stream.side_effect = _stream
+    session.stream.side_effect = _stream
     return session
 
 
@@ -141,8 +141,8 @@ class TestDownloadAtomic:
         assert result == target
         # Content remains unchanged.
         assert target.read_bytes() == b"original"
-        # Streaming client was never called.
-        session._client.stream.assert_not_called()
+        # Streaming session was never called.
+        session.stream.assert_not_called()
 
     def test_正常系_force_Trueで上書き(self, tmp_path: Path) -> None:
         session = _build_session_with_stream(chunks=[b"new"])
@@ -171,15 +171,13 @@ class TestDownloadAtomic:
 
     def test_異常系_httpx_NetworkErrorでtmp清掃(self, tmp_path: Path) -> None:
         session = MagicMock()
-        client = MagicMock()
-        session._client = client
 
         @contextmanager
-        def _stream(method: str, url: str, **_: Any) -> Any:
+        def _stream(url: str, **_: Any) -> Any:
             raise httpx.ConnectError("network down")
             yield  # pragma: no cover
 
-        client.stream.side_effect = _stream
+        session.stream.side_effect = _stream
         dl = FraserDownloader(session, base_dir=tmp_path)
 
         target = tmp_path / "out" / "doc.txt"
@@ -210,11 +208,9 @@ class TestParallelDeduplication:
         call_lock = threading.Lock()
 
         session = MagicMock()
-        client = MagicMock()
-        session._client = client
 
         @contextmanager
-        def _stream(method: str, url: str, **_: Any) -> Any:
+        def _stream(url: str, **_: Any) -> Any:
             with call_lock:
                 call_count["value"] += 1
             response = MagicMock(spec=httpx.Response)
@@ -223,7 +219,7 @@ class TestParallelDeduplication:
             response.raise_for_status.return_value = None
             yield response
 
-        client.stream.side_effect = _stream
+        session.stream.side_effect = _stream
 
         dl = FraserDownloader(session, base_dir=tmp_path)
         item = _make_item(item_id=1001, txt=True, pdf=False)

--- a/tests/market/fraser/unit/test_downloader.py
+++ b/tests/market/fraser/unit/test_downloader.py
@@ -52,6 +52,9 @@ def _build_session_with_stream(
     response = MagicMock(spec=httpx.Response)
     response.status_code = status_code
     response.iter_bytes.return_value = iter(chunks or [])
+    # Integrity headers — empty by default; tests can override per case
+    # by reassigning ``response.headers`` to a dict-like object.
+    response.headers = {}
     if raise_http_status:
         # Simulate ``response.raise_for_status()`` raising on 4xx/5xx.
         request = httpx.Request("GET", "https://fraser.stlouisfed.org/x")
@@ -217,6 +220,7 @@ class TestParallelDeduplication:
             response.status_code = 200
             response.iter_bytes.return_value = iter([b"payload"])
             response.raise_for_status.return_value = None
+            response.headers = {}
             yield response
 
         session.stream.side_effect = _stream
@@ -302,3 +306,40 @@ class TestDownloadWithMeta:
         item = _make_item(item_id=6006, txt=False, pdf=False)
         with pytest.raises(FraserDownloadError):
             dl.download_with_meta(item, "fomc/minutes", prefer="txt")
+
+
+# ---------------------------------------------------------------------------
+# Branch coverage follow-ups (PR review MEDIUM / LOW)
+# ---------------------------------------------------------------------------
+
+
+class TestSelectURLEdgeCases:
+    """Cover the corners of ``FraserDownloader._select_url``."""
+
+    def test_異常系_preferが未知の値でFraserDownloadError(self, tmp_path: Path) -> None:
+        """``prefer`` outside the Literal must trip the final fallthrough.
+
+        At runtime ``Literal["txt", "pdf"]`` is not enforced, so an
+        accidental ``prefer="xml"`` from an unverified caller should
+        not return an asset whose extension is meaningless.
+        """
+        item = _make_item(item_id=7007, txt=True, pdf=True)
+
+        with pytest.raises(FraserDownloadError):
+            FraserDownloader._select_url(item, prefer="xml")  # type: ignore[arg-type]
+
+
+class TestEmptyChunk:
+    """Cover the ``if chunk:`` skip branch in ``_stream_to``."""
+
+    def test_正常系_空チャンクは書き込みをスキップ(self, tmp_path: Path) -> None:
+        # Mix in empty bytes between two real chunks. ``_stream_to`` must
+        # skip the empty entry without raising; the resulting file size
+        # equals the sum of the non-empty chunks.
+        session = _build_session_with_stream(chunks=[b"abc", b"", b"def"])
+        dl = FraserDownloader(session, base_dir=tmp_path)
+
+        target = tmp_path / "out" / "empty_chunk.txt"
+        result = dl.download("https://fraser.stlouisfed.org/x.txt", target)
+
+        assert result.read_bytes() == b"abcdef"

--- a/tests/market/fraser/unit/test_errors.py
+++ b/tests/market/fraser/unit/test_errors.py
@@ -1,0 +1,231 @@
+"""Tests for ``market.fraser.errors`` module.
+
+Covers the 7-class FRASER exception hierarchy:
+
+- Each class is a subclass of ``FraserError`` and of ``Exception``.
+- None of the classes inherits from ``market.errors.MarketError``
+  (HF1 confirmed direct ``Exception`` inheritance).
+- Constructor-set attributes are preserved (``url``, ``status_code``,
+  ``response_body``, ``retry_after``, ``raw_data``, ``field``,
+  ``cause``, ``value``).
+"""
+
+import pytest
+
+from market.errors import MarketError
+from market.fraser import errors
+from market.fraser.errors import (
+    FraserAPIError,
+    FraserAuthError,
+    FraserDownloadError,
+    FraserError,
+    FraserNotFoundError,
+    FraserParseError,
+    FraserRateLimitError,
+    FraserValidationError,
+)
+
+
+class TestFraserErrorBase:
+    """Tests for ``FraserError`` base class."""
+
+    def test_正常系_Exceptionを継承(self) -> None:
+        assert issubclass(FraserError, Exception)
+
+    def test_正常系_MarketErrorを継承しない(self) -> None:
+        """HF1: FRASER errors must not inherit from ``MarketError``.
+
+        Inheriting from ``MarketError`` would force ``market.fraser``
+        to import ``market.errors`` and risks circular dependencies.
+        """
+        assert not issubclass(FraserError, MarketError)
+
+    def test_正常系_メッセージが設定される(self) -> None:
+        error = FraserError("test error")
+        assert error.message == "test error"
+        assert str(error) == "test error"
+
+    def test_正常系_raiseできる(self) -> None:
+        with pytest.raises(FraserError, match="test error"):
+            raise FraserError("test error")
+
+
+class TestFraserAuthError:
+    """Tests for ``FraserAuthError`` (401 / 403)."""
+
+    def test_正常系_FraserErrorを継承(self) -> None:
+        assert issubclass(FraserAuthError, FraserError)
+
+    def test_正常系_MarketErrorを継承しない(self) -> None:
+        assert not issubclass(FraserAuthError, MarketError)
+
+    def test_正常系_メッセージが設定される(self) -> None:
+        error = FraserAuthError("Invalid API key")
+        assert error.message == "Invalid API key"
+
+    def test_正常系_FraserErrorでキャッチ可能(self) -> None:
+        with pytest.raises(FraserError):
+            raise FraserAuthError("Auth failed")
+
+
+class TestFraserRateLimitError:
+    """Tests for ``FraserRateLimitError`` (429 + Retry-After)."""
+
+    def test_正常系_FraserErrorを継承(self) -> None:
+        assert issubclass(FraserRateLimitError, FraserError)
+
+    def test_正常系_retry_after保持(self) -> None:
+        error = FraserRateLimitError("Rate limit exceeded", retry_after=120.5)
+        assert error.retry_after == 120.5
+        assert error.message == "Rate limit exceeded"
+
+    def test_正常系_retry_afterデフォルトNone(self) -> None:
+        error = FraserRateLimitError("Rate limit")
+        assert error.retry_after is None
+
+
+class TestFraserNotFoundError:
+    """Tests for ``FraserNotFoundError`` (404)."""
+
+    def test_正常系_FraserErrorを継承(self) -> None:
+        assert issubclass(FraserNotFoundError, FraserError)
+
+    def test_正常系_メッセージが設定される(self) -> None:
+        error = FraserNotFoundError("Title 999 not found")
+        assert error.message == "Title 999 not found"
+
+
+class TestFraserAPIError:
+    """Tests for ``FraserAPIError`` (4xx / 5xx generic)."""
+
+    def test_正常系_FraserErrorを継承(self) -> None:
+        assert issubclass(FraserAPIError, FraserError)
+
+    def test_正常系_属性が正しく設定される(self) -> None:
+        error = FraserAPIError(
+            "API returned HTTP 500",
+            url="https://fraser.stlouisfed.org/api/title/677",
+            status_code=500,
+            response_body='{"error": "Internal Server Error"}',
+        )
+        assert error.message == "API returned HTTP 500"
+        assert error.url == "https://fraser.stlouisfed.org/api/title/677"
+        assert error.status_code == 500
+        assert error.response_body == '{"error": "Internal Server Error"}'
+
+
+class TestFraserParseError:
+    """Tests for ``FraserParseError``."""
+
+    def test_正常系_FraserErrorを継承(self) -> None:
+        assert issubclass(FraserParseError, FraserError)
+
+    def test_正常系_属性が正しく設定される(self) -> None:
+        underlying = ValueError("invalid date")
+        error = FraserParseError(
+            "Failed to parse response",
+            raw_data='{"items": []}',
+            field="items",
+            cause=underlying,
+        )
+        assert error.message == "Failed to parse response"
+        assert error.raw_data == '{"items": []}'
+        assert error.field == "items"
+        assert error.cause is underlying
+
+    def test_正常系_causeデフォルトNone(self) -> None:
+        error = FraserParseError("bad", raw_data="", field="x")
+        assert error.cause is None
+
+
+class TestFraserDownloadError:
+    """Tests for ``FraserDownloadError``."""
+
+    def test_正常系_FraserErrorを継承(self) -> None:
+        assert issubclass(FraserDownloadError, FraserError)
+
+    def test_正常系_属性が正しく設定される(self) -> None:
+        underlying = OSError("disk full")
+        error = FraserDownloadError(
+            "Download failed",
+            url="https://fraser.stlouisfed.org/files/doc/1.pdf",
+            cause=underlying,
+        )
+        assert error.url == "https://fraser.stlouisfed.org/files/doc/1.pdf"
+        assert error.cause is underlying
+
+    def test_正常系_causeデフォルトNone(self) -> None:
+        error = FraserDownloadError("fail", url="https://x")
+        assert error.cause is None
+
+
+class TestFraserValidationError:
+    """Tests for ``FraserValidationError``."""
+
+    def test_正常系_FraserErrorを継承(self) -> None:
+        assert issubclass(FraserValidationError, FraserError)
+
+    def test_正常系_属性が正しく設定される(self) -> None:
+        error = FraserValidationError(
+            "timeout must be positive",
+            field="timeout",
+            value=-1.0,
+        )
+        assert error.message == "timeout must be positive"
+        assert error.field == "timeout"
+        assert error.value == -1.0
+
+
+class TestErrorHierarchy:
+    """Cross-cutting tests for the exception hierarchy."""
+
+    SUBCLASSES = (
+        FraserAuthError,
+        FraserRateLimitError,
+        FraserNotFoundError,
+        FraserAPIError,
+        FraserParseError,
+        FraserDownloadError,
+        FraserValidationError,
+    )
+
+    def test_正常系_全エラーがFraserErrorのサブクラス(self) -> None:
+        for cls in self.SUBCLASSES:
+            assert issubclass(cls, FraserError), (
+                f"{cls.__name__} does not inherit from FraserError"
+            )
+
+    def test_正常系_全エラーがException直接継承パスを持つ(self) -> None:
+        """Every subclass should reach ``Exception`` through ``FraserError``.
+
+        Combined with the ``FraserError`` test ensuring direct
+        ``Exception`` inheritance, this covers the full hierarchy.
+        """
+        for cls in self.SUBCLASSES:
+            assert issubclass(cls, Exception)
+
+    def test_正常系_どのクラスもMarketErrorを継承しない(self) -> None:
+        for cls in (FraserError, *self.SUBCLASSES):
+            assert not issubclass(cls, MarketError), (
+                f"{cls.__name__} must not inherit from MarketError"
+            )
+
+
+class TestAllExports:
+    """Tests for ``__all__`` completeness."""
+
+    def test_正常系_allが定義されている(self) -> None:
+        assert hasattr(errors, "__all__")
+
+    def test_正常系_全例外クラスがallに含まれる(self) -> None:
+        expected = {
+            "FraserAPIError",
+            "FraserAuthError",
+            "FraserDownloadError",
+            "FraserError",
+            "FraserNotFoundError",
+            "FraserParseError",
+            "FraserRateLimitError",
+            "FraserValidationError",
+        }
+        assert set(errors.__all__) == expected

--- a/tests/market/fraser/unit/test_fetchers_base.py
+++ b/tests/market/fraser/unit/test_fetchers_base.py
@@ -1,0 +1,259 @@
+"""Unit tests for ``market.fraser.fetchers.base.BaseFraserFetcher``.
+
+These tests cover the abstract base class behaviour:
+
+- ``_resolve_title_id`` priority: ``KNOWN_TITLE_IDS`` hit, JSON fallback,
+  validation error when neither source provides a value.
+- ``_filter_by_year_range`` boundary handling for ``YYYY-MM-DD`` /
+  ``YYYY-MM`` / ``YYYY`` style ``date`` strings.
+- ``fetch_text`` delegation to the downloader (with mocked dependencies).
+
+A minimal :class:`_DummyFetcher` subclass is used to instantiate the
+abstract base because :class:`BaseFraserFetcher` itself cannot be
+instantiated directly.
+
+See Also
+--------
+market.fraser.fetchers.base : Class under test.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from market.fraser.errors import FraserValidationError
+from market.fraser.fetchers.base import BaseFraserFetcher
+from market.fraser.models import FraserItem
+from market.fraser.types import DocType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _DummyFetcher(BaseFraserFetcher):
+    """Concrete subclass used solely for exercising the abstract base."""
+
+    _doc_type_override: DocType = DocType.FOMC_MINUTES
+
+    @property
+    def doc_type(self) -> DocType:
+        return self._doc_type_override
+
+
+def _make_item(item_id: int, date_str: str) -> FraserItem:
+    """Build a minimal ``FraserItem`` with the supplied ``date`` string."""
+    return FraserItem.model_validate(
+        {
+            "itemId": item_id,
+            "title": f"Item {item_id}",
+            "date": date_str,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_title_id
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTitleId:
+    """Tests for :meth:`BaseFraserFetcher._resolve_title_id`."""
+
+    def test_正常系_known_title_idsに値があれば即返却(self) -> None:
+        # FOMC_MINUTES is hard-coded as 677 in ``KNOWN_TITLE_IDS``.
+        fetcher = _DummyFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher.title_id == 677
+
+    def test_正常系_known_title_idsがNoneでもjsonに値があれば返却(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Override KNOWN_TITLE_IDS so that the FOMC_MINUTES entry is None,
+        # forcing the JSON fallback to be exercised.
+        from market.fraser.fetchers import base as base_module
+
+        monkeypatch.setattr(
+            base_module,
+            "KNOWN_TITLE_IDS",
+            {"fomc_minutes": None},
+        )
+
+        # Write a fallback titles JSON file pointing at id 999.
+        titles_file = tmp_path / "fraser_titles.json"
+        titles_file.write_text(json.dumps({"fomc_minutes": 999}))
+        monkeypatch.setattr(base_module, "DEFAULT_TITLES_JSON_PATH", titles_file)
+
+        fetcher = _DummyFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher.title_id == 999
+
+    def test_異常系_両方Noneで_FraserValidationError(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from market.fraser.fetchers import base as base_module
+
+        monkeypatch.setattr(
+            base_module,
+            "KNOWN_TITLE_IDS",
+            {"fomc_minutes": None},
+        )
+
+        # Point fallback path at a non-existent file so the JSON branch fails.
+        monkeypatch.setattr(
+            base_module,
+            "DEFAULT_TITLES_JSON_PATH",
+            tmp_path / "missing.json",
+        )
+
+        fetcher = _DummyFetcher(client=MagicMock(), downloader=MagicMock())
+        with pytest.raises(FraserValidationError) as excinfo:
+            _ = fetcher.title_id
+        assert excinfo.value.field == "title_id"
+
+
+# ---------------------------------------------------------------------------
+# _filter_by_year_range
+# ---------------------------------------------------------------------------
+
+
+class TestFilterByYearRange:
+    """Boundary tests for :meth:`BaseFraserFetcher._filter_by_year_range`."""
+
+    def test_正常系_範囲内のitemのみ返却される(self) -> None:
+        fetcher = _DummyFetcher(client=MagicMock(), downloader=MagicMock())
+        items = [
+            _make_item(1, "2023-12-31"),
+            _make_item(2, "2024-01-01"),
+            _make_item(3, "2024-06-15"),
+            _make_item(4, "2024-12-31"),
+            _make_item(5, "2025-01-01"),
+        ]
+        result = fetcher._filter_by_year_range(items, (2024, 2024))
+        assert [i.item_id for i in result] == [2, 3, 4]
+
+    def test_エッジケース_空リストで空結果(self) -> None:
+        fetcher = _DummyFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher._filter_by_year_range([], (2024, 2024)) == []
+
+    def test_正常系_年のみのdate文字列でも正しく動作(self) -> None:
+        # ``_coerce_date`` normalises ``"2024"`` to ``date(2024, 1, 1)``.
+        fetcher = _DummyFetcher(client=MagicMock(), downloader=MagicMock())
+        items = [_make_item(1, "2024"), _make_item(2, "2023")]
+        result = fetcher._filter_by_year_range(items, (2024, 2024))
+        assert [i.item_id for i in result] == [1]
+
+
+# ---------------------------------------------------------------------------
+# fetch_text
+# ---------------------------------------------------------------------------
+
+
+class TestFetchText:
+    """Tests for :meth:`BaseFraserFetcher.fetch_text` delegation."""
+
+    def test_正常系_clientとdownloaderが呼ばれてtupleが返る(
+        self, tmp_path: Path
+    ) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 42,
+                "title": "Test",
+                "date": "2024-03-20",
+                "location": {
+                    "textUrl": ["https://example.org/42.txt"],
+                },
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = item
+
+        mock_downloader = MagicMock()
+        asset_path = tmp_path / "asset.txt"
+        meta_path = tmp_path / "asset.meta.json"
+        mock_downloader.download_with_meta.return_value = (asset_path, meta_path)
+
+        fetcher = _DummyFetcher(client=mock_client, downloader=mock_downloader)
+        result_path, result_item = fetcher.fetch_text(42, prefer="txt")
+
+        mock_client.get_item.assert_called_once_with(42)
+        mock_downloader.download_with_meta.assert_called_once_with(
+            item, "fomc/minutes", prefer="txt"
+        )
+        assert result_path == asset_path
+        assert result_item is item
+
+    def test_正常系_fetch_pdfがprefer_pdfで委譲される(self, tmp_path: Path) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 43,
+                "title": "Test PDF",
+                "date": "2024-03-20",
+                "location": {"pdfUrl": ["https://example.org/43.pdf"]},
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = item
+
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            tmp_path / "x.pdf",
+            tmp_path / "x.meta.json",
+        )
+
+        fetcher = _DummyFetcher(client=mock_client, downloader=mock_downloader)
+        fetcher.fetch_pdf(43)
+
+        # ``fetch_pdf`` is a thin wrapper that forces ``prefer='pdf'``.
+        _, kwargs = mock_downloader.download_with_meta.call_args
+        assert kwargs["prefer"] == "pdf"
+
+
+# ---------------------------------------------------------------------------
+# Dependency injection defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultDependencies:
+    """Tests covering the dependency-injection defaults of ``__init__``."""
+
+    def test_正常系_クライアントもダウンローダもデフォルト生成される(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When called with no arguments both dependencies are auto-built."""
+        from market.fraser.fetchers import base as base_module
+
+        sentinel_client = MagicMock(name="default-client")
+        sentinel_client._session = MagicMock(name="default-session")
+        sentinel_downloader = MagicMock(name="default-downloader")
+
+        monkeypatch.setattr(base_module, "FraserClient", lambda: sentinel_client)
+
+        captured_kwargs: dict[str, object] = {}
+
+        def _fake_downloader(*, session: object, base_dir: Path) -> object:
+            captured_kwargs["session"] = session
+            captured_kwargs["base_dir"] = base_dir
+            return sentinel_downloader
+
+        monkeypatch.setattr(base_module, "FraserDownloader", _fake_downloader)
+
+        fetcher = _DummyFetcher(base_dir=tmp_path)
+
+        assert fetcher._client is sentinel_client
+        assert fetcher._downloader is sentinel_downloader
+        assert captured_kwargs["session"] is sentinel_client._session
+        assert captured_kwargs["base_dir"] == tmp_path
+
+    def test_正常系_doc_subdir_FOMC_MINUTES_returns_fomc_minutes(
+        self,
+    ) -> None:
+        fetcher = _DummyFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher._doc_subdir() == "fomc/minutes"

--- a/tests/market/fraser/unit/test_fetchers_base.py
+++ b/tests/market/fraser/unit/test_fetchers_base.py
@@ -230,8 +230,12 @@ class TestDefaultDependencies:
         """When called with no arguments both dependencies are auto-built."""
         from market.fraser.fetchers import base as base_module
 
+        sentinel_session = MagicMock(name="default-session")
         sentinel_client = MagicMock(name="default-client")
-        sentinel_client._session = MagicMock(name="default-session")
+        # Default downloader construction now goes through the public
+        # ``client.session`` property (DIP-compliant), so wire the mock
+        # accordingly.
+        sentinel_client.session = sentinel_session
         sentinel_downloader = MagicMock(name="default-downloader")
 
         monkeypatch.setattr(base_module, "FraserClient", lambda: sentinel_client)
@@ -249,7 +253,7 @@ class TestDefaultDependencies:
 
         assert fetcher._client is sentinel_client
         assert fetcher._downloader is sentinel_downloader
-        assert captured_kwargs["session"] is sentinel_client._session
+        assert captured_kwargs["session"] is sentinel_session
         assert captured_kwargs["base_dir"] == tmp_path
 
     def test_正常系_doc_subdir_FOMC_MINUTES_returns_fomc_minutes(

--- a/tests/market/fraser/unit/test_fetchers_beige_book.py
+++ b/tests/market/fraser/unit/test_fetchers_beige_book.py
@@ -1,0 +1,341 @@
+"""Unit tests for ``market.fraser.fetchers.beige_book.BeigeBookFetcher``.
+
+Covers:
+
+- ``doc_type`` reports :data:`DocType.BEIGE_BOOK`.
+- ``list_reports`` filters by year and returns ``BeigeBookReport``.
+- ``fetch_all`` parallelises via ``ThreadPoolExecutor`` and tolerates
+  partial failures (returns ``{item_id: Path | Exception}``).
+- ``MAX_WORKERS_LIMIT`` clamps oversized ``max_workers``.
+- ``fetch_all`` with ``max_workers < 1`` raises :class:`ValueError`.
+
+See Also
+--------
+market.fraser.fetchers.beige_book : Class under test.
+tests.market.fraser.conftest : Shared fixtures.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from market.fraser.fetchers.beige_book import (
+    MAX_WORKERS_LIMIT,
+    BeigeBookFetcher,
+)
+from market.fraser.models import BeigeBookReport, FraserItem
+from market.fraser.types import DocType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Title id slot for "beige_book" must be present in KNOWN_TITLE_IDS for the
+# fetcher's ``title_id`` property to resolve. We monkeypatch the constant
+# directly via a fixture below — keeping the conftest unchanged.
+_BEIGE_BOOK_TITLE_ID: int = 77777
+
+
+@pytest.fixture
+def beige_book_title_id(monkeypatch: pytest.MonkeyPatch) -> int:
+    """Inject a dummy title_id for ``beige_book`` into KNOWN_TITLE_IDS."""
+    from market.fraser.fetchers import base as base_module
+
+    monkeypatch.setitem(base_module.KNOWN_TITLE_IDS, "beige_book", _BEIGE_BOOK_TITLE_ID)
+    return _BEIGE_BOOK_TITLE_ID
+
+
+def _items_from_sample(
+    payload: dict[str, object],
+) -> list[FraserItem]:
+    """Convert the ``sample_beige_book_items_response`` fixture into models."""
+    raw_items = payload["items"]
+    assert isinstance(raw_items, list)
+    return [FraserItem.model_validate(raw) for raw in raw_items]
+
+
+# ---------------------------------------------------------------------------
+# doc_type
+# ---------------------------------------------------------------------------
+
+
+class TestDocType:
+    def test_正常系_doc_typeはBEIGE_BOOK(self) -> None:
+        fetcher = BeigeBookFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher.doc_type is DocType.BEIGE_BOOK
+
+
+# ---------------------------------------------------------------------------
+# list_reports
+# ---------------------------------------------------------------------------
+
+
+class TestListReports:
+    def test_正常系_2023_2024年指定で4件取得(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_beige_book_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+        reports = fetcher.list_reports(year_range=(2023, 2024))
+
+        assert all(isinstance(r, BeigeBookReport) for r in reports)
+        years = sorted({r.date.year for r in reports})
+        assert years == [2023, 2024]
+        # Fixture contains 2 items in 2023, 2 in 2024, and 1 in 1995.
+        assert len(reports) == 4
+
+    def test_正常系_client_list_itemsがtitle_idで呼ばれる(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_beige_book_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+        fetcher.list_reports(year_range=(2023, 2024), limit=50)
+
+        mock_client.list_items.assert_called_once()
+        positional_args, kwargs = mock_client.list_items.call_args
+        assert positional_args[0] == _BEIGE_BOOK_TITLE_ID
+        assert kwargs.get("limit", 50) == 50
+
+
+# ---------------------------------------------------------------------------
+# _to_beige_book_report
+# ---------------------------------------------------------------------------
+
+
+class TestToBeigeBookReport:
+    def test_正常系_FraserItemからBeigeBookReportへ変換(self) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 1,
+                "titleId": 1234,
+                "title": "Beige Book January 2024",
+                "date": "2024-01-17",
+            }
+        )
+        fetcher = BeigeBookFetcher(client=MagicMock(), downloader=MagicMock())
+        report = fetcher._to_beige_book_report(item)
+        assert isinstance(report, BeigeBookReport)
+        assert report.item_id == 1
+        assert report.date.isoformat() == "2024-01-17"
+
+    def test_正常系_BeigeBookReport入力はそのまま返却(self) -> None:
+        report = BeigeBookReport.model_validate(
+            {
+                "itemId": 9,
+                "title": "x",
+                "date": "2024-01-01",
+                "district": "Boston",
+            }
+        )
+        fetcher = BeigeBookFetcher(client=MagicMock(), downloader=MagicMock())
+        result = fetcher._to_beige_book_report(report)
+        assert result is report
+        assert result.district == "Boston"
+
+
+# ---------------------------------------------------------------------------
+# fetch_text
+# ---------------------------------------------------------------------------
+
+
+class TestFetchText:
+    def test_正常系_fetch_textでBeigeBookReportが返る(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_beige_book_items_response)
+        target_item = next(i for i in items if i.item_id == 2003)
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        expected_path = tmp_path / "beige_book" / "2024-03-06_2003.txt"
+        expected_meta = expected_path.with_suffix(".meta.json")
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            expected_path,
+            expected_meta,
+        )
+
+        fetcher = BeigeBookFetcher(
+            client=mock_client,
+            downloader=mock_downloader,
+        )
+        path, report = fetcher.fetch_text(2003, prefer="txt")
+
+        assert path == expected_path
+        assert isinstance(report, BeigeBookReport)
+        assert report.item_id == 2003
+
+
+# ---------------------------------------------------------------------------
+# fetch_all
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAll:
+    def test_正常系_fetch_all並列DLでdict返却(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+        tmp_path: Path,
+    ) -> None:
+        """``fetch_all`` returns dict[item_id, Path] when every download succeeds."""
+        items = _items_from_sample(sample_beige_book_items_response)
+        target_items = [i for i in items if i.date.year in (2023, 2024)]
+        assert len(target_items) == 4
+
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        # ``fetch_text`` is bypassed by patching ``_fetch_text_path`` directly
+        # so we don't have to wire up the downloader for each per-item call.
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+
+        def _fake_fetch(item_id: int, prefer: str) -> Path:
+            return tmp_path / f"beige_book_{item_id}.{prefer}"
+
+        with patch.object(
+            fetcher, "_fetch_text_path", side_effect=_fake_fetch
+        ) as patched:
+            results = fetcher.fetch_all((2023, 2024), max_workers=4)
+
+        assert set(results.keys()) == {i.item_id for i in target_items}
+        for item_id, outcome in results.items():
+            assert isinstance(outcome, Path)
+            assert outcome == tmp_path / f"beige_book_{item_id}.txt"
+        # _fetch_text_path was invoked once per target item.
+        assert patched.call_count == len(target_items)
+
+    def test_正常系_fetch_all_max_workersクランプ(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+        tmp_path: Path,
+    ) -> None:
+        """``max_workers`` above ``MAX_WORKERS_LIMIT`` is silently clamped."""
+        items = _items_from_sample(sample_beige_book_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+
+        captured: dict[str, object] = {}
+
+        class _RecordingExecutor(ThreadPoolExecutor):
+            def __init__(self, max_workers: int, **_kwargs: object) -> None:
+                captured["max_workers"] = max_workers
+                super().__init__(max_workers=max_workers)
+
+        with (
+            patch.object(
+                fetcher,
+                "_fetch_text_path",
+                side_effect=lambda item_id, prefer: tmp_path / f"{item_id}.txt",
+            ),
+            patch(
+                "market.fraser.fetchers.beige_book.ThreadPoolExecutor",
+                _RecordingExecutor,
+            ),
+        ):
+            fetcher.fetch_all((2023, 2024), max_workers=100)
+
+        assert captured["max_workers"] == MAX_WORKERS_LIMIT
+
+    def test_異常系_max_workersが0以下でValueError(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_beige_book_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+
+        with pytest.raises(ValueError, match="max_workers must be >= 1"):
+            fetcher.fetch_all((2023, 2024), max_workers=0)
+
+    def test_正常系_fetch_all部分障害をException値で保持(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+        tmp_path: Path,
+    ) -> None:
+        """A failing future is captured in the result dict as an Exception value."""
+        items = _items_from_sample(sample_beige_book_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+
+        failing_id = 2003
+
+        def _fake_fetch(item_id: int, prefer: str) -> Path:
+            if item_id == failing_id:
+                raise RuntimeError(f"injected failure for {item_id}")
+            return tmp_path / f"beige_book_{item_id}.{prefer}"
+
+        with patch.object(fetcher, "_fetch_text_path", side_effect=_fake_fetch):
+            results = fetcher.fetch_all((2023, 2024), max_workers=2)
+
+        assert failing_id in results
+        assert isinstance(results[failing_id], RuntimeError)
+        assert "injected failure" in str(results[failing_id])
+
+        # All other items still produced Path values.
+        for item_id, outcome in results.items():
+            if item_id == failing_id:
+                continue
+            assert isinstance(outcome, Path)
+
+    def test_正常系_fetch_all範囲外空結果(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_beige_book_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+        # Range with no items in fixture (fixture covers 1995, 2023, 2024).
+        results = fetcher.fetch_all((1900, 1950), max_workers=4)
+        assert results == {}
+
+    def test_正常系_fetch_all_preferがfetch_textへ伝搬(
+        self,
+        sample_beige_book_items_response: dict[str, object],
+        beige_book_title_id: int,
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_beige_book_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = BeigeBookFetcher(client=mock_client, downloader=MagicMock())
+        observed: list[str] = []
+
+        def _fake_fetch(item_id: int, prefer: str) -> Path:
+            observed.append(prefer)
+            return tmp_path / f"{item_id}.{prefer}"
+
+        with patch.object(fetcher, "_fetch_text_path", side_effect=_fake_fetch):
+            fetcher.fetch_all((2024, 2024), max_workers=2, prefer="pdf")
+
+        assert observed
+        assert set(observed) == {"pdf"}

--- a/tests/market/fraser/unit/test_fetchers_beige_book.py
+++ b/tests/market/fraser/unit/test_fetchers_beige_book.py
@@ -353,4 +353,6 @@ class TestFetchAll:
         with patch.object(fetcher, "_fetch_text_path", side_effect=_fake_fetch):
             fetcher.fetch_all((2024, 2024), max_workers=2, prefer="pdf")
 
-        assert set(observed) == {"pdf"}, "fetch_all did not propagate prefer to _fetch_text_path"
+        assert set(observed) == {"pdf"}, (
+            "fetch_all did not propagate prefer to _fetch_text_path"
+        )

--- a/tests/market/fraser/unit/test_fetchers_beige_book.py
+++ b/tests/market/fraser/unit/test_fetchers_beige_book.py
@@ -112,11 +112,21 @@ class TestListReports:
 
 
 # ---------------------------------------------------------------------------
-# _to_beige_book_report
+# _convert_to (shared helper replacing the legacy ``_to_beige_book_report``)
 # ---------------------------------------------------------------------------
 
 
-class TestToBeigeBookReport:
+class TestConvertToBeigeBookReport:
+    """Exercises :meth:`BaseFraserFetcher._convert_to` for BeigeBookReport.
+
+    The legacy ``_to_beige_book_report`` per-fetcher helper was removed
+    in PR #3967 in favour of the shared ``_convert_to`` static helper.
+    Unlike the deleted helper, ``_convert_to`` always re-validates and
+    therefore returns a fresh instance even when the input already
+    matches the target type — the equality assertion below replaces the
+    previous identity check.
+    """
+
     def test_正常系_FraserItemからBeigeBookReportへ変換(self) -> None:
         item = FraserItem.model_validate(
             {
@@ -127,12 +137,18 @@ class TestToBeigeBookReport:
             }
         )
         fetcher = BeigeBookFetcher(client=MagicMock(), downloader=MagicMock())
-        report = fetcher._to_beige_book_report(item)
+        report = fetcher._convert_to(item, BeigeBookReport)
         assert isinstance(report, BeigeBookReport)
         assert report.item_id == 1
         assert report.date.isoformat() == "2024-01-17"
 
-    def test_正常系_BeigeBookReport入力はそのまま返却(self) -> None:
+    def test_正常系_BeigeBookReport入力でもdistrict保持(self) -> None:
+        """``_convert_to`` re-validates so ``district`` survives the round-trip.
+
+        The previous behaviour returned the same instance via ``isinstance``
+        short-circuit; ``_convert_to`` always builds a new model, so we
+        assert equality on the carried-over field instead of identity.
+        """
         report = BeigeBookReport.model_validate(
             {
                 "itemId": 9,
@@ -142,8 +158,8 @@ class TestToBeigeBookReport:
             }
         )
         fetcher = BeigeBookFetcher(client=MagicMock(), downloader=MagicMock())
-        result = fetcher._to_beige_book_report(report)
-        assert result is report
+        result = fetcher._convert_to(report, BeigeBookReport)
+        assert isinstance(result, BeigeBookReport)
         assert result.district == "Boston"
 
 

--- a/tests/market/fraser/unit/test_fetchers_beige_book.py
+++ b/tests/market/fraser/unit/test_fetchers_beige_book.py
@@ -353,5 +353,4 @@ class TestFetchAll:
         with patch.object(fetcher, "_fetch_text_path", side_effect=_fake_fetch):
             fetcher.fetch_all((2024, 2024), max_workers=2, prefer="pdf")
 
-        assert observed
-        assert set(observed) == {"pdf"}
+        assert set(observed) == {"pdf"}, "fetch_all did not propagate prefer to _fetch_text_path"

--- a/tests/market/fraser/unit/test_fetchers_fomc.py
+++ b/tests/market/fraser/unit/test_fetchers_fomc.py
@@ -24,7 +24,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+from market.fraser.errors import FraserValidationError
+from market.fraser.fetchers.fomc import (
+    FOMCMinutesFetcher,
+    FOMCPressConferencesFetcher,
+    FOMCStatementsFetcher,
+)
 from market.fraser.models import FOMCMeeting, FraserItem
 from market.fraser.types import DocType
 
@@ -199,3 +204,272 @@ class TestFetchText:
 
         _, kwargs = mock_downloader.download_with_meta.call_args
         assert kwargs["prefer"] == "pdf"
+
+
+# ---------------------------------------------------------------------------
+# FOMCStatementsFetcher
+# ---------------------------------------------------------------------------
+
+
+class TestFOMCStatementsFetcherDocType:
+    def test_正常系_doc_typeはFOMC_STATEMENTS(self) -> None:
+        fetcher = FOMCStatementsFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher.doc_type is DocType.FOMC_STATEMENTS
+
+
+class TestFOMCStatementsFetcherListStatements:
+    """Tests for :meth:`FOMCStatementsFetcher.list_statements`."""
+
+    def test_正常系_2024年指定で2024年itemのみFOMCMeeting返却(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # ``fomc_statements`` is currently None in KNOWN_TITLE_IDS; inject a
+        # dummy value so that title_id resolution succeeds for the year-filter
+        # branch we want to test.
+        from market.fraser.fetchers import base as base_module
+
+        monkeypatch.setitem(base_module.KNOWN_TITLE_IDS, "fomc_statements", 99999)
+
+        # Reuse the shared FOMC fixture; ``list_statements`` filters by year
+        # the same way ``list_minutes`` does, so the fixture works as-is.
+        items = _items_from_sample(sample_fomc_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FOMCStatementsFetcher(client=mock_client, downloader=MagicMock())
+        meetings = fetcher.list_statements(year_range=(2024, 2024))
+
+        assert all(isinstance(m, FOMCMeeting) for m in meetings)
+        years = sorted({m.date.year for m in meetings})
+        assert years == [2024]
+        # Fixture contains 4 items dated in 2024.
+        assert len(meetings) == 4
+
+    def test_正常系_title_id_未確定の場合FraserValidationError(
+        self,
+        sample_fomc_items_response: dict[str, object],
+    ) -> None:
+        """``title_id`` lookup raises when neither KNOWN_TITLE_IDS nor JSON has a value.
+
+        ``fomc_statements`` is currently ``None`` in ``KNOWN_TITLE_IDS`` and
+        the operator JSON file. Resolving the title_id should raise
+        :class:`FraserValidationError` until task-2 populates the mapping.
+        """
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = _items_from_sample(
+            sample_fomc_items_response
+        )
+
+        fetcher = FOMCStatementsFetcher(client=mock_client, downloader=MagicMock())
+        # ``list_statements`` resolves ``title_id`` via the property, which
+        # currently has no confirmed value for fomc_statements.
+        with pytest.raises(FraserValidationError):
+            _ = fetcher.title_id
+
+    def test_正常系_title_id_jsonにあれば返却(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``fraser_titles.json`` provides a title_id, list_statements works."""
+        from market.fraser.fetchers import base as base_module
+
+        # Write a JSON file with a known title_id and point the base module at it.
+        titles_json = tmp_path / "fraser_titles.json"
+        titles_json.write_text('{"fomc_statements": 12345}\n', encoding="utf-8")
+        monkeypatch.setattr(base_module, "DEFAULT_TITLES_JSON_PATH", titles_json)
+
+        items = _items_from_sample(sample_fomc_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FOMCStatementsFetcher(client=mock_client, downloader=MagicMock())
+        meetings = fetcher.list_statements(year_range=(2024, 2024))
+
+        # Confirm title_id was resolved via the JSON fallback and forwarded
+        # to ``client.list_items``.
+        positional_args, _ = mock_client.list_items.call_args
+        assert positional_args[0] == 12345
+        assert all(isinstance(m, FOMCMeeting) for m in meetings)
+
+
+class TestFOMCStatementsFetcherFetchText:
+    """Tests for :meth:`FOMCStatementsFetcher.fetch_text`."""
+
+    def test_正常系_fetch_textでファイル生成パスが返る(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_fomc_items_response)
+        target_item = next(i for i in items if i.item_id == 1002)
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        expected_path = tmp_path / "fomc" / "statements" / "2024-03-20_1002.txt"
+        expected_meta = expected_path.with_suffix(".meta.json")
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            expected_path,
+            expected_meta,
+        )
+
+        fetcher = FOMCStatementsFetcher(
+            client=mock_client,
+            downloader=mock_downloader,
+        )
+        path, meeting = fetcher.fetch_text(1002, prefer="txt")
+
+        assert path == expected_path
+        assert isinstance(meeting, FOMCMeeting)
+        assert meeting.item_id == 1002
+
+    def test_正常系_fetch_textのpreferがdownloaderに伝搬(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_fomc_items_response)
+        target_item = items[0]
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            tmp_path / "asset.pdf",
+            tmp_path / "asset.meta.json",
+        )
+
+        fetcher = FOMCStatementsFetcher(client=mock_client, downloader=mock_downloader)
+        fetcher.fetch_text(target_item.item_id, prefer="pdf")
+
+        _, kwargs = mock_downloader.download_with_meta.call_args
+        assert kwargs["prefer"] == "pdf"
+
+
+# ---------------------------------------------------------------------------
+# FOMCPressConferencesFetcher
+# ---------------------------------------------------------------------------
+
+
+class TestFOMCPressConferencesFetcherDocType:
+    def test_正常系_doc_typeはFOMC_PRESS_CONFERENCES(self) -> None:
+        fetcher = FOMCPressConferencesFetcher(
+            client=MagicMock(), downloader=MagicMock()
+        )
+        assert fetcher.doc_type is DocType.FOMC_PRESS_CONFERENCES
+
+
+class TestFOMCPressConferencesFetcherListPressConferences:
+    """Tests for :meth:`FOMCPressConferencesFetcher.list_press_conferences`."""
+
+    def test_正常系_2024年指定で2024年itemのみFOMCMeeting返却(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # ``fomc_press_conferences`` is currently None in KNOWN_TITLE_IDS;
+        # inject a dummy value so the year-filter branch is exercised.
+        from market.fraser.fetchers import base as base_module
+
+        monkeypatch.setitem(
+            base_module.KNOWN_TITLE_IDS, "fomc_press_conferences", 88888
+        )
+
+        items = _items_from_sample(sample_fomc_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FOMCPressConferencesFetcher(
+            client=mock_client, downloader=MagicMock()
+        )
+        meetings = fetcher.list_press_conferences(year_range=(2024, 2024))
+
+        assert all(isinstance(m, FOMCMeeting) for m in meetings)
+        years = sorted({m.date.year for m in meetings})
+        assert years == [2024]
+        assert len(meetings) == 4
+
+    def test_正常系_title_id_未確定の場合FraserValidationError(
+        self,
+        sample_fomc_items_response: dict[str, object],
+    ) -> None:
+        """``title_id`` lookup raises when neither KNOWN_TITLE_IDS nor JSON has a value."""
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = _items_from_sample(
+            sample_fomc_items_response
+        )
+
+        fetcher = FOMCPressConferencesFetcher(
+            client=mock_client, downloader=MagicMock()
+        )
+        with pytest.raises(FraserValidationError):
+            _ = fetcher.title_id
+
+    def test_正常系_title_id_jsonにあれば返却(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``fraser_titles.json`` provides a title_id, list works."""
+        from market.fraser.fetchers import base as base_module
+
+        titles_json = tmp_path / "fraser_titles.json"
+        titles_json.write_text('{"fomc_press_conferences": 54321}\n', encoding="utf-8")
+        monkeypatch.setattr(base_module, "DEFAULT_TITLES_JSON_PATH", titles_json)
+
+        items = _items_from_sample(sample_fomc_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FOMCPressConferencesFetcher(
+            client=mock_client, downloader=MagicMock()
+        )
+        meetings = fetcher.list_press_conferences(year_range=(2024, 2024))
+
+        positional_args, _ = mock_client.list_items.call_args
+        assert positional_args[0] == 54321
+        assert all(isinstance(m, FOMCMeeting) for m in meetings)
+
+
+class TestFOMCPressConferencesFetcherFetchText:
+    """Tests for :meth:`FOMCPressConferencesFetcher.fetch_text`."""
+
+    def test_正常系_fetch_text_pdf_fallback(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        """``prefer='pdf'`` is propagated to the downloader (TXT fallback path)."""
+        items = _items_from_sample(sample_fomc_items_response)
+        # Pick the 2024-03-20 item (item_id=1002) which only exposes pdfUrl.
+        target_item = next(i for i in items if i.item_id == 1002)
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        expected_path = tmp_path / "fomc" / "press_conferences" / "2024-03-20_1002.pdf"
+        expected_meta = expected_path.with_suffix(".meta.json")
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            expected_path,
+            expected_meta,
+        )
+
+        fetcher = FOMCPressConferencesFetcher(
+            client=mock_client,
+            downloader=mock_downloader,
+        )
+        path, meeting = fetcher.fetch_text(1002, prefer="pdf")
+
+        _, kwargs = mock_downloader.download_with_meta.call_args
+        assert kwargs["prefer"] == "pdf"
+        assert path == expected_path
+        assert isinstance(meeting, FOMCMeeting)
+        assert meeting.item_id == 1002

--- a/tests/market/fraser/unit/test_fetchers_fomc.py
+++ b/tests/market/fraser/unit/test_fetchers_fomc.py
@@ -3,16 +3,20 @@
 Covers:
 
 - ``list_minutes`` returns ``FOMCMeeting`` instances filtered by year.
-- ``_to_fomc_meeting`` correctly inherits ``FraserItem`` fields when
-  converting from a ``FraserItem``.
+- ``BaseFraserFetcher._convert_to`` correctly inherits ``FraserItem``
+  fields when converting from a ``FraserItem``. The shared helper
+  replaces the per-class ``_to_fomc_meeting`` duplication removed in
+  PR #3967 (HIGH-2).
 - ``fetch_text`` writes files under ``<base>/fomc/minutes/`` with the
   expected ``<YYYY-MM-DD>_<itemId>.txt`` naming.
 - Multiple ``date`` string formats are accepted (``YYYY-MM-DD``,
-  ``YYYY-MM``, ``YYYY``).
+  ``YYYY-MM``, ``YYYY``) — exercised via ``_convert_to(item, FOMCMeeting)``
+  to ensure the date-coercion path survives the consolidation.
 
 See Also
 --------
 market.fraser.fetchers.fomc : Class under test.
+market.fraser.fetchers.base : ``BaseFraserFetcher._convert_to`` helper.
 tests.market.fraser.conftest : Shared fixtures
     (``sample_fomc_items_response``).
 """
@@ -108,11 +112,19 @@ class TestListMinutes:
 
 
 # ---------------------------------------------------------------------------
-# _to_fomc_meeting
+# _convert_to (shared helper replacing the legacy ``_to_fomc_meeting``)
 # ---------------------------------------------------------------------------
 
 
-class TestToFomcMeeting:
+class TestConvertToFomcMeeting:
+    """Exercises :meth:`BaseFraserFetcher._convert_to` for FOMCMeeting.
+
+    The legacy ``_to_fomc_meeting`` per-fetcher helpers were removed in
+    PR #3967 in favour of the shared static helper. These tests pin the
+    date-coercion behaviour that callers relied on so the consolidation
+    does not silently regress ``YYYY-MM`` / ``YYYY`` handling.
+    """
+
     def test_正常系_FraserItemからFOMCMeetingへ変換できる(self) -> None:
         item = FraserItem.model_validate(
             {
@@ -123,7 +135,7 @@ class TestToFomcMeeting:
             }
         )
         fetcher = FOMCMinutesFetcher(client=MagicMock(), downloader=MagicMock())
-        meeting = fetcher._to_fomc_meeting(item)
+        meeting = fetcher._convert_to(item, FOMCMeeting)
         assert isinstance(meeting, FOMCMeeting)
         assert meeting.item_id == 1
         assert meeting.date.isoformat() == "2024-03-20"
@@ -141,7 +153,7 @@ class TestToFomcMeeting:
     ) -> None:
         item = FraserItem.model_validate({"itemId": 5, "title": "x", "date": date_str})
         fetcher = FOMCMinutesFetcher(client=MagicMock(), downloader=MagicMock())
-        meeting = fetcher._to_fomc_meeting(item)
+        meeting = fetcher._convert_to(item, FOMCMeeting)
         assert meeting.date.isoformat() == expected_iso
 
 

--- a/tests/market/fraser/unit/test_fetchers_fomc.py
+++ b/tests/market/fraser/unit/test_fetchers_fomc.py
@@ -1,0 +1,201 @@
+"""Unit tests for ``market.fraser.fetchers.fomc.FOMCMinutesFetcher``.
+
+Covers:
+
+- ``list_minutes`` returns ``FOMCMeeting`` instances filtered by year.
+- ``_to_fomc_meeting`` correctly inherits ``FraserItem`` fields when
+  converting from a ``FraserItem``.
+- ``fetch_text`` writes files under ``<base>/fomc/minutes/`` with the
+  expected ``<YYYY-MM-DD>_<itemId>.txt`` naming.
+- Multiple ``date`` string formats are accepted (``YYYY-MM-DD``,
+  ``YYYY-MM``, ``YYYY``).
+
+See Also
+--------
+market.fraser.fetchers.fomc : Class under test.
+tests.market.fraser.conftest : Shared fixtures
+    (``sample_fomc_items_response``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from market.fraser.fetchers.fomc import FOMCMinutesFetcher
+from market.fraser.models import FOMCMeeting, FraserItem
+from market.fraser.types import DocType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _items_from_sample(
+    payload: dict[str, object],
+) -> list[FraserItem]:
+    """Convert the ``sample_fomc_items_response`` fixture into model instances."""
+    raw_items = payload["items"]
+    assert isinstance(raw_items, list)
+    return [FraserItem.model_validate(raw) for raw in raw_items]
+
+
+# ---------------------------------------------------------------------------
+# doc_type
+# ---------------------------------------------------------------------------
+
+
+class TestDocType:
+    def test_正常系_doc_typeはFOMC_MINUTES(self) -> None:
+        fetcher = FOMCMinutesFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher.doc_type is DocType.FOMC_MINUTES
+
+
+# ---------------------------------------------------------------------------
+# list_minutes
+# ---------------------------------------------------------------------------
+
+
+class TestListMinutes:
+    def test_正常系_2024年指定で2024年itemのみFOMCMeeting返却(
+        self,
+        sample_fomc_items_response: dict[str, object],
+    ) -> None:
+        # Build items via the conftest fixture and stub the client.
+        items = _items_from_sample(sample_fomc_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FOMCMinutesFetcher(client=mock_client, downloader=MagicMock())
+        meetings = fetcher.list_minutes(year_range=(2024, 2024))
+
+        assert all(isinstance(m, FOMCMeeting) for m in meetings)
+        # Fixture contains 4 items dated in 2024 and 1 in 1995.
+        years = sorted({m.date.year for m in meetings})
+        assert years == [2024]
+        assert len(meetings) == 4
+
+    def test_正常系_client_list_itemsがtitle_id_677で呼ばれる(
+        self,
+        sample_fomc_items_response: dict[str, object],
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = _items_from_sample(
+            sample_fomc_items_response
+        )
+
+        fetcher = FOMCMinutesFetcher(client=mock_client, downloader=MagicMock())
+        fetcher.list_minutes(year_range=(2024, 2024), limit=50)
+
+        mock_client.list_items.assert_called_once()
+        _, kwargs = mock_client.list_items.call_args
+        # title_id may be passed positionally or as keyword.
+        if kwargs:
+            assert kwargs.get("limit", 50) == 50
+
+        positional_args, _ = mock_client.list_items.call_args
+        assert positional_args[0] == 677  # KNOWN_TITLE_IDS["fomc_minutes"] == 677
+
+
+# ---------------------------------------------------------------------------
+# _to_fomc_meeting
+# ---------------------------------------------------------------------------
+
+
+class TestToFomcMeeting:
+    def test_正常系_FraserItemからFOMCMeetingへ変換できる(self) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 1,
+                "titleId": 677,
+                "title": "FOMC Minutes",
+                "date": "2024-03-20",
+            }
+        )
+        fetcher = FOMCMinutesFetcher(client=MagicMock(), downloader=MagicMock())
+        meeting = fetcher._to_fomc_meeting(item)
+        assert isinstance(meeting, FOMCMeeting)
+        assert meeting.item_id == 1
+        assert meeting.date.isoformat() == "2024-03-20"
+
+    @pytest.mark.parametrize(
+        "date_str,expected_iso",
+        [
+            ("2024-03-20", "2024-03-20"),
+            ("2024-03", "2024-03-01"),
+            ("2024", "2024-01-01"),
+        ],
+    )
+    def test_正常系_dateフォーマット差異吸収(
+        self, date_str: str, expected_iso: str
+    ) -> None:
+        item = FraserItem.model_validate({"itemId": 5, "title": "x", "date": date_str})
+        fetcher = FOMCMinutesFetcher(client=MagicMock(), downloader=MagicMock())
+        meeting = fetcher._to_fomc_meeting(item)
+        assert meeting.date.isoformat() == expected_iso
+
+
+# ---------------------------------------------------------------------------
+# fetch_text
+# ---------------------------------------------------------------------------
+
+
+class TestFetchText:
+    def test_正常系_fetch_textでファイル生成パスが返る(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        """``fetch_text`` returns the path produced by the downloader."""
+        items = _items_from_sample(sample_fomc_items_response)
+        # Pick the 2024-03-20 item (item_id=1002) which has only a pdfUrl.
+        target_item = next(i for i in items if i.item_id == 1002)
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        expected_path = tmp_path / "fomc" / "minutes" / "2024-03-20_1002.txt"
+        expected_meta = expected_path.with_suffix(".meta.json")
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            expected_path,
+            expected_meta,
+        )
+
+        fetcher = FOMCMinutesFetcher(
+            client=mock_client,
+            downloader=mock_downloader,
+        )
+        path, meeting = fetcher.fetch_text(1002, prefer="txt")
+
+        assert path == expected_path
+        assert isinstance(meeting, FOMCMeeting)
+        assert meeting.item_id == 1002
+
+    def test_正常系_fetch_textのpreferがdownloaderに伝搬(
+        self,
+        sample_fomc_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_fomc_items_response)
+        target_item = items[0]
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            tmp_path / "asset.pdf",
+            tmp_path / "asset.meta.json",
+        )
+
+        fetcher = FOMCMinutesFetcher(client=mock_client, downloader=mock_downloader)
+        fetcher.fetch_text(target_item.item_id, prefer="pdf")
+
+        _, kwargs = mock_downloader.download_with_meta.call_args
+        assert kwargs["prefer"] == "pdf"

--- a/tests/market/fraser/unit/test_fetchers_monetary_policy.py
+++ b/tests/market/fraser/unit/test_fetchers_monetary_policy.py
@@ -176,11 +176,19 @@ class TestFetchText:
 
 
 # ---------------------------------------------------------------------------
-# _to_mpr
+# _convert_to (shared helper replacing the legacy ``_to_mpr``)
 # ---------------------------------------------------------------------------
 
 
-class TestToMPR:
+class TestConvertToMPR:
+    """Exercises :meth:`BaseFraserFetcher._convert_to` for MonetaryPolicyReport.
+
+    The legacy ``_to_mpr`` per-fetcher helper was removed in PR #3967 in
+    favour of the shared static helper. ``_convert_to`` always
+    re-validates and therefore returns a fresh instance even when the
+    input already matches the target type.
+    """
+
     def test_正常系_FraserItemからMonetaryPolicyReportへ変換(self) -> None:
         item = FraserItem.model_validate(
             {
@@ -192,11 +200,12 @@ class TestToMPR:
         fetcher = MonetaryPolicyReportFetcher(
             client=MagicMock(), downloader=MagicMock()
         )
-        report = fetcher._to_mpr(item)
+        report = fetcher._convert_to(item, MonetaryPolicyReport)
         assert isinstance(report, MonetaryPolicyReport)
         assert report.item_id == 99
 
-    def test_正常系_MonetaryPolicyReport入力はそのまま返却(self) -> None:
+    def test_正常系_MonetaryPolicyReport入力でもreport_period保持(self) -> None:
+        """``_convert_to`` re-validates so ``report_period`` survives."""
         report = MonetaryPolicyReport.model_validate(
             {
                 "itemId": 11,
@@ -208,6 +217,6 @@ class TestToMPR:
         fetcher = MonetaryPolicyReportFetcher(
             client=MagicMock(), downloader=MagicMock()
         )
-        result = fetcher._to_mpr(report)
-        assert result is report
+        result = fetcher._convert_to(report, MonetaryPolicyReport)
+        assert isinstance(result, MonetaryPolicyReport)
         assert result.report_period == "February 2024"

--- a/tests/market/fraser/unit/test_fetchers_monetary_policy.py
+++ b/tests/market/fraser/unit/test_fetchers_monetary_policy.py
@@ -1,0 +1,213 @@
+"""Unit tests for ``MonetaryPolicyReportFetcher``.
+
+Covers:
+
+- ``doc_type`` reports :data:`DocType.MONETARY_POLICY_REPORT`.
+- ``list_reports`` filters by year and returns
+  :class:`MonetaryPolicyReport` instances.
+- Historical Humphrey-Hawkins archive (1979-2000) is reachable.
+- ``fetch_text`` defaults to ``prefer='pdf'`` because the legacy
+  archive is PDF-only.
+
+See Also
+--------
+market.fraser.fetchers.monetary_policy : Class under test.
+tests.market.fraser.conftest : Shared fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from market.fraser.fetchers.monetary_policy import MonetaryPolicyReportFetcher
+from market.fraser.models import FraserItem, MonetaryPolicyReport
+from market.fraser.types import DocType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MPR_TITLE_ID: int = 33333
+
+
+@pytest.fixture
+def mpr_title_id(monkeypatch: pytest.MonkeyPatch) -> int:
+    """Inject a dummy title_id for ``monetary_policy_report`` into KNOWN_TITLE_IDS."""
+    from market.fraser.fetchers import base as base_module
+
+    monkeypatch.setitem(
+        base_module.KNOWN_TITLE_IDS, "monetary_policy_report", _MPR_TITLE_ID
+    )
+    return _MPR_TITLE_ID
+
+
+def _items_from_sample(payload: dict[str, object]) -> list[FraserItem]:
+    raw_items = payload["items"]
+    assert isinstance(raw_items, list)
+    return [FraserItem.model_validate(raw) for raw in raw_items]
+
+
+# ---------------------------------------------------------------------------
+# doc_type
+# ---------------------------------------------------------------------------
+
+
+class TestDocType:
+    def test_正常系_doc_typeはMONETARY_POLICY_REPORT(self) -> None:
+        fetcher = MonetaryPolicyReportFetcher(
+            client=MagicMock(), downloader=MagicMock()
+        )
+        assert fetcher.doc_type is DocType.MONETARY_POLICY_REPORT
+
+
+# ---------------------------------------------------------------------------
+# list_reports
+# ---------------------------------------------------------------------------
+
+
+class TestListReports:
+    def test_正常系_2020_2024年指定でモダン期2件取得(
+        self,
+        sample_mpr_items_response: dict[str, object],
+        mpr_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_mpr_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = MonetaryPolicyReportFetcher(
+            client=mock_client, downloader=MagicMock()
+        )
+        reports = fetcher.list_reports(year_range=(2020, 2024))
+
+        assert all(isinstance(r, MonetaryPolicyReport) for r in reports)
+        # Fixture contains 2 items in 2024 plus 1 in 2000 and 1 in 1979.
+        assert len(reports) == 2
+        assert {r.date.year for r in reports} == {2024}
+
+    def test_正常系_歴史アーカイブ_HumphreyHawkins対応(
+        self,
+        sample_mpr_items_response: dict[str, object],
+        mpr_title_id: int,
+    ) -> None:
+        """``year_range`` accepts historical lower bounds (1979)."""
+        items = _items_from_sample(sample_mpr_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = MonetaryPolicyReportFetcher(
+            client=mock_client, downloader=MagicMock()
+        )
+        reports = fetcher.list_reports(year_range=(1979, 2024))
+
+        assert len(reports) == 4
+        years = sorted({r.date.year for r in reports})
+        assert years == [1979, 2000, 2024]
+        # Confirm the Humphrey-Hawkins-era item is included.
+        hh = next(r for r in reports if r.date.year == 1979)
+        assert hh.item_id == 4099
+        assert "Humphrey-Hawkins" in (hh.title or "")
+
+
+# ---------------------------------------------------------------------------
+# fetch_text
+# ---------------------------------------------------------------------------
+
+
+class TestFetchText:
+    def test_正常系_fetch_text_prefer_pdfデフォルト動作(
+        self,
+        sample_mpr_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_mpr_items_response)
+        target_item = next(i for i in items if i.item_id == 4001)
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        expected_path = tmp_path / "monetary_policy" / "2024-02-09_4001.pdf"
+        expected_meta = expected_path.with_suffix(".meta.json")
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            expected_path,
+            expected_meta,
+        )
+
+        fetcher = MonetaryPolicyReportFetcher(
+            client=mock_client,
+            downloader=mock_downloader,
+        )
+        # Call without ``prefer`` — default must be ``"pdf"``.
+        path, report = fetcher.fetch_text(4001)
+
+        assert path == expected_path
+        assert isinstance(report, MonetaryPolicyReport)
+        # Confirm ``prefer="pdf"`` was forwarded to the downloader.
+        _, kwargs = mock_downloader.download_with_meta.call_args
+        assert kwargs["prefer"] == "pdf"
+
+    def test_正常系_fetch_text_prefer_txt明示で上書き(
+        self,
+        sample_mpr_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_mpr_items_response)
+        target_item = next(i for i in items if i.item_id == 4001)
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            tmp_path / "asset.txt",
+            tmp_path / "asset.meta.json",
+        )
+
+        fetcher = MonetaryPolicyReportFetcher(
+            client=mock_client, downloader=mock_downloader
+        )
+        fetcher.fetch_text(4001, prefer="txt")
+
+        _, kwargs = mock_downloader.download_with_meta.call_args
+        assert kwargs["prefer"] == "txt"
+
+
+# ---------------------------------------------------------------------------
+# _to_mpr
+# ---------------------------------------------------------------------------
+
+
+class TestToMPR:
+    def test_正常系_FraserItemからMonetaryPolicyReportへ変換(self) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 99,
+                "title": "MPR",
+                "date": "2024-01-01",
+            }
+        )
+        fetcher = MonetaryPolicyReportFetcher(
+            client=MagicMock(), downloader=MagicMock()
+        )
+        report = fetcher._to_mpr(item)
+        assert isinstance(report, MonetaryPolicyReport)
+        assert report.item_id == 99
+
+    def test_正常系_MonetaryPolicyReport入力はそのまま返却(self) -> None:
+        report = MonetaryPolicyReport.model_validate(
+            {
+                "itemId": 11,
+                "title": "MPR",
+                "date": "2024-01-01",
+                "reportPeriod": "February 2024",
+            }
+        )
+        fetcher = MonetaryPolicyReportFetcher(
+            client=MagicMock(), downloader=MagicMock()
+        )
+        result = fetcher._to_mpr(report)
+        assert result is report
+        assert result.report_period == "February 2024"

--- a/tests/market/fraser/unit/test_fetchers_speeches.py
+++ b/tests/market/fraser/unit/test_fetchers_speeches.py
@@ -169,11 +169,19 @@ class TestListSpeechesSpeakerFilter:
 
 
 # ---------------------------------------------------------------------------
-# _to_frb_speech
+# _convert_to (shared helper replacing the legacy ``_to_frb_speech``)
 # ---------------------------------------------------------------------------
 
 
-class TestToFrbSpeech:
+class TestConvertToFrbSpeech:
+    """Exercises :meth:`BaseFraserFetcher._convert_to` for FRBSpeech.
+
+    The legacy ``_to_frb_speech`` per-fetcher helper was removed in
+    PR #3967 in favour of the shared static helper. ``_convert_to``
+    always re-validates and therefore returns a fresh instance even when
+    the input already matches the target type.
+    """
+
     def test_正常系_FraserItemからFRBSpeechへ変換(self) -> None:
         item = FraserItem.model_validate(
             {
@@ -183,11 +191,12 @@ class TestToFrbSpeech:
             }
         )
         fetcher = FRBSpeechFetcher(client=MagicMock(), downloader=MagicMock())
-        speech = fetcher._to_frb_speech(item)
+        speech = fetcher._convert_to(item, FRBSpeech)
         assert isinstance(speech, FRBSpeech)
         assert speech.item_id == 42
 
-    def test_正常系_FRBSpeech入力はそのまま返却(self) -> None:
+    def test_正常系_FRBSpeech入力でもspeaker保持(self) -> None:
+        """``_convert_to`` re-validates so ``speaker`` survives the round-trip."""
         speech = FRBSpeech.model_validate(
             {
                 "itemId": 7,
@@ -197,8 +206,8 @@ class TestToFrbSpeech:
             }
         )
         fetcher = FRBSpeechFetcher(client=MagicMock(), downloader=MagicMock())
-        result = fetcher._to_frb_speech(speech)
-        assert result is speech
+        result = fetcher._convert_to(speech, FRBSpeech)
+        assert isinstance(result, FRBSpeech)
         assert result.speaker == "Powell"
 
 

--- a/tests/market/fraser/unit/test_fetchers_speeches.py
+++ b/tests/market/fraser/unit/test_fetchers_speeches.py
@@ -1,0 +1,238 @@
+"""Unit tests for ``market.fraser.fetchers.speeches.FRBSpeechFetcher``.
+
+Covers:
+
+- ``doc_type`` reports :data:`DocType.FRB_SPEECHES`.
+- ``list_speeches`` filters by year and returns ``FRBSpeech`` instances.
+- ``list_speeches(speaker=None)`` returns all year-matching speeches.
+- ``list_speeches(speaker='Powell')`` filters by author name
+  (case-insensitive: Powell == powell == POWELL).
+- Historical (1980) speeches are reachable when ``year_range`` includes
+  the historical archive.
+- ``fetch_text`` narrows the return tuple to :class:`FRBSpeech`.
+
+See Also
+--------
+market.fraser.fetchers.speeches : Class under test.
+tests.market.fraser.conftest : Shared fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from market.fraser.fetchers.speeches import FRBSpeechFetcher
+from market.fraser.models import FraserItem, FRBSpeech
+from market.fraser.types import DocType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_FRB_SPEECHES_TITLE_ID: int = 55555
+
+
+@pytest.fixture
+def frb_speeches_title_id(monkeypatch: pytest.MonkeyPatch) -> int:
+    """Inject a dummy title_id for ``frb_speeches`` into KNOWN_TITLE_IDS."""
+    from market.fraser.fetchers import base as base_module
+
+    monkeypatch.setitem(
+        base_module.KNOWN_TITLE_IDS, "frb_speeches", _FRB_SPEECHES_TITLE_ID
+    )
+    return _FRB_SPEECHES_TITLE_ID
+
+
+def _items_from_sample(payload: dict[str, object]) -> list[FraserItem]:
+    raw_items = payload["items"]
+    assert isinstance(raw_items, list)
+    return [FraserItem.model_validate(raw) for raw in raw_items]
+
+
+# ---------------------------------------------------------------------------
+# doc_type
+# ---------------------------------------------------------------------------
+
+
+class TestDocType:
+    def test_正常系_doc_typeはFRB_SPEECHES(self) -> None:
+        fetcher = FRBSpeechFetcher(client=MagicMock(), downloader=MagicMock())
+        assert fetcher.doc_type is DocType.FRB_SPEECHES
+
+
+# ---------------------------------------------------------------------------
+# list_speeches (no speaker filter)
+# ---------------------------------------------------------------------------
+
+
+class TestListSpeechesNoFilter:
+    def test_正常系_speakerNoneで2024年全件返却(
+        self,
+        sample_speech_items_response: dict[str, object],
+        frb_speeches_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_speech_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FRBSpeechFetcher(client=mock_client, downloader=MagicMock())
+        speeches = fetcher.list_speeches(year_range=(2024, 2024))
+
+        assert all(isinstance(s, FRBSpeech) for s in speeches)
+        # Fixture has 4 speeches dated in 2024 (3001, 3002, 3003, 3005).
+        assert len(speeches) == 4
+        assert all(s.date.year == 2024 for s in speeches)
+
+
+# ---------------------------------------------------------------------------
+# list_speeches (speaker filter)
+# ---------------------------------------------------------------------------
+
+
+class TestListSpeechesSpeakerFilter:
+    def test_正常系_speakerPowell大文字小文字区別なし(
+        self,
+        sample_speech_items_response: dict[str, object],
+        frb_speeches_title_id: int,
+    ) -> None:
+        """Speaker filtering is case-insensitive (Powell == powell == POWELL)."""
+        items = _items_from_sample(sample_speech_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FRBSpeechFetcher(client=mock_client, downloader=MagicMock())
+
+        # Three variants must all return the same Powell speech ids.
+        ids_capital = {
+            s.item_id for s in fetcher.list_speeches((2024, 2024), speaker="Powell")
+        }
+        ids_lower = {
+            s.item_id for s in fetcher.list_speeches((2024, 2024), speaker="powell")
+        }
+        ids_upper = {
+            s.item_id for s in fetcher.list_speeches((2024, 2024), speaker="POWELL")
+        }
+
+        assert ids_capital == ids_lower == ids_upper
+        # 3001 + 3002 are Powell authors; 3005 mentions Powell in description.
+        assert ids_capital == {3001, 3002, 3005}
+
+    def test_正常系_speakerCook単一マッチ(
+        self,
+        sample_speech_items_response: dict[str, object],
+        frb_speeches_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_speech_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FRBSpeechFetcher(client=mock_client, downloader=MagicMock())
+        cook_speeches = fetcher.list_speeches((2024, 2024), speaker="Cook")
+
+        assert len(cook_speeches) == 1
+        assert cook_speeches[0].item_id == 3003
+
+    def test_正常系_speaker未マッチで空リスト(
+        self,
+        sample_speech_items_response: dict[str, object],
+        frb_speeches_title_id: int,
+    ) -> None:
+        items = _items_from_sample(sample_speech_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FRBSpeechFetcher(client=mock_client, downloader=MagicMock())
+        assert fetcher.list_speeches((2024, 2024), speaker="Bernanke") == []
+
+    def test_正常系_歴史アーカイブVolcker1980年取得(
+        self,
+        sample_speech_items_response: dict[str, object],
+        frb_speeches_title_id: int,
+    ) -> None:
+        """Speaker filter works on historical archive (1970s-1980s)."""
+        items = _items_from_sample(sample_speech_items_response)
+        mock_client = MagicMock()
+        mock_client.list_items.return_value = items
+
+        fetcher = FRBSpeechFetcher(client=mock_client, downloader=MagicMock())
+        volcker = fetcher.list_speeches((1970, 1985), speaker="Volcker")
+
+        assert len(volcker) == 1
+        assert volcker[0].item_id == 3004
+        assert volcker[0].date.year == 1980
+
+
+# ---------------------------------------------------------------------------
+# _to_frb_speech
+# ---------------------------------------------------------------------------
+
+
+class TestToFrbSpeech:
+    def test_正常系_FraserItemからFRBSpeechへ変換(self) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 42,
+                "title": "Speech",
+                "date": "2024-01-01",
+            }
+        )
+        fetcher = FRBSpeechFetcher(client=MagicMock(), downloader=MagicMock())
+        speech = fetcher._to_frb_speech(item)
+        assert isinstance(speech, FRBSpeech)
+        assert speech.item_id == 42
+
+    def test_正常系_FRBSpeech入力はそのまま返却(self) -> None:
+        speech = FRBSpeech.model_validate(
+            {
+                "itemId": 7,
+                "title": "x",
+                "date": "2024-01-01",
+                "speaker": "Powell",
+            }
+        )
+        fetcher = FRBSpeechFetcher(client=MagicMock(), downloader=MagicMock())
+        result = fetcher._to_frb_speech(speech)
+        assert result is speech
+        assert result.speaker == "Powell"
+
+
+# ---------------------------------------------------------------------------
+# fetch_text
+# ---------------------------------------------------------------------------
+
+
+class TestFetchText:
+    def test_正常系_fetch_textでFRBSpeechが返る(
+        self,
+        sample_speech_items_response: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        items = _items_from_sample(sample_speech_items_response)
+        target_item = next(i for i in items if i.item_id == 3001)
+
+        mock_client = MagicMock()
+        mock_client.get_item.return_value = target_item
+
+        expected_path = tmp_path / "speeches" / "2024-02-07_3001.txt"
+        expected_meta = expected_path.with_suffix(".meta.json")
+        mock_downloader = MagicMock()
+        mock_downloader.download_with_meta.return_value = (
+            expected_path,
+            expected_meta,
+        )
+
+        fetcher = FRBSpeechFetcher(
+            client=mock_client,
+            downloader=mock_downloader,
+        )
+        path, speech = fetcher.fetch_text(3001, prefer="txt")
+
+        assert path == expected_path
+        assert isinstance(speech, FRBSpeech)
+        assert speech.item_id == 3001

--- a/tests/market/fraser/unit/test_models.py
+++ b/tests/market/fraser/unit/test_models.py
@@ -1,0 +1,347 @@
+"""Unit tests for ``market.fraser.models`` module.
+
+Covers:
+
+- Sample FOMC items payload parses end-to-end (5 items, mixed date
+  formats).
+- camelCase aliases (``itemId``, ``titleId``, ``pdfUrl``, ``textUrl``)
+  map to snake_case fields when ``populate_by_name=True``.
+- ``FraserLocation.pdf_url`` accepts ``None`` and ``list[str]``.
+- ``FOMCMeeting`` / ``BeigeBookReport`` / ``FRBSpeech`` /
+  ``MonetaryPolicyReport`` derive from ``FraserItem``.
+- ``field_validator('date')`` handles ``YYYY-MM-DD`` / ``YYYY-MM`` /
+  ``YYYY`` formats.
+- ``FraserTitle`` requires ``title_id`` and ``name``.
+- ``extra='ignore'`` keeps unknown fields out of the model.
+"""
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from market.fraser.models import (
+    BeigeBookReport,
+    FOMCMeeting,
+    FraserAuthor,
+    FraserItem,
+    FraserLocation,
+    FraserSubject,
+    FraserTheme,
+    FraserTimelineEvent,
+    FraserTitle,
+    FraserTocEntry,
+    FRBSpeech,
+    MonetaryPolicyReport,
+)
+
+# =============================================================================
+# FraserLocation tests
+# =============================================================================
+
+
+class TestFraserLocation:
+    """Tests for ``FraserLocation``."""
+
+    def test_正常系_pdf_url_text_url_None(self) -> None:
+        loc = FraserLocation()
+        assert loc.pdf_url is None
+        assert loc.text_url is None
+
+    def test_正常系_camelCaseエイリアスでpdfUrlを受け付ける(self) -> None:
+        loc = FraserLocation.model_validate(
+            {"pdfUrl": ["https://x/a.pdf"], "textUrl": ["https://x/a.txt"]}
+        )
+        assert loc.pdf_url == ["https://x/a.pdf"]
+        assert loc.text_url == ["https://x/a.txt"]
+
+    def test_正常系_snake_caseでも作成可能(self) -> None:
+        loc = FraserLocation(pdf_url=["https://x/b.pdf"])
+        assert loc.pdf_url == ["https://x/b.pdf"]
+        assert loc.text_url is None
+
+    def test_エッジケース_extra_ignoreで未知フィールドを無視(self) -> None:
+        loc = FraserLocation.model_validate(
+            {"pdfUrl": ["https://x"], "unknownField": "ignored"}
+        )
+        assert loc.pdf_url == ["https://x"]
+        assert not hasattr(loc, "unknownField")
+
+
+# =============================================================================
+# FraserItem tests
+# =============================================================================
+
+
+class TestFraserItem:
+    """Tests for ``FraserItem`` base model."""
+
+    def test_正常系_最小構成で作成できる(self) -> None:
+        item = FraserItem.model_validate(
+            {"itemId": 1, "title": "Sample", "date": "2024-01-31"}
+        )
+        assert item.item_id == 1
+        assert item.title == "Sample"
+        assert item.date == date(2024, 1, 31)
+
+    def test_正常系_camelCaseエイリアスでitemIdが解釈される(self) -> None:
+        item = FraserItem.model_validate(
+            {"itemId": 42, "titleId": 677, "title": "x", "date": "2024-01-01"}
+        )
+        assert item.item_id == 42
+        assert item.title_id == 677
+
+    def test_異常系_item_id欠落でValidationError(self) -> None:
+        with pytest.raises(ValidationError):
+            FraserItem.model_validate({"title": "x", "date": "2024-01-01"})
+
+    def test_異常系_title欠落でValidationError(self) -> None:
+        with pytest.raises(ValidationError):
+            FraserItem.model_validate({"itemId": 1, "date": "2024-01-01"})
+
+    def test_異常系_date欠落でValidationError(self) -> None:
+        with pytest.raises(ValidationError):
+            FraserItem.model_validate({"itemId": 1, "title": "x"})
+
+
+class TestFraserItemDateFormats:
+    """Tests for ``field_validator('date', mode='before')`` formats."""
+
+    def test_正常系_YYYYMMDD形式(self) -> None:
+        item = FraserItem.model_validate(
+            {"itemId": 1, "title": "x", "date": "2024-03-20"}
+        )
+        assert item.date == date(2024, 3, 20)
+
+    def test_正常系_YYYYMM形式(self) -> None:
+        item = FraserItem.model_validate({"itemId": 1, "title": "x", "date": "2024-04"})
+        # YYYY-MM should normalise to the first day of the month.
+        assert item.date == date(2024, 4, 1)
+
+    def test_正常系_YYYY形式(self) -> None:
+        item = FraserItem.model_validate({"itemId": 1, "title": "x", "date": "1995"})
+        assert item.date == date(1995, 1, 1)
+
+    def test_正常系_dateオブジェクトを直接受け付ける(self) -> None:
+        item = FraserItem.model_validate(
+            {"itemId": 1, "title": "x", "date": date(2024, 5, 10)}
+        )
+        assert item.date == date(2024, 5, 10)
+
+
+class TestFraserItemOptionalNested:
+    """Tests for optional nested fields on ``FraserItem``."""
+
+    def test_正常系_locationを保持する(self) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 1,
+                "title": "x",
+                "date": "2024-01-01",
+                "location": {"pdfUrl": ["https://x/1.pdf"]},
+            }
+        )
+        assert item.location is not None
+        assert item.location.pdf_url == ["https://x/1.pdf"]
+
+    def test_正常系_authors_subjects_themesを保持する(self) -> None:
+        item = FraserItem.model_validate(
+            {
+                "itemId": 1,
+                "title": "x",
+                "date": "2024-01-01",
+                "authors": [{"name": "Alice", "authorId": 10}],
+                "subjects": [{"name": "Monetary Policy", "subjectId": 20}],
+                "themes": [{"name": "Banking", "themeId": 30}],
+            }
+        )
+        assert item.authors is not None and item.authors[0].name == "Alice"
+        assert item.authors[0].author_id == 10
+        assert item.subjects is not None and item.subjects[0].subject_id == 20
+        assert item.themes is not None and item.themes[0].theme_id == 30
+
+
+# =============================================================================
+# Sample fixture parsing
+# =============================================================================
+
+
+class TestSampleFomcItemsResponse:
+    """Tests using the ``sample_fomc_items_response`` fixture."""
+
+    def test_正常系_5件全てパース成功(
+        self, sample_fomc_items_response: dict[str, object]
+    ) -> None:
+        raw_items = sample_fomc_items_response["items"]
+        assert isinstance(raw_items, list)
+        parsed = [FraserItem.model_validate(it) for it in raw_items]
+        assert len(parsed) == 5
+        # All items have item_id, title, and a date set.
+        for item in parsed:
+            assert item.item_id is not None
+            assert item.title
+            assert item.date is not None
+
+    def test_正常系_部分日付フォーマットが混在しても全件パース(
+        self, sample_fomc_items_response: dict[str, object]
+    ) -> None:
+        raw_items = sample_fomc_items_response["items"]
+        assert isinstance(raw_items, list)
+        parsed = [FraserItem.model_validate(it) for it in raw_items]
+        dates = [item.date for item in parsed]
+        # YYYY-MM-DD
+        assert date(2024, 1, 31) in dates
+        # YYYY-MM normalised to first of month
+        assert date(2024, 4, 1) in dates
+        # YYYY normalised to first of year
+        assert date(1995, 1, 1) in dates
+
+
+# =============================================================================
+# Domain model tests
+# =============================================================================
+
+
+class TestFOMCMeeting:
+    """Tests for ``FOMCMeeting``."""
+
+    def test_正常系_FraserItem派生(self) -> None:
+        assert issubclass(FOMCMeeting, FraserItem)
+
+    def test_正常系_meeting_date_meeting_typeを保持(self) -> None:
+        meeting = FOMCMeeting.model_validate(
+            {
+                "itemId": 1,
+                "title": "FOMC Minutes",
+                "date": "2024-01-31",
+                "meetingDate": "2024-01-30",
+                "meetingType": "regular",
+            }
+        )
+        assert meeting.meeting_date == date(2024, 1, 30)
+        assert meeting.meeting_type == "regular"
+
+    def test_正常系_meeting_dateがNoneでも作成可能(self) -> None:
+        meeting = FOMCMeeting.model_validate(
+            {"itemId": 1, "title": "x", "date": "2024-01-01"}
+        )
+        assert meeting.meeting_date is None
+
+
+class TestBeigeBookReport:
+    """Tests for ``BeigeBookReport``."""
+
+    def test_正常系_FraserItem派生(self) -> None:
+        assert issubclass(BeigeBookReport, FraserItem)
+
+    def test_正常系_district保持(self) -> None:
+        report = BeigeBookReport.model_validate(
+            {
+                "itemId": 2,
+                "title": "Beige Book",
+                "date": "2024-01-17",
+                "district": "national",
+            }
+        )
+        assert report.district == "national"
+
+
+class TestFRBSpeech:
+    """Tests for ``FRBSpeech``."""
+
+    def test_正常系_FraserItem派生(self) -> None:
+        assert issubclass(FRBSpeech, FraserItem)
+
+    def test_正常系_speaker_venue保持(self) -> None:
+        speech = FRBSpeech.model_validate(
+            {
+                "itemId": 3,
+                "title": "Speech",
+                "date": "2024-02-01",
+                "speaker": "Jerome Powell",
+                "venue": "Washington, DC",
+            }
+        )
+        assert speech.speaker == "Jerome Powell"
+        assert speech.venue == "Washington, DC"
+
+
+class TestMonetaryPolicyReport:
+    """Tests for ``MonetaryPolicyReport``."""
+
+    def test_正常系_FraserItem派生(self) -> None:
+        assert issubclass(MonetaryPolicyReport, FraserItem)
+
+    def test_正常系_report_period保持(self) -> None:
+        report = MonetaryPolicyReport.model_validate(
+            {
+                "itemId": 4,
+                "title": "MPR",
+                "date": "2024-02-21",
+                "reportPeriod": "February 2024",
+            }
+        )
+        assert report.report_period == "February 2024"
+
+
+# =============================================================================
+# Auxiliary model tests
+# =============================================================================
+
+
+class TestFraserTitle:
+    """Tests for ``FraserTitle``."""
+
+    def test_正常系_必須フィールドで作成(self) -> None:
+        title = FraserTitle.model_validate({"titleId": 677, "name": "FOMC"})
+        assert title.title_id == 677
+        assert title.name == "FOMC"
+        assert title.item_count is None
+
+    def test_異常系_title_id欠落でValidationError(self) -> None:
+        with pytest.raises(ValidationError):
+            FraserTitle.model_validate({"name": "FOMC"})
+
+
+class TestFraserTocEntry:
+    """Tests for ``FraserTocEntry``."""
+
+    def test_正常系_全フィールドオプショナル(self) -> None:
+        entry = FraserTocEntry()
+        assert entry.label is None
+        assert entry.page is None
+        assert entry.anchor is None
+
+
+class TestFraserAuthor:
+    """Tests for ``FraserAuthor``."""
+
+    def test_正常系_authorIdエイリアス(self) -> None:
+        author = FraserAuthor.model_validate({"name": "Jane Doe", "authorId": 7})
+        assert author.author_id == 7
+
+
+class TestFraserSubject:
+    """Tests for ``FraserSubject``."""
+
+    def test_正常系_subjectIdエイリアス(self) -> None:
+        subject = FraserSubject.model_validate({"name": "Monetary", "subjectId": 11})
+        assert subject.subject_id == 11
+
+
+class TestFraserTheme:
+    """Tests for ``FraserTheme``."""
+
+    def test_正常系_themeIdエイリアス(self) -> None:
+        theme = FraserTheme.model_validate({"name": "Banking", "themeId": 22})
+        assert theme.theme_id == 22
+
+
+class TestFraserTimelineEvent:
+    """Tests for ``FraserTimelineEvent``."""
+
+    def test_正常系_event_dateを部分形式で受け付ける(self) -> None:
+        event = FraserTimelineEvent.model_validate(
+            {"label": "Founded", "eventDate": "1913"}
+        )
+        assert event.event_date == date(1913, 1, 1)

--- a/tests/market/fraser/unit/test_parser.py
+++ b/tests/market/fraser/unit/test_parser.py
@@ -1,0 +1,169 @@
+"""Tests for ``market.fraser.parser`` module.
+
+Verifies that the parser wrappers transform raw JSON into Pydantic models
+and raise :class:`FraserParseError` (with ``raw_data`` / ``field`` /
+``cause`` populated, and the original ``ValidationError`` chained via
+``raise ... from``) when required fields are missing.
+
+See Also
+--------
+market.fraser.parser : Module under test.
+market.fraser.errors : ``FraserParseError`` definition.
+market.fraser.models : Pydantic models used as parse targets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from market.fraser.errors import FraserParseError
+from market.fraser.parser import (
+    parse_authors,
+    parse_item,
+    parse_items,
+    parse_subjects,
+    parse_themes,
+    parse_timeline,
+    parse_title,
+    parse_toc,
+)
+
+# ---------------------------------------------------------------------------
+# parse_items / parse_item
+# ---------------------------------------------------------------------------
+
+
+class TestParseItems:
+    """Verify :func:`parse_items` happy paths and failure modes."""
+
+    def test_正常系_FOMC形式のレスポンスをパース成功(
+        self, sample_fomc_items_response: dict[str, Any]
+    ) -> None:
+        items = parse_items(sample_fomc_items_response)
+        assert len(items) == 5
+        assert items[0].item_id == 1001
+        assert items[0].title.startswith("Minutes")
+        assert items[2].date.year == 2024
+
+    def test_正常系_リスト形式の入力もパース成功(self) -> None:
+        payload = [
+            {"itemId": 10, "title": "X", "date": "2024-01-01"},
+            {"itemId": 11, "title": "Y", "date": "2024-02-01"},
+        ]
+        items = parse_items(payload)
+        assert [i.item_id for i in items] == [10, 11]
+
+    def test_異常系_itemsキー欠損でFraserParseError(self) -> None:
+        with pytest.raises(FraserParseError) as exc_info:
+            parse_items({"meta": {}})
+        err = exc_info.value
+        assert err.field == "items"
+        # raw_data must contain the original JSON for debuggability.
+        assert "meta" in err.raw_data
+
+    def test_異常系_itemsが配列でないとFraserParseError(self) -> None:
+        with pytest.raises(FraserParseError) as exc_info:
+            parse_items({"items": {"not": "a list"}})
+        assert exc_info.value.field == "items"
+
+    def test_異常系_必須フィールド欠損で詳細エラー(self) -> None:
+        # Drop the required ``itemId`` from the first entry.
+        bad_payload = {
+            "items": [
+                {"title": "no item_id", "date": "2024-01-01"},
+            ]
+        }
+        with pytest.raises(FraserParseError) as exc_info:
+            parse_items(bad_payload)
+
+        err = exc_info.value
+        # Pydantic reports the missing field by its serialised alias
+        # (``itemId``) when ``populate_by_name=True`` is in effect.
+        assert err.field in {"item_id", "itemId"}
+        # raw_data should retain the original JSON.
+        assert "no item_id" in err.raw_data
+        # The cause should be a Pydantic ValidationError.
+        assert isinstance(err.cause, ValidationError)
+        # raise ... from ... chaining.
+        assert err.__cause__ is err.cause
+
+
+class TestParseItem:
+    """Verify :func:`parse_item` for the single-item path."""
+
+    def test_正常系_camelCaseで構築成功(self) -> None:
+        data = {"itemId": 42, "title": "OK", "date": "2024-05-25"}
+        item = parse_item(data)
+        assert item.item_id == 42
+        assert item.title == "OK"
+        assert item.date.year == 2024
+
+    def test_異常系_dateフィールド欠損で例外(self) -> None:
+        data = {"itemId": 42, "title": "OK"}
+        with pytest.raises(FraserParseError) as exc_info:
+            parse_item(data)
+        assert "date" in exc_info.value.field
+
+
+# ---------------------------------------------------------------------------
+# parse_title
+# ---------------------------------------------------------------------------
+
+
+class TestParseTitle:
+    def test_正常系_最小ペイロードで構築(self) -> None:
+        title = parse_title({"titleId": 677, "name": "FOMC"})
+        assert title.title_id == 677
+        assert title.name == "FOMC"
+
+    def test_異常系_titleIdなしで例外(self) -> None:
+        with pytest.raises(FraserParseError) as exc_info:
+            parse_title({"name": "no id"})
+        assert exc_info.value.field in {"title_id", "titleId"}
+        assert isinstance(exc_info.value.cause, ValidationError)
+
+
+# ---------------------------------------------------------------------------
+# parse_toc / parse_authors / parse_subjects / parse_themes / parse_timeline
+# ---------------------------------------------------------------------------
+
+
+class TestParseAuxiliaryCollections:
+    """Verify the small auxiliary parsers accept both shapes."""
+
+    def test_正常系_toc配列を直接受け取れる(self) -> None:
+        entries = parse_toc([{"label": "Intro", "page": 1}])
+        assert len(entries) == 1
+        assert entries[0].label == "Intro"
+
+    def test_正常系_toc_dict_with_key(self) -> None:
+        entries = parse_toc({"toc": [{"label": "Body", "page": 2}]})
+        assert entries[0].page == 2
+
+    def test_正常系_authorsの基本パース(self) -> None:
+        authors = parse_authors([{"name": "A", "authorId": 1}])
+        assert authors[0].author_id == 1
+
+    def test_正常系_subjectsの基本パース(self) -> None:
+        subjects = parse_subjects([{"name": "macro", "subjectId": 10}])
+        assert subjects[0].subject_id == 10
+
+    def test_正常系_themesの基本パース(self) -> None:
+        themes = parse_themes([{"name": "policy", "themeId": 100}])
+        assert themes[0].theme_id == 100
+
+    def test_正常系_timelineの基本パース(self) -> None:
+        events = parse_timeline(
+            [{"label": "Founded", "eventDate": "1913", "description": "Fed"}]
+        )
+        assert events[0].label == "Founded"
+        assert events[0].event_date is not None
+        assert events[0].event_date.year == 1913
+
+    def test_異常系_authorsが配列でないと例外(self) -> None:
+        with pytest.raises(FraserParseError) as exc_info:
+            parse_authors({"authors": {"not": "a list"}})
+        assert exc_info.value.field == "authors"

--- a/tests/market/fraser/unit/test_rate_limiter.py
+++ b/tests/market/fraser/unit/test_rate_limiter.py
@@ -84,7 +84,7 @@ class TestAcquireBehaviour:
 
         waited = limiter.acquire()
 
-        assert waited == 0.0
+        assert waited == pytest.approx(0.0, abs=1e-9)
         assert limiter.available_minute == 4
         assert limiter.available_hour == 99
 
@@ -93,7 +93,7 @@ class TestAcquireBehaviour:
         limiter = get_fraser_rate_limiter(config)
 
         for _ in range(3):
-            assert limiter.acquire() == 0.0
+            assert limiter.acquire() == pytest.approx(0.0, abs=1e-9)
 
         assert limiter.available_minute == 2
         assert limiter.available_hour == 97
@@ -135,8 +135,8 @@ class TestTimeControlledBlocking:
         limiter = get_fraser_rate_limiter(config)
 
         # Consume the two allowed slots at t=1000.
-        assert limiter.acquire() == 0.0
-        assert limiter.acquire() == 0.0
+        assert limiter.acquire() == pytest.approx(0.0, abs=1e-9)
+        assert limiter.acquire() == pytest.approx(0.0, abs=1e-9)
 
         # The third acquire should wait until t = 1000 + 60 = 1060.
         waited = limiter.acquire()

--- a/tests/market/fraser/unit/test_rate_limiter.py
+++ b/tests/market/fraser/unit/test_rate_limiter.py
@@ -1,0 +1,160 @@
+"""Unit tests for ``market.fraser.rate_limiter`` module.
+
+Covers:
+
+- ``DualWindowRateLimiter`` is re-exported from
+  ``market.alphavantage.rate_limiter`` (identity check, not a copy).
+- ``get_fraser_rate_limiter`` returns a ``DualWindowRateLimiter``
+  instance configured with the per-minute / per-hour values from
+  ``FraserConfig``.
+- Acquired slots reduce ``available_minute`` / ``available_hour`` by
+  one (sanity check for the underlying behaviour).
+- Time-controlled blocking uses ``monkeypatch.setattr(time,
+  "monotonic", ...)`` to verify the limiter blocks when full and
+  unblocks when the window slides.
+"""
+
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from market.alphavantage.rate_limiter import (
+    DualWindowRateLimiter as AlphaVantageDualWindowRateLimiter,
+)
+from market.fraser import rate_limiter as fraser_rate_limiter
+from market.fraser.rate_limiter import (
+    DualWindowRateLimiter,
+    get_fraser_rate_limiter,
+)
+from market.fraser.types import FraserConfig
+
+
+class TestReExport:
+    """Tests verifying re-export semantics."""
+
+    def test_正常系_DualWindowRateLimiterはalphavantageからの再エクスポート(
+        self,
+    ) -> None:
+        """The re-exported class must be the *same* object."""
+        assert DualWindowRateLimiter is AlphaVantageDualWindowRateLimiter
+
+    def test_正常系_rate_limiterモジュールに新規実装なし(self) -> None:
+        """``rate_limiter.py`` must not define its own limiter class.
+
+        Confirms HF1 directive (re-use, no re-implementation).
+        """
+        assert "DualWindowRateLimiter" not in fraser_rate_limiter.__dict__ or (
+            fraser_rate_limiter.DualWindowRateLimiter
+            is AlphaVantageDualWindowRateLimiter
+        )
+
+
+class TestGetFraserRateLimiter:
+    """Tests for ``get_fraser_rate_limiter``."""
+
+    def test_正常系_戻り値型がDualWindowRateLimiter(self) -> None:
+        config = FraserConfig(api_key="x")
+        limiter = get_fraser_rate_limiter(config)
+        assert isinstance(limiter, DualWindowRateLimiter)
+
+    def test_正常系_デフォルトFraserConfigで30毎分1800毎時(self) -> None:
+        config = FraserConfig(api_key="x")
+        limiter = get_fraser_rate_limiter(config)
+        assert limiter.available_minute == 30
+        assert limiter.available_hour == 1800
+
+    def test_正常系_カスタム設定が反映される(self) -> None:
+        config = FraserConfig(
+            api_key="x",
+            requests_per_minute=10,
+            requests_per_hour=600,
+        )
+        limiter = get_fraser_rate_limiter(config)
+        assert limiter.available_minute == 10
+        assert limiter.available_hour == 600
+
+
+class TestAcquireBehaviour:
+    """Tests for ``DualWindowRateLimiter.acquire`` behaviour through the factory."""
+
+    def test_正常系_acquireで毎分残数が減少(self) -> None:
+        config = FraserConfig(api_key="x", requests_per_minute=5, requests_per_hour=100)
+        limiter = get_fraser_rate_limiter(config)
+
+        waited = limiter.acquire()
+
+        assert waited == 0.0
+        assert limiter.available_minute == 4
+        assert limiter.available_hour == 99
+
+    def test_正常系_複数回acquireで残数が正しく減少(self) -> None:
+        config = FraserConfig(api_key="x", requests_per_minute=5, requests_per_hour=100)
+        limiter = get_fraser_rate_limiter(config)
+
+        for _ in range(3):
+            assert limiter.acquire() == 0.0
+
+        assert limiter.available_minute == 2
+        assert limiter.available_hour == 97
+
+
+class TestTimeControlledBlocking:
+    """Tests using ``monkeypatch.setattr(time, 'monotonic', ...)``."""
+
+    @pytest.fixture
+    def fake_clock(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[list[float]]:
+        """Provide a manually-controllable monotonic clock.
+
+        Yields a mutable ``[current_time]`` list. The
+        ``time.monotonic`` and ``time.sleep`` patches read / advance
+        the first element. ``time.sleep(s)`` does not actually sleep
+        – it simply moves the clock forward, keeping the test fast.
+        """
+        clock = [1000.0]
+
+        def fake_monotonic() -> float:
+            return clock[0]
+
+        def fake_sleep(seconds: float) -> None:
+            clock[0] += seconds
+
+        monkeypatch.setattr(time, "monotonic", fake_monotonic)
+        # ``DualWindowRateLimiter`` uses ``time.sleep`` from the
+        # imported module reference; patch the same name on the
+        # original alphavantage module so that the patched sleep is
+        # picked up regardless of how the limiter resolves ``time``.
+        monkeypatch.setattr("market.alphavantage.rate_limiter.time.sleep", fake_sleep)
+        yield clock
+
+    def test_正常系_毎分制限到達で待機が必要になる(
+        self, fake_clock: list[float]
+    ) -> None:
+        """After consuming the per-minute quota, the limiter must block."""
+        config = FraserConfig(api_key="x", requests_per_minute=2, requests_per_hour=100)
+        limiter = get_fraser_rate_limiter(config)
+
+        # Consume the two allowed slots at t=1000.
+        assert limiter.acquire() == 0.0
+        assert limiter.acquire() == 0.0
+
+        # The third acquire should wait until t = 1000 + 60 = 1060.
+        waited = limiter.acquire()
+        assert waited == pytest.approx(60.0, abs=0.5)
+        # The clock advanced by the wait amount.
+        assert fake_clock[0] == pytest.approx(1060.0, abs=0.5)
+
+    def test_正常系_時間経過後にスロットが回復する(
+        self, fake_clock: list[float]
+    ) -> None:
+        """Advancing time past the minute window restores availability."""
+        config = FraserConfig(api_key="x", requests_per_minute=2, requests_per_hour=100)
+        limiter = get_fraser_rate_limiter(config)
+
+        limiter.acquire()
+        limiter.acquire()
+        assert limiter.available_minute == 0
+
+        # Advance the fake clock past the minute window.
+        fake_clock[0] += 61.0
+        assert limiter.available_minute == 2

--- a/tests/market/fraser/unit/test_scripts_discover_titles.py
+++ b/tests/market/fraser/unit/test_scripts_discover_titles.py
@@ -1,0 +1,342 @@
+"""Unit tests for ``market.fraser.scripts.discover_titles``.
+
+Covers argument parsing, subject / title traversal, interactive vs
+non-interactive selection, and the merge-and-write JSON output logic.
+
+The tests deliberately avoid network access by stubbing
+``FraserSession`` with ``MagicMock`` and feeding canned response bodies
+through ``mock_httpx_response_factory``-style helpers. This mirrors the
+HF1 pattern adopted across the FRASER unit suite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from market.fraser.errors import FraserError
+from market.fraser.scripts import discover_titles
+
+
+def _make_response(payload: dict[str, Any]) -> MagicMock:
+    """Return a MagicMock that mimics ``httpx.Response.json()``."""
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def _make_session(responses: list[dict[str, Any]]) -> MagicMock:
+    """Return a MagicMock FraserSession that returns ``responses`` in order."""
+    session = MagicMock()
+    session.get_with_retry.side_effect = [_make_response(p) for p in responses]
+    return session
+
+
+class TestParseArgs:
+    """Argument parsing surface."""
+
+    def test_正常系_デフォルト引数(self) -> None:
+        args = discover_titles.parse_args([])
+
+        assert args.output == discover_titles.DEFAULT_OUTPUT_PATH
+        assert args.interactive is False
+        assert args.keywords == discover_titles.DEFAULT_KEYWORDS
+
+    def test_正常系_interactiveフラグ(self) -> None:
+        args = discover_titles.parse_args(["--interactive"])
+
+        assert args.interactive is True
+
+    def test_正常系_outputパス上書き(self, tmp_path: Any) -> None:
+        custom_path = tmp_path / "fraser_titles.json"
+        args = discover_titles.parse_args(["--output", str(custom_path)])
+
+        assert args.output == custom_path
+
+    def test_正常系_keywords差し替え(self) -> None:
+        args = discover_titles.parse_args(
+            ["--keywords", "Beige Book", "Monetary Policy Report"]
+        )
+
+        assert args.keywords == ["Beige Book", "Monetary Policy Report"]
+
+
+class TestFetchSubjects:
+    """``fetch_subjects`` payload handling."""
+
+    def test_正常系_subjects配列を返す(self) -> None:
+        subjects = [{"id": 1, "name": "FOMC"}, {"id": 2, "name": "Beige Book"}]
+        session = _make_session([{"subjects": subjects}])
+
+        result = discover_titles.fetch_subjects(session)
+
+        assert result == subjects
+
+    def test_エッジケース_dict以外のレスポンスで空リスト(self) -> None:
+        session = _make_session([{"subjects": "not-a-list"}])
+
+        result = discover_titles.fetch_subjects(session)
+
+        assert result == []
+
+    def test_エッジケース_subjectsキーなしで空リスト(self) -> None:
+        session = _make_session([{"items": []}])
+
+        result = discover_titles.fetch_subjects(session)
+
+        assert result == []
+
+    def test_エッジケース_リストレスポンスで空リスト(self) -> None:
+        session = MagicMock()
+        session.get_with_retry.return_value = _make_response([])  # type: ignore[arg-type]
+
+        result = discover_titles.fetch_subjects(session)
+
+        assert result == []
+
+
+class TestFindMatchingSubjects:
+    """``find_matching_subjects`` filter."""
+
+    def test_正常系_部分一致でフィルタ(self) -> None:
+        subjects = [
+            {"id": 1, "name": "Federal Open Market Committee"},
+            {"id": 2, "name": "Beige Book"},
+            {"id": 3, "name": "FOMC Press"},
+        ]
+
+        matched = discover_titles.find_matching_subjects(subjects, "FOMC")
+
+        assert len(matched) == 1
+        assert matched[0]["id"] == 3
+
+    def test_正常系_大文字小文字非依存(self) -> None:
+        subjects = [{"id": 1, "name": "Federal Open Market Committee"}]
+
+        matched = discover_titles.find_matching_subjects(
+            subjects, "federal open market"
+        )
+
+        assert len(matched) == 1
+
+    def test_エッジケース_nameフィールドなしで除外(self) -> None:
+        subjects = [{"id": 1}, {"id": 2, "name": "Beige Book"}]
+
+        matched = discover_titles.find_matching_subjects(subjects, "Beige")
+
+        assert len(matched) == 1
+        assert matched[0]["id"] == 2
+
+
+class TestFetchTitlesForSubject:
+    """``fetch_titles_for_subject`` payload handling."""
+
+    def test_正常系_titles配列を返す(self) -> None:
+        titles = [{"id": 100, "name": "Title A"}, {"id": 200, "name": "Title B"}]
+        session = _make_session([{"titles": titles}])
+
+        result = discover_titles.fetch_titles_for_subject(session, subject_id=99)
+
+        assert result == titles
+        session.get_with_retry.assert_called_once()
+
+    def test_エッジケース_titlesなしで空リスト(self) -> None:
+        session = _make_session([{}])
+
+        result = discover_titles.fetch_titles_for_subject(session, subject_id=99)
+
+        assert result == []
+
+
+class TestSelectTitle:
+    """``_select_title`` interactive / auto selection."""
+
+    def test_エッジケース_空候補でNone(self) -> None:
+        chosen = discover_titles._select_title([], "Keyword", interactive=False)
+
+        assert chosen is None
+
+    def test_正常系_非対話モードで先頭候補(self) -> None:
+        titles = [{"id": 42, "name": "First"}, {"id": 99, "name": "Second"}]
+
+        chosen = discover_titles._select_title(titles, "X", interactive=False)
+
+        assert chosen == 42
+
+    def test_エッジケース_非対話モード_id無しでNone(self) -> None:
+        titles = [{"name": "Missing id"}]
+
+        chosen = discover_titles._select_title(titles, "X", interactive=False)
+
+        assert chosen is None
+
+    def test_正常系_対話モードで数値選択(self) -> None:
+        titles = [{"id": 10, "name": "A"}, {"id": 20, "name": "B"}]
+
+        with patch("builtins.input", side_effect=["2"]):
+            chosen = discover_titles._select_title(titles, "X", interactive=True)
+
+        assert chosen == 20
+
+    def test_正常系_対話モードでskip(self) -> None:
+        titles = [{"id": 10, "name": "A"}]
+
+        with patch("builtins.input", side_effect=["s"]):
+            chosen = discover_titles._select_title(titles, "X", interactive=True)
+
+        assert chosen is None
+
+    def test_異常系_対話モード_範囲外でリトライ(self) -> None:
+        titles = [{"id": 10, "name": "A"}]
+
+        with patch("builtins.input", side_effect=["999", "abc", "1"]):
+            chosen = discover_titles._select_title(titles, "X", interactive=True)
+
+        assert chosen == 10
+
+
+class TestDiscoverTitleIds:
+    """``discover_title_ids`` end-to-end orchestration."""
+
+    def test_エッジケース_subjects空で即空dict(self) -> None:
+        session = _make_session([{"subjects": []}])
+
+        result = discover_titles.discover_title_ids(
+            session, keywords=["Beige Book"], interactive=False
+        )
+
+        assert result == {}
+
+    def test_正常系_keywordsからdiscovery(self) -> None:
+        subjects_payload = {
+            "subjects": [
+                {"id": 1, "name": "Beige Book"},
+            ]
+        }
+        titles_payload = {
+            "titles": [{"id": 555, "name": "Beige Book Reports"}],
+        }
+        session = MagicMock()
+        session.get_with_retry.side_effect = [
+            _make_response(subjects_payload),
+            _make_response(titles_payload),
+        ]
+
+        result = discover_titles.discover_title_ids(
+            session, keywords=["Beige Book"], interactive=False
+        )
+
+        assert result == {"beige_book": 555}
+
+    def test_エッジケース_未マップキーワードはスキップ(self) -> None:
+        session = _make_session([{"subjects": [{"id": 1, "name": "Anything"}]}])
+
+        result = discover_titles.discover_title_ids(
+            session, keywords=["Not A Real Category"], interactive=False
+        )
+
+        assert result == {}
+
+    def test_異常系_titlesフェッチエラーは継続(self) -> None:
+        subjects_payload = {
+            "subjects": [
+                {"id": 1, "name": "Beige Book"},
+                {"id": 2, "name": "Beige Book Archive"},
+            ]
+        }
+        titles_payload = {"titles": [{"id": 700, "name": "Reports"}]}
+        session = MagicMock()
+        session.get_with_retry.side_effect = [
+            _make_response(subjects_payload),
+            FraserError("simulated failure"),
+            _make_response(titles_payload),
+        ]
+
+        result = discover_titles.discover_title_ids(
+            session, keywords=["Beige Book"], interactive=False
+        )
+
+        assert result == {"beige_book": 700}
+
+
+class TestWriteTitlesJson:
+    """``write_titles_json`` merge + backfill behaviour."""
+
+    def test_正常系_新規ファイル作成_KNOWN_TITLE_IDSバックフィル(
+        self, tmp_path: Any
+    ) -> None:
+        output_path = tmp_path / "fraser_titles.json"
+
+        discover_titles.write_titles_json(output_path, discovered={"beige_book": 700})
+
+        loaded = json.loads(output_path.read_text(encoding="utf-8"))
+        # KNOWN_TITLE_IDS の fomc_minutes (677) がバックフィルされる
+        assert loaded["fomc_minutes"] == 677
+        # discovered の値が含まれる
+        assert loaded["beige_book"] == 700
+
+    def test_正常系_既存値を保持しつつ上書き(self, tmp_path: Any) -> None:
+        output_path = tmp_path / "fraser_titles.json"
+        output_path.write_text(
+            json.dumps({"fomc_minutes": 999, "preserved": 123}), encoding="utf-8"
+        )
+
+        discover_titles.write_titles_json(output_path, discovered={"fomc_minutes": 677})
+
+        loaded = json.loads(output_path.read_text(encoding="utf-8"))
+        assert loaded["fomc_minutes"] == 677
+        assert loaded["preserved"] == 123
+
+    def test_異常系_不正なJSON既存ファイルでフォールバック(self, tmp_path: Any) -> None:
+        output_path = tmp_path / "fraser_titles.json"
+        output_path.write_text("{ not valid json", encoding="utf-8")
+
+        # 例外を投げず、既存={} として処理続行する
+        discover_titles.write_titles_json(output_path, discovered={"beige_book": 700})
+
+        loaded = json.loads(output_path.read_text(encoding="utf-8"))
+        assert loaded["beige_book"] == 700
+
+    def test_エッジケース_親ディレクトリ自動作成(self, tmp_path: Any) -> None:
+        output_path = tmp_path / "nested" / "dir" / "fraser_titles.json"
+
+        discover_titles.write_titles_json(output_path, discovered={"beige_book": 1})
+
+        assert output_path.exists()
+
+
+class TestRun:
+    """``run`` driver function smoke tests."""
+
+    def test_正常系_全工程実行(self, tmp_path: Any) -> None:
+        output_path = tmp_path / "fraser_titles.json"
+        args = argparse.Namespace(
+            output=output_path, interactive=False, keywords=["Beige Book"]
+        )
+
+        subjects_payload = {"subjects": [{"id": 1, "name": "Beige Book"}]}
+        titles_payload = {"titles": [{"id": 555, "name": "Beige Book Reports"}]}
+
+        session_mock = MagicMock()
+        session_mock.__enter__ = MagicMock(return_value=session_mock)
+        session_mock.__exit__ = MagicMock(return_value=False)
+        session_mock.get_with_retry.side_effect = [
+            _make_response(subjects_payload),
+            _make_response(titles_payload),
+        ]
+
+        with patch.object(discover_titles, "FraserSession", return_value=session_mock):
+            exit_code = discover_titles.run(args)
+
+        assert exit_code == 0
+        assert output_path.exists()
+        loaded = json.loads(output_path.read_text(encoding="utf-8"))
+        assert loaded["beige_book"] == 555
+
+
+# Ensure unused pytest import shows up under coverage tools.
+pytestmark = pytest.mark.unit

--- a/tests/market/fraser/unit/test_session.py
+++ b/tests/market/fraser/unit/test_session.py
@@ -209,15 +209,17 @@ class TestXAPIKeyHeaderInjection:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """``FraserAuthError`` is raised when no API key is configured."""
+        """``FraserAuthError`` is raised when no API key is configured.
+
+        The session resolves the API key once at construction time so
+        the failure surfaces eagerly (instead of per-request); this test
+        asserts the error is raised by ``FraserSession.__init__`` itself.
+        """
         monkeypatch.delenv("FRASER_API_KEY", raising=False)
         config = FraserConfig(api_key="", timeout=5.0)
 
-        with (
-            FraserSession(config=config) as session,
-            pytest.raises(FraserAuthError, match="API key"),
-        ):
-            session.get(_FRASER_PATH)
+        with pytest.raises(FraserAuthError, match="API key"):
+            FraserSession(config=config)
 
 
 # =============================================================================

--- a/tests/market/fraser/unit/test_session.py
+++ b/tests/market/fraser/unit/test_session.py
@@ -625,10 +625,20 @@ class TestExponentialBackoffRetry:
     def test_正常系_429_Retry_Afterに従い_sleep(
         self,
         sample_fraser_config: FraserConfig,
-        fast_retry_config: RetryConfig,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Retry uses ``Retry-After`` value when present (preferred over backoff)."""
+        """Retry uses ``Retry-After`` value when present (preferred over backoff).
+
+        The session caps ``retry_after`` by ``RetryConfig.max_wait`` (CWE-400
+        guard), so this test uses ``max_wait=10.0`` to leave headroom above the
+        ``Retry-After: 3`` value while still keeping the backoff bounded.
+        """
+        # Use a retry config whose ``max_wait`` is greater than the Retry-After
+        # value so the ``min(retry_after, max_wait)`` cap does not zero out the
+        # observed sleep argument. ``fast_retry_config`` uses ``max_wait=0.0``
+        # and therefore cannot exercise this code path.
+        retry_config = RetryConfig(max_attempts=3, base_wait=0.0, max_wait=10.0)
+
         err_429 = _make_mock_response(
             status_code=429,
             text="Rate limit",
@@ -645,7 +655,7 @@ class TestExponentialBackoffRetry:
 
         with (
             FraserSession(
-                config=sample_fraser_config, retry_config=fast_retry_config
+                config=sample_fraser_config, retry_config=retry_config
             ) as session,
             patch.object(session._client, "get", side_effect=[err_429, ok]),
         ):

--- a/tests/market/fraser/unit/test_session.py
+++ b/tests/market/fraser/unit/test_session.py
@@ -1,0 +1,718 @@
+"""Tests for ``market.fraser.session`` module.
+
+Tests cover the :class:`FraserSession` class including:
+
+- Initialization and context manager protocol.
+- X-API-Key header injection (no query-parameter authentication).
+- SSRF prevention via ``ALLOWED_HOSTS`` whitelist.
+- HTTPS enforcement.
+- Polite delay between consecutive requests.
+- HTTP status code error mapping (401/403/404/429/4xx/5xx).
+- 429 ``Retry-After`` header parsing and exception attribute population.
+- Exponential backoff retry logic in :meth:`get_with_retry`.
+- Rate limiter integration.
+
+See Also
+--------
+tests.market.alphavantage.unit.test_session : Reference test patterns
+    that were adapted for FRASER (MagicMock(spec=httpx.Response) +
+    patch('FraserSession._client.get')).
+market.fraser.session : Implementation under test.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from market.fraser.errors import (
+    FraserAPIError,
+    FraserAuthError,
+    FraserNotFoundError,
+    FraserRateLimitError,
+    FraserValidationError,
+)
+from market.fraser.session import FraserSession
+from market.fraser.types import FraserConfig, RetryConfig
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+_FRASER_PATH = "/items"
+_FRASER_FULL_URL = "https://fraser.stlouisfed.org/api/items"
+
+
+@pytest.fixture
+def fast_retry_config() -> RetryConfig:
+    """Retry config with fast iteration for tests."""
+    return RetryConfig(max_attempts=3, base_wait=0.0, max_wait=0.0)
+
+
+@pytest.fixture
+def single_attempt_retry_config() -> RetryConfig:
+    """Single-attempt retry config (effectively disables retries)."""
+    return RetryConfig(max_attempts=1, base_wait=0.0, max_wait=0.0)
+
+
+def _make_mock_response(
+    status_code: int = 200,
+    json_data: dict[str, Any] | None = None,
+    text: str = "",
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    """Build a :class:`MagicMock` configured as an ``httpx.Response``."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = text or (str(json_data) if json_data else "")
+    resp.headers = headers or {"Content-Type": "application/json"}
+    return resp
+
+
+# =============================================================================
+# TestFraserSessionInit
+# =============================================================================
+
+
+class TestFraserSessionInit:
+    """Tests for :class:`FraserSession` initialisation."""
+
+    def test_正常系_デフォルト設定で初期化(self) -> None:
+        """Session initialises with default config (api_key from env)."""
+        session = FraserSession()
+        assert isinstance(session, FraserSession)
+        session.close()
+
+    def test_正常系_カスタム設定で初期化(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """Session initialises with custom config."""
+        session = FraserSession(config=sample_fraser_config)
+        assert isinstance(session, FraserSession)
+        session.close()
+
+    def test_正常系_リトライ設定で初期化(
+        self,
+        sample_fraser_config: FraserConfig,
+        fast_retry_config: RetryConfig,
+    ) -> None:
+        """Session initialises with explicit retry config override."""
+        session = FraserSession(
+            config=sample_fraser_config,
+            retry_config=fast_retry_config,
+        )
+        assert isinstance(session, FraserSession)
+        session.close()
+
+
+# =============================================================================
+# TestFraserSessionContextManager
+# =============================================================================
+
+
+class TestFraserSessionContextManager:
+    """Tests for context manager protocol."""
+
+    def test_正常系_context_manager_close呼出(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """``with FraserSession(...)`` calls ``close()`` on exit."""
+        session = FraserSession(config=sample_fraser_config)
+        with patch.object(session._client, "close") as mock_close:
+            with session as s:
+                assert s is session
+            mock_close.assert_called_once()
+
+
+# =============================================================================
+# TestXAPIKeyHeaderInjection
+# =============================================================================
+
+
+class TestXAPIKeyHeaderInjection:
+    """Tests for X-API-Key header injection (no query-param auth)."""
+
+    def test_正常系_X_API_Key_ヘッダ_injection(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """``X-API-Key`` header is injected on every request."""
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(
+                session._client, "get", return_value=mock_response
+            ) as mock_get,
+        ):
+            session.get(_FRASER_PATH)
+
+            call_kwargs = mock_get.call_args
+            actual_headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get(
+                "headers"
+            )
+            assert actual_headers == {"X-API-Key": "dummy_test_key"}
+
+    def test_正常系_apikey_クエリパラメータには注入されない(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """API key is NOT injected into query params (FRASER uses headers)."""
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(
+                session._client, "get", return_value=mock_response
+            ) as mock_get,
+        ):
+            session.get(_FRASER_PATH, params={"titleId": 677})
+
+            call_kwargs = mock_get.call_args
+            actual_params = call_kwargs.kwargs.get("params") or call_kwargs[1].get(
+                "params"
+            )
+            assert actual_params == {"titleId": 677}
+            assert "apikey" not in (actual_params or {})
+
+    def test_正常系_環境変数からAPIキー取得(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API key falls back to ``FRASER_API_KEY`` env var when config is empty."""
+        monkeypatch.setenv("FRASER_API_KEY", "env-fraser-key")
+        config = FraserConfig(api_key="", timeout=5.0)
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        with (
+            FraserSession(config=config) as session,
+            patch.object(
+                session._client, "get", return_value=mock_response
+            ) as mock_get,
+        ):
+            session.get(_FRASER_PATH)
+
+            call_kwargs = mock_get.call_args
+            actual_headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get(
+                "headers"
+            )
+            assert actual_headers == {"X-API-Key": "env-fraser-key"}
+
+    def test_異常系_APIキー未設定でFraserAuthError(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``FraserAuthError`` is raised when no API key is configured."""
+        monkeypatch.delenv("FRASER_API_KEY", raising=False)
+        config = FraserConfig(api_key="", timeout=5.0)
+
+        with (
+            FraserSession(config=config) as session,
+            pytest.raises(FraserAuthError, match="API key"),
+        ):
+            session.get(_FRASER_PATH)
+
+
+# =============================================================================
+# TestSSRFGuard
+# =============================================================================
+
+
+class TestSSRFGuard:
+    """Tests for SSRF prevention via ``ALLOWED_HOSTS`` whitelist."""
+
+    def test_異常系_SSRF_guard_ALLOWED_HOSTS_外で例外(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """Hosts outside ``ALLOWED_HOSTS`` raise ``FraserValidationError``."""
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            pytest.raises(FraserValidationError, match="not in allowed hosts"),
+        ):
+            session.get("https://evil.com/api/items")
+
+    def test_異常系_HTTPS_強制_httpスキームで例外(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """``http://`` scheme raises ``FraserValidationError``."""
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            pytest.raises(FraserValidationError, match="must be 'https'"),
+        ):
+            session.get("http://fraser.stlouisfed.org/api/items")
+
+    def test_異常系_不正なスキームでFraserValidationError(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """Non-http(s) schemes raise ``FraserValidationError``."""
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            pytest.raises(FraserValidationError, match="scheme"),
+        ):
+            session.get("ftp://fraser.stlouisfed.org/api/items")
+
+    def test_正常系_許可されたホストでリクエスト成功(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """Whitelisted host requests proceed without error."""
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            # Should not raise.
+            session.get(_FRASER_FULL_URL)
+
+
+# =============================================================================
+# TestPoliteDelay
+# =============================================================================
+
+
+class TestPoliteDelay:
+    """Tests for polite-delay timing between consecutive requests."""
+
+    def test_正常系_polite_delay_最小間隔保証(
+        self,
+        sample_fraser_config: FraserConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``time.sleep`` is invoked when calls happen faster than the delay."""
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        # Patch ``time.monotonic`` and ``time.sleep`` only inside the session
+        # module so the rate-limiter's own ``time.monotonic()`` calls (in
+        # market.alphavantage.rate_limiter) are unaffected.
+        time_values: list[float] = [100.0, 100.01]
+        call_idx = {"i": 0}
+
+        def _fake_monotonic() -> float:
+            idx = call_idx["i"]
+            value = time_values[min(idx, len(time_values) - 1)]
+            call_idx["i"] += 1
+            return value
+
+        sleep_calls: list[float] = []
+
+        def _fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr("market.fraser.session.time.monotonic", _fake_monotonic)
+        monkeypatch.setattr("market.fraser.session.time.sleep", _fake_sleep)
+        # Eliminate jitter randomness for deterministic asserts.
+        monkeypatch.setattr(
+            "market.fraser.session.random.uniform",
+            lambda _a, _b: 0.0,
+        )
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            session.get(_FRASER_PATH)
+            session.get(_FRASER_PATH)
+
+        # At least one positive sleep should have been recorded on the second
+        # request (polite-delay enforcement).
+        assert any(s > 0 for s in sleep_calls)
+
+
+# =============================================================================
+# TestRateLimiterIntegration
+# =============================================================================
+
+
+class TestRateLimiterIntegration:
+    """Tests for ``DualWindowRateLimiter`` integration."""
+
+    def test_正常系_レートリミッターacquireが呼ばれる(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """``rate_limiter.acquire()`` is called once per ``get()``."""
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._rate_limiter, "acquire") as mock_acquire,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            mock_acquire.return_value = 0.0
+            session.get(_FRASER_PATH)
+            mock_acquire.assert_called_once()
+
+    def test_正常系_30req_per_min_デフォルト(self) -> None:
+        """Default ``requests_per_minute`` is 30 (FRASER documented limit)."""
+        config = FraserConfig(api_key="x")
+        assert config.requests_per_minute == 30
+
+
+# =============================================================================
+# TestHTTPStatusErrorMapping
+# =============================================================================
+
+
+class TestHTTPStatusErrorMapping:
+    """Tests for HTTP status code → FRASER exception mapping."""
+
+    def test_異常系_401_でFraserAuthError(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """HTTP 401 raises :class:`FraserAuthError`."""
+        mock_response = _make_mock_response(status_code=401, text="Unauthorized")
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+            pytest.raises(FraserAuthError, match="401"),
+        ):
+            session.get(_FRASER_PATH)
+
+    def test_異常系_403_でFraserAuthError(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """HTTP 403 raises :class:`FraserAuthError`."""
+        mock_response = _make_mock_response(status_code=403, text="Forbidden")
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+            pytest.raises(FraserAuthError, match="403"),
+        ):
+            session.get(_FRASER_PATH)
+
+    def test_異常系_404_でFraserNotFoundError(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """HTTP 404 raises :class:`FraserNotFoundError`."""
+        mock_response = _make_mock_response(status_code=404, text="Not Found")
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+            pytest.raises(FraserNotFoundError, match="404"),
+        ):
+            session.get(_FRASER_PATH)
+
+    def test_異常系_429_Retry_After_尊重(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """HTTP 429 with ``Retry-After`` populates ``retry_after`` (float seconds)."""
+        mock_response = _make_mock_response(
+            status_code=429,
+            text="Rate limited",
+            headers={"Retry-After": "5"},
+        )
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            with pytest.raises(FraserRateLimitError) as exc_info:
+                session.get(_FRASER_PATH)
+            assert exc_info.value.retry_after == 5.0
+
+    def test_異常系_429_Retry_After_欠落でNone(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """HTTP 429 without ``Retry-After`` yields ``retry_after=None``."""
+        mock_response = _make_mock_response(
+            status_code=429,
+            text="Rate limited",
+            headers={},
+        )
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            with pytest.raises(FraserRateLimitError) as exc_info:
+                session.get(_FRASER_PATH)
+            assert exc_info.value.retry_after is None
+
+    def test_異常系_429_Retry_After_非数値はNone(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """Non-numeric ``Retry-After`` (e.g. HTTP-date) parses as ``None``."""
+        mock_response = _make_mock_response(
+            status_code=429,
+            text="Rate limited",
+            headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+        )
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            with pytest.raises(FraserRateLimitError) as exc_info:
+                session.get(_FRASER_PATH)
+            assert exc_info.value.retry_after is None
+
+    def test_異常系_500_でFraserAPIError_status_code(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """HTTP 500 raises ``FraserAPIError`` with ``status_code=500``."""
+        mock_response = _make_mock_response(
+            status_code=500,
+            text="Internal Server Error",
+        )
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            with pytest.raises(FraserAPIError) as exc_info:
+                session.get(_FRASER_PATH)
+            assert exc_info.value.status_code == 500
+
+    def test_異常系_400_でFraserAPIError(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """HTTP 400 (generic client error) raises ``FraserAPIError``."""
+        mock_response = _make_mock_response(
+            status_code=400,
+            text="Bad Request",
+        )
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(session._client, "get", return_value=mock_response),
+        ):
+            with pytest.raises(FraserAPIError) as exc_info:
+                session.get(_FRASER_PATH)
+            assert exc_info.value.status_code == 400
+
+
+# =============================================================================
+# TestExponentialBackoffRetry
+# =============================================================================
+
+
+class TestExponentialBackoffRetry:
+    """Tests for :meth:`FraserSession.get_with_retry` exponential backoff."""
+
+    def test_正常系_初回成功でリトライなし(
+        self,
+        sample_fraser_config: FraserConfig,
+        fast_retry_config: RetryConfig,
+    ) -> None:
+        """First successful response returns immediately (no retries)."""
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        with (
+            FraserSession(
+                config=sample_fraser_config, retry_config=fast_retry_config
+            ) as session,
+            patch.object(
+                session._client, "get", return_value=mock_response
+            ) as mock_get,
+        ):
+            response = session.get_with_retry(_FRASER_PATH)
+            assert response.status_code == 200
+            assert mock_get.call_count == 1
+
+    def test_正常系_get_with_retry_tenacity_exponential_backoff(
+        self,
+        sample_fraser_config: FraserConfig,
+        fast_retry_config: RetryConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """500 → 500 → 200 succeeds on the third attempt."""
+        err_500 = _make_mock_response(status_code=500, text="Server Error")
+        err_500_b = _make_mock_response(status_code=500, text="Server Error")
+        ok = _make_mock_response(json_data={"items": []})
+
+        # Avoid actual sleeps in tests.
+        monkeypatch.setattr("market.fraser.session.time.sleep", lambda _s: None)
+
+        with (
+            FraserSession(
+                config=sample_fraser_config, retry_config=fast_retry_config
+            ) as session,
+            patch.object(
+                session._client,
+                "get",
+                side_effect=[err_500, err_500_b, ok],
+            ) as mock_get,
+        ):
+            response = session.get_with_retry(_FRASER_PATH)
+            assert response.status_code == 200
+            assert mock_get.call_count == 3
+
+    def test_異常系_全リトライ失敗で最後のエラー再raise(
+        self,
+        sample_fraser_config: FraserConfig,
+        fast_retry_config: RetryConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When all attempts return 500, the final exception is raised."""
+        err_500 = _make_mock_response(status_code=500, text="Server Error")
+
+        monkeypatch.setattr("market.fraser.session.time.sleep", lambda _s: None)
+
+        with (
+            FraserSession(
+                config=sample_fraser_config, retry_config=fast_retry_config
+            ) as session,
+            patch.object(session._client, "get", return_value=err_500),
+            pytest.raises(FraserAPIError),
+        ):
+            session.get_with_retry(_FRASER_PATH)
+
+    def test_異常系_4xxエラーはリトライしない(
+        self,
+        sample_fraser_config: FraserConfig,
+        fast_retry_config: RetryConfig,
+    ) -> None:
+        """Client errors (4xx other than 429) are *not* retried."""
+        err_400 = _make_mock_response(status_code=400, text="Bad Request")
+
+        with (
+            FraserSession(
+                config=sample_fraser_config, retry_config=fast_retry_config
+            ) as session,
+            patch.object(session._client, "get", return_value=err_400) as mock_get,
+        ):
+            with pytest.raises(FraserAPIError):
+                session.get_with_retry(_FRASER_PATH)
+            assert mock_get.call_count == 1
+
+    def test_正常系_429はリトライ対象(
+        self,
+        sample_fraser_config: FraserConfig,
+        fast_retry_config: RetryConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """HTTP 429 triggers retry and succeeds on next attempt."""
+        err_429 = _make_mock_response(
+            status_code=429,
+            text="Rate limit",
+            headers={"Retry-After": "0"},
+        )
+        ok = _make_mock_response(json_data={"items": []})
+
+        monkeypatch.setattr("market.fraser.session.time.sleep", lambda _s: None)
+
+        with (
+            FraserSession(
+                config=sample_fraser_config, retry_config=fast_retry_config
+            ) as session,
+            patch.object(session._client, "get", side_effect=[err_429, ok]),
+        ):
+            response = session.get_with_retry(_FRASER_PATH)
+            assert response.status_code == 200
+
+    def test_正常系_429_Retry_Afterに従い_sleep(
+        self,
+        sample_fraser_config: FraserConfig,
+        fast_retry_config: RetryConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry uses ``Retry-After`` value when present (preferred over backoff)."""
+        err_429 = _make_mock_response(
+            status_code=429,
+            text="Rate limit",
+            headers={"Retry-After": "3"},
+        )
+        ok = _make_mock_response(json_data={"items": []})
+
+        sleep_calls: list[float] = []
+
+        def _record_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr("market.fraser.session.time.sleep", _record_sleep)
+
+        with (
+            FraserSession(
+                config=sample_fraser_config, retry_config=fast_retry_config
+            ) as session,
+            patch.object(session._client, "get", side_effect=[err_429, ok]),
+        ):
+            session.get_with_retry(_FRASER_PATH)
+
+        # Among recorded sleeps, the Retry-After value (3.0) must appear; we
+        # only assert membership because polite-delay may also call sleep.
+        assert 3.0 in sleep_calls
+
+
+# =============================================================================
+# TestURLBuilding
+# =============================================================================
+
+
+class TestURLBuilding:
+    """Tests for relative-path ↔ absolute-URL handling."""
+
+    def test_正常系_相対パスはbase_urlに結合される(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """Relative paths are prefixed with ``base_url``."""
+        mock_response = _make_mock_response(json_data={"items": []})
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(
+                session._client, "get", return_value=mock_response
+            ) as mock_get,
+        ):
+            session.get("/items")
+            called_url = mock_get.call_args.args[0]
+            assert called_url == _FRASER_FULL_URL
+
+    def test_正常系_絶対URLはそのまま使用される(
+        self,
+        sample_fraser_config: FraserConfig,
+    ) -> None:
+        """Absolute URLs are passed through unchanged."""
+        mock_response = _make_mock_response(json_data={"items": []})
+        absolute = "https://fraser.stlouisfed.org/api/title/677"
+
+        with (
+            FraserSession(config=sample_fraser_config) as session,
+            patch.object(
+                session._client, "get", return_value=mock_response
+            ) as mock_get,
+        ):
+            session.get(absolute)
+            called_url = mock_get.call_args.args[0]
+            assert called_url == absolute
+
+
+# =============================================================================
+# Diagnostic helper — keep at end so module load is fast.
+# =============================================================================
+
+
+def test_session_module_exposes_FraserSession() -> None:
+    """Smoke test: :class:`FraserSession` is exported from session module."""
+    from market.fraser.session import FraserSession as _S
+
+    assert _S is FraserSession
+
+
+def test_time_import_marker() -> None:
+    """Sanity test ensuring the ``time`` module is importable in test scope."""
+    # Avoid flake8/ruff F401 noise without affecting runtime behaviour.
+    assert callable(time.monotonic)

--- a/tests/market/fraser/unit/test_session.py
+++ b/tests/market/fraser/unit/test_session.py
@@ -715,14 +715,14 @@ class TestURLBuilding:
 # =============================================================================
 
 
-def test_session_module_exposes_FraserSession() -> None:
-    """Smoke test: :class:`FraserSession` is exported from session module."""
-    from market.fraser.session import FraserSession as _S
+class TestModuleStructure:
+    """Smoke tests for module-level invariants of ``market.fraser.session``."""
 
-    assert _S is FraserSession
+    def test_正常系_sessionモジュールがFraserSessionを公開する(self) -> None:
+        from market.fraser.session import FraserSession as _S
 
+        assert _S is FraserSession
 
-def test_time_import_marker() -> None:
-    """Sanity test ensuring the ``time`` module is importable in test scope."""
-    # Avoid flake8/ruff F401 noise without affecting runtime behaviour.
-    assert callable(time.monotonic)
+    def test_正常系_timeモジュールがimport可能(self) -> None:
+        # Avoid flake8/ruff F401 noise without affecting runtime behaviour.
+        assert callable(time.monotonic)

--- a/tests/market/fraser/unit/test_types.py
+++ b/tests/market/fraser/unit/test_types.py
@@ -1,0 +1,204 @@
+"""Unit tests for ``market.fraser.types`` module.
+
+Covers:
+
+- ``FraserConfig`` default values, custom values, repr secrecy
+  (CWE-532), ``__post_init__`` validation, frozen immutability.
+- ``RetryConfig`` defaults and immutability.
+- ``FetchOptions`` defaults and immutability.
+- ``DocType`` member count, values, and ``str`` inheritance.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from market.fraser.constants import (
+    BASE_URL,
+    DEFAULT_REQUESTS_PER_HOUR,
+    DEFAULT_REQUESTS_PER_MINUTE,
+    DEFAULT_TIMEOUT,
+)
+from market.fraser.errors import FraserValidationError
+from market.fraser.types import (
+    DocType,
+    FetchOptions,
+    FraserConfig,
+    RetryConfig,
+)
+
+# =============================================================================
+# RetryConfig Tests
+# =============================================================================
+
+
+class TestRetryConfig:
+    """Tests for ``RetryConfig`` frozen dataclass."""
+
+    def test_正常系_デフォルト値で生成できる(self) -> None:
+        config = RetryConfig()
+        assert config.max_attempts == 5
+        assert config.base_wait == 1.0
+        assert config.max_wait == 60.0
+
+    def test_正常系_カスタム値で生成できる(self) -> None:
+        config = RetryConfig(max_attempts=3, base_wait=2.0, max_wait=30.0)
+        assert config.max_attempts == 3
+        assert config.base_wait == 2.0
+        assert config.max_wait == 30.0
+
+    def test_エッジケース_frozenで属性変更不可(self) -> None:
+        config = RetryConfig()
+        with pytest.raises(AttributeError):
+            config.max_attempts = 10
+
+
+# =============================================================================
+# FraserConfig Tests
+# =============================================================================
+
+
+class TestFraserConfigDefaults:
+    """Tests for ``FraserConfig`` default values."""
+
+    def test_正常系_デフォルト値で生成できる(self) -> None:
+        config = FraserConfig()
+        assert config.api_key == ""
+        assert config.base_url == BASE_URL
+        assert config.timeout == DEFAULT_TIMEOUT
+        assert config.requests_per_minute == DEFAULT_REQUESTS_PER_MINUTE
+        assert config.requests_per_hour == DEFAULT_REQUESTS_PER_HOUR
+        assert isinstance(config.retry_config, RetryConfig)
+
+    def test_正常系_カスタム値で生成できる(self) -> None:
+        retry = RetryConfig(max_attempts=2)
+        config = FraserConfig(
+            api_key="custom-key",
+            base_url="https://fraser.stlouisfed.org/api",
+            timeout=5.0,
+            requests_per_minute=10,
+            requests_per_hour=600,
+            retry_config=retry,
+        )
+        assert config.api_key == "custom-key"
+        assert config.timeout == 5.0
+        assert config.requests_per_minute == 10
+        assert config.requests_per_hour == 600
+        assert config.retry_config is retry
+
+
+class TestFraserConfigReprSecrecy:
+    """Tests verifying ``api_key`` does not leak via repr (CWE-532)."""
+
+    def test_正常系_api_keyがreprに含まれない(self) -> None:
+        config = FraserConfig(api_key="secret123")
+        assert "secret123" not in repr(config)
+
+    def test_正常系_api_keyフィールド名もreprに含まれない(self) -> None:
+        config = FraserConfig(api_key="anything")
+        assert "api_key" not in repr(config)
+
+
+class TestFraserConfigValidation:
+    """Tests for ``FraserConfig.__post_init__`` validation."""
+
+    def test_異常系_timeoutがゼロでFraserValidationError(self) -> None:
+        with pytest.raises(FraserValidationError, match="timeout must be positive"):
+            FraserConfig(timeout=0)
+
+    def test_異常系_timeoutが負でFraserValidationError(self) -> None:
+        with pytest.raises(FraserValidationError, match="timeout must be positive"):
+            FraserConfig(timeout=-1.0)
+
+    def test_異常系_requests_per_minuteがゼロでFraserValidationError(self) -> None:
+        with pytest.raises(
+            FraserValidationError, match="requests_per_minute must be >= 1"
+        ):
+            FraserConfig(requests_per_minute=0)
+
+    def test_異常系_requests_per_minuteが負でFraserValidationError(self) -> None:
+        with pytest.raises(
+            FraserValidationError, match="requests_per_minute must be >= 1"
+        ):
+            FraserConfig(requests_per_minute=-5)
+
+    def test_異常系_FraserValidationErrorがfield属性を持つ(self) -> None:
+        with pytest.raises(FraserValidationError) as exc_info:
+            FraserConfig(timeout=-1.0)
+        assert exc_info.value.field == "timeout"
+        assert exc_info.value.value == -1.0
+
+
+class TestFraserConfigImmutability:
+    """Tests for ``FraserConfig`` immutability (frozen dataclass)."""
+
+    def test_エッジケース_frozenでapi_key変更不可(self) -> None:
+        config = FraserConfig()
+        with pytest.raises(AttributeError):
+            config.api_key = "changed"
+
+    def test_エッジケース_frozenでtimeout変更不可(self) -> None:
+        config = FraserConfig()
+        with pytest.raises(AttributeError):
+            config.timeout = 99.0
+
+
+# =============================================================================
+# FetchOptions Tests
+# =============================================================================
+
+
+class TestFetchOptions:
+    """Tests for ``FetchOptions`` frozen dataclass."""
+
+    def test_正常系_デフォルト値(self) -> None:
+        options = FetchOptions()
+        assert options.use_cache is True
+        assert options.prefer == "txt"
+        assert options.download_dir is None
+
+    def test_正常系_カスタム値(self) -> None:
+        path = Path("/tmp/fraser")
+        options = FetchOptions(use_cache=False, prefer="pdf", download_dir=path)
+        assert options.use_cache is False
+        assert options.prefer == "pdf"
+        assert options.download_dir == path
+
+    def test_エッジケース_frozenで変更不可(self) -> None:
+        options = FetchOptions()
+        with pytest.raises(AttributeError):
+            options.use_cache = False
+
+
+# =============================================================================
+# DocType Enum Tests
+# =============================================================================
+
+
+class TestDocType:
+    """Tests for the ``DocType`` enum."""
+
+    def test_正常系_メンバー数が6(self) -> None:
+        assert len(DocType) == 6
+
+    def test_正常系_全メンバーの値(self) -> None:
+        expected = {
+            "FOMC_MINUTES": "fomc_minutes",
+            "FOMC_STATEMENTS": "fomc_statements",
+            "FOMC_PRESS_CONFERENCES": "fomc_press_conferences",
+            "BEIGE_BOOK": "beige_book",
+            "FRB_SPEECHES": "frb_speeches",
+            "MONETARY_POLICY_REPORT": "monetary_policy_report",
+        }
+        for name, value in expected.items():
+            assert DocType[name].value == value
+
+    def test_正常系_str継承(self) -> None:
+        assert isinstance(DocType.FOMC_MINUTES, str)
+        assert DocType.FOMC_MINUTES == "fomc_minutes"
+
+    def test_正常系_キーがKNOWN_TITLE_IDSに含まれる(self) -> None:
+        from market.fraser.constants import KNOWN_TITLE_IDS
+
+        for member in DocType:
+            assert member.value in KNOWN_TITLE_IDS

--- a/tests/market/fraser/unit/test_types.py
+++ b/tests/market/fraser/unit/test_types.py
@@ -157,8 +157,8 @@ class TestFetchOptions:
         assert options.prefer == "txt"
         assert options.download_dir is None
 
-    def test_正常系_カスタム値(self) -> None:
-        path = Path("/tmp/fraser")
+    def test_正常系_カスタム値(self, tmp_path: Path) -> None:
+        path = tmp_path / "fraser"
         options = FetchOptions(use_cache=False, prefer="pdf", download_dir=path)
         assert options.use_cache is False
         assert options.prefer == "pdf"


### PR DESCRIPTION
## Summary

PRJ#115 (GitHub Project #115 / market.fraser - FRASER REST API サブパッケージ) の 7 Issue を連続実装。FRASER REST API (https://fraser.stlouisfed.org/api) クライアントを構築し、FOMC Minutes/Statements/Press Conferences、Beige Book、FRB Speeches、Monetary Policy Reports の 6 ドキュメント種別を取得可能にしました。

### 実装した Issue (Wave1-5)

- **#3956** [Wave1] PR1 前半: 基盤モジュール (constants/types/errors/rate_limiter/models)
- **#3957** [Wave2] PR1 後半: FraserSession + discover_titles CLI
- **#3958** [Wave3] PR2: FraserClient + FraserCache + FraserDownloader + parser
- **#3959** [Wave4] PR3: FOMC Minutes MVP (BaseFraserFetcher + FOMCMinutesFetcher + README + E2E)
- **#3960** [Wave4] PR4 前半: FOMC Statements + Press Conferences fetcher 拡張
- **#3961** [Wave4] PR4 後半: Beige Book + FRB Speeches + Monetary Policy Reports + property テスト
- **#3962** [Wave5] PR5: 検証 notebook (fraser_demo.ipynb) + README 運用情報

### 主要な実装

**ソース (src/market/fraser/, 17 ファイル)**:
- `client.py`: `FraserClient` (8 エンドポイントメソッド、cache hit/miss パイプライン)
- `session.py`: `FraserSession` (X-API-Key ヘッダ、SSRF guard、HTTPS強制、30 req/min、429 Retry-After 尊重)
- `cache.py`: `market.cache.cache.SQLiteCache` を再利用 (独自実装なし、prefix='fraser:')
- `downloader.py`: tempfile + Path.replace() で atomic rename + itemId-keyed Lock dict で並列重複DL抑止
- `parser.py`: Pydantic ValidationError → FraserParseError wrap
- `errors.py`: 7 例外クラス (Exception 直接継承、MarketError 不継承で循環インポート回避)
- `rate_limiter.py`: market.alphavantage の DualWindowRateLimiter 再エクスポート
- `models.py`: Pydantic V2 BaseModel 12 クラス
- `types.py`: FraserConfig (api_key に repr=False で CWE-532 対策)
- `fetchers/` (6 fetcher): FOMCMinutesFetcher / FOMCStatementsFetcher / FOMCPressConferencesFetcher / BeigeBookFetcher / FRBSpeechFetcher / MonetaryPolicyReportFetcher
- `scripts/discover_titles.py`: 5 ドキュメント種別の title_id 探索CLI

**テスト (tests/market/fraser/, 21 ファイル)**:
- unit テスト: 282 件、カバレッジ 94%
- property テスト: parser / downloader / rate_limiter の不変条件 (Hypothesis)
- integration テスト: E2E スモーク 8 件 (FRASER_API_KEY 設定時のみ実行)

**設定/ドキュメント**:
- `.env.example`: FRASER_API_KEY=your_api_key_here 追記
- `src/market/fraser/README.md`: 320 行 (Features / Quick Start / API Reference / Examples / Troubleshooting)
- `notebook/FRASER/fraser_demo.ipynb`: 5 セル検証 notebook
- `data/config/fraser_titles.json`: 6 キー雛形 (fomc_minutes=677 のみ確定)

## 既知の未達事項 (手動運用が必要)

以下は実 API キーまたは手動運用が必要なため本 PR では未達:
- [ ] `discover_titles.py` 実行で残り 5 title_id (fomc_statements, fomc_press_conferences, beige_book, monetary_policy_report, frb_speeches) を確定
- [ ] KNOWN_TITLE_IDS 型を `dict[str, int | None]` から `dict[str, int]` に変更
- [ ] integration テストの実 API 実行
- [ ] `notebook/FRASER/fraser_demo.ipynb` の実行確認 (出力 populated)
- [ ] FRASER 旧 API key revoke + 新 key 発行

これらは task-2/task-7 の手動運用部分です。

## Test plan

- [x] `tests/market/fraser/` で 282 unit tests passed (カバレッジ 94%)
- [x] property テスト 3 ファイル (parser/downloader/rate_limiter) で不変条件 GREEN
- [ ] `make check-all` 通過 — fraser スコープは全パス。`notebook/FILING_NLP/` 等の pre-existing 問題 (commit `ce9ab22`, `bcd01b6` 由来) で全体は fail するが、CI lint policy (#3952) により Python/設定/docs スコープに限定されているため CI ブロックには至らない想定
- [ ] CI チェック (gh pr checks) を別途確認

## 注意事項

- HF1 確定方針: errors.py は `Exception` 直接継承 (`MarketError` 不継承で循環インポート回避)
- HF1 確定方針: cache.py は薄い層 (独自 `SQLiteCache` 実装禁止、検証テスト含む)
- HF1 確定方針: 公開サーフェスは 16 シンボル (PR3 で 8、PR4 で +8)
- HF1 確定方針: KNOWN_TITLE_IDS は手動コピー方針 (自動 AST 書き換え不採用)

Fixes #3956, #3957, #3958, #3959, #3960, #3961, #3962

🤖 Generated with [Claude Code](https://claude.com/claude-code)