### PR TITLE
feat(neo4j): 複数 PC 間の手動同期手順とスクリプトを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,10 +49,12 @@ services:
       - "7474:7474"   # Browser UI
       - "7687:7687"   # Bolt protocol
     volumes:
-      - /Volumes/NeoData/enterprise/data:/data
-      - /Volumes/NeoData/enterprise/logs:/logs
-      - /Volumes/NeoData/enterprise/plugins:/plugins
-      - /Volumes/NeoData/enterprise/import:/var/lib/neo4j/import
+      # bind mount はローカルディスクの ~/neo4j-data/ を使用 (外付け SSD は使わない)
+      # YAML では ~ が展開されないため ${HOME} を使う (複数 PC のユーザー名差を吸収)
+      - ${HOME}/neo4j-data/enterprise/data:/data
+      - ${HOME}/neo4j-data/enterprise/logs:/logs
+      - ${HOME}/neo4j-data/enterprise/plugins:/plugins
+      - ${HOME}/neo4j-data/enterprise/import:/var/lib/neo4j/import
     environment:
       - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-gomasuke}
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes

--- a/docs/neo4j-sync-via-nas.md
+++ b/docs/neo4j-sync-via-nas.md
@@ -1,0 +1,261 @@
+# Neo4j 手動同期手順（NAS 経由）
+
+MacBook Air（メイン PC）の Neo4j データを、自宅 Mac へ NAS 経由で手動同期するための手順。
+
+**初回検証日**: 2026-05-27（MacBook Air → 自宅 Mac、4 DB 同期成功）
+
+## 概要
+
+- **方式**: `neo4j-admin database dump` / `load` による論理バックアップ
+- **転送経路**: NAS（`/Volumes/personal_folder`）を中継ストレージとして利用
+- **同期方向**: MacBook Air → 自宅 Mac（片方向）
+- **対象 DB**: `quants`, `research`, `note`, `creator`
+
+## 前提条件
+
+| 項目 | 内容 |
+|------|------|
+| Neo4j バージョン | 両 Mac で `neo4j:5.26-enterprise` 必須（マイナーバージョン差があると load 失敗の可能性） |
+| コンテナ名 | 両 Mac で `neo4j-enterprise`（`docker-compose.yml` で固定） |
+| 認証 | ユーザー `neo4j` / パスワード `gomasuke`（`NEO4J_PASSWORD` 環境変数で上書き可） |
+| NAS マウント | 両 Mac で `/Volumes/personal_folder` にマウント済み |
+| bind mount | 両 Mac とも `${HOME}/neo4j-data/enterprise/` を使用（`docker-compose.yml` で `${HOME}` 展開） |
+| DB 存在 | 自宅 Mac 側に対象 DB が未作成でも OK（Phase 2 Step B で新規作成可能） |
+
+## 実測値（2026-05-27 時点）
+
+| DB | dump サイズ | ノード数 | リレーション数 |
+|----|------------|---------|---------------|
+| `quants` | 1.7M | 3,789 | 8,345 |
+| `research` | 59M | 28,100 | 516,807 |
+| `note` | 478K | 838 | 983 |
+| `creator` | 131M | 15,312 | 31,362 |
+| **合計** | **約 191M** | **48,039** | **557,497** |
+
+各 DB の dump 処理時間: 約 1.2〜3 秒（ローカル NVMe）。
+全工程（dump → NAS 転送 → load → 件数検証）の所要時間: 約 30 分以内。
+
+---
+
+## Phase 1: MacBook Air（メイン PC）で dump → NAS へ転送
+
+```bash
+# 1. NAS マウント確認
+ls /Volumes/personal_folder
+
+# 2. NAS にダンプ置き場を作成
+mkdir -p /Volumes/personal_folder/neo4j-dumps
+
+# 3. コンテナ内に作業ディレクトリを作成
+docker exec neo4j-enterprise mkdir -p /tmp/dumps
+
+# 4. 各 DB を停止 → dump → 起動
+for DB in quants research note creator; do
+  echo "=== Dumping $DB ==="
+  docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d system "STOP DATABASE $DB WAIT"
+  docker exec neo4j-enterprise neo4j-admin database dump $DB \
+    --to-path=/tmp/dumps --overwrite-destination=true
+  docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d system "START DATABASE $DB WAIT"
+done
+
+# 5. コンテナから NAS へコピー
+for DB in quants research note creator; do
+  docker cp neo4j-enterprise:/tmp/dumps/$DB.dump /Volumes/personal_folder/neo4j-dumps/
+done
+
+# 6. 確認（タイムスタンプとサイズをチェック）
+ls -lh /Volumes/personal_folder/neo4j-dumps/
+
+# 7. 一時ファイル削除
+docker exec neo4j-enterprise rm -rf /tmp/dumps
+```
+
+> 💡 `STOP DATABASE ... WAIT` の `WAIT` を付けることでアクティブな接続が切れるまで待ちます。これを省くとアクティブセッション中は STOP が完了しません。
+
+---
+
+## Phase 2: 自宅 Mac で NAS から取り込み → load
+
+自宅 Mac で以下を実行する。
+
+### Step 0: 事前確認
+
+```bash
+# NAS マウント確認 (4 ファイルが見えること)
+ls -lh /Volumes/personal_folder/neo4j-dumps/
+
+# コンテナ稼働確認
+docker ps --filter "name=neo4j-enterprise" --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+
+# 既存 DB の確認 (Step A/B の判断に使う)
+docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d system \
+  "SHOW DATABASES YIELD name, currentStatus"
+```
+
+### Step 1: NAS から dump をコンテナへ投入
+
+```bash
+# 作業ディレクトリ作成
+docker exec neo4j-enterprise mkdir -p /tmp/dumps
+
+# 4 ファイルをコンテナへコピー
+for DB in quants research note creator; do
+  echo "=== Copying $DB.dump ==="
+  docker cp /Volumes/personal_folder/neo4j-dumps/$DB.dump neo4j-enterprise:/tmp/dumps/
+done
+
+# 確認 (MacBook Air と同じサイズか)
+docker exec neo4j-enterprise ls -lh /tmp/dumps/
+```
+
+> ⚠️ **`docker cp` の宛先パスは必ず先頭 `/` 付き**で指定すること。`neo4j-enterprise:tmp/dumps/`（先頭 `/` なし）でも環境によっては `/tmp/dumps/` に展開される場合があるが、挙動が不安定なため絶対パス推奨。
+
+### Step 2-A: DB が既に存在する場合（上書き load）
+
+```bash
+for DB in quants research note creator; do
+  echo "=== [$DB] Loading (overwrite) ==="
+  docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d system "STOP DATABASE $DB WAIT"
+  docker exec neo4j-enterprise neo4j-admin database load $DB \
+    --from-path=/tmp/dumps --overwrite-destination=true
+  docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d system "START DATABASE $DB WAIT"
+done
+```
+
+### Step 2-B: DB が未登録の場合（新規作成 + load）✅ 検証済み
+
+新規構築した Neo4j コンテナで初めて load する場合の標準手順。`load` を先にして、その後 `CREATE DATABASE` で DBMS に登録する。
+
+```bash
+for DB in quants research note creator; do
+  echo ""
+  echo "============================================"
+  echo "  [$DB] load + register"
+  echo "============================================"
+
+  # 1. dump からファイル展開 (DB が未登録なので STOP 不要)
+  docker exec neo4j-enterprise neo4j-admin database load $DB \
+    --from-path=/tmp/dumps --overwrite-destination=true
+
+  # 2. DBMS に登録 (これをやらないと SHOW DATABASES に出ない)
+  docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d system \
+    "CREATE DATABASE $DB IF NOT EXISTS WAIT"
+done
+
+# 4 DB すべて online か確認
+docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d system \
+  "SHOW DATABASES YIELD name, currentStatus WHERE name IN ['quants','research','note','creator'] RETURN name, currentStatus"
+```
+
+### Step 3: 件数検証
+
+```bash
+for DB in quants research note creator; do
+  echo "=== $DB ==="
+  docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d $DB \
+    "MATCH (n) RETURN count(n) AS nodes"
+  docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke -d $DB \
+    "MATCH ()-[r]->() RETURN count(r) AS relationships"
+done
+```
+
+MacBook Air 側で同じコマンドを実行し、件数が完全一致すれば同期成功。
+
+### Step 4: クリーンアップ
+
+```bash
+# コンテナ内の一時 dump を削除
+docker exec neo4j-enterprise rm -rf /tmp/dumps
+
+# NAS 上の dump は次回同期まで保持してもよい (再 load 用バックアップ)
+```
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| `Database '<name>' does not exist` (load 時) | DB 未登録 | Step 2-B に切り替え |
+| `Failed to load database... store format ...` | バージョン差 (5.26 以外) | コンテナを `5.26-enterprise` に揃える |
+| `STOP DATABASE` が完了しない | アクティブな接続あり | Claude Code / Browser UI を一度閉じてから再試行、または `STOP DATABASE ... WAIT` を使う |
+| `mkdir /host_mnt/Volumes/...: permission denied` | bind mount 先（外付け SSD）が切断 | `${HOME}/neo4j-data/` 構成に切り替え（`docker-compose.yml` 修正） |
+| `docker cp` 後にコンテナ内で `*.dump` が見つからない | 宛先パスの先頭 `/` 漏れ | `find / -name "*.dump"` で実際の場所を探す |
+| load 後に件数が 0 | DB 未起動 or 異なる DBMS にロード | `START DATABASE <name> WAIT`、`SHOW DATABASES` で確認 |
+
+---
+
+## 既存環境のセットアップ（自宅 Mac 初回構築）
+
+自宅 Mac に Neo4j コンテナがまだない場合、または `/Volumes/NeoData/` 等の古い構成のコンテナがある場合のセットアップ手順。
+
+### 1. 古いコンテナの削除（必要に応じて）
+
+```bash
+docker rm neo4j-enterprise 2>/dev/null
+# 残骸コンテナがあれば併せて削除
+docker ps -a --format "{{.Names}}" | grep neo4j | xargs -r docker rm
+```
+
+### 2. ローカルデータディレクトリ作成
+
+```bash
+mkdir -p ~/neo4j-data/enterprise/{data,logs,plugins,import}
+```
+
+### 3. quants リポジトリ取得（未取得の場合）
+
+```bash
+cd ~/Desktop
+git clone git@github.com:YH-05/quants.git
+cd quants
+```
+
+### 4. コンテナ起動
+
+```bash
+cd ~/Desktop/quants
+docker compose up -d neo4j
+
+# 起動完了を待つ (初回は APOC ダウンロードで 1〜2 分)
+until docker exec neo4j-enterprise cypher-shell -u neo4j -p gomasuke "RETURN 1" 2>/dev/null | grep -q "1 row"; do
+  echo "waiting Neo4j startup..."
+  sleep 3
+done
+echo "Neo4j is ready"
+```
+
+その後 Phase 2 Step 1 から進める。
+
+---
+
+## 注意点
+
+| 項目 | 内容 |
+|------|------|
+| **バージョン一致** | 両 Mac とも Neo4j 5.26 Enterprise でないと load 失敗の可能性 |
+| **DB 存在** | 自宅 Mac に DB が未登録の場合は Step 2-B で対応 |
+| **データサイズ** | 現状約 191MB（dump 圧縮後）。NAS の SMB 帯域に依存 |
+| **停止時間** | dump 時は DB ごとに数秒〜数十秒停止 (load 時は overwrite なので接続不可) |
+| **片方向のみ** | MacBook Air → 自宅 Mac の片方向。逆方向に書き込むと差分が消える |
+| **`.DS_Store` 等** | macOS が SMB に作るメタファイル。dump 整合性には影響なし |
+| **ユーザー名差** | MacBook Air (`yukihata`) と自宅 Mac (`yuki`) でユーザー名が異なるが、`${HOME}` 展開で吸収 |
+
+## 自動化
+
+スクリプト化版: [`scripts/neo4j_sync.sh`](../scripts/neo4j_sync.sh)
+
+```bash
+# Phase 1 (MacBook Air で実行)
+./scripts/neo4j_sync.sh dump
+
+# Phase 2 (自宅 Mac で実行)
+./scripts/neo4j_sync.sh load
+```
+
+## 関連
+
+- 議論メモ: [docs/plan/2026-05-26_discussion-neo4j-multi-pc-sync.md](plan/2026-05-26_discussion-neo4j-multi-pc-sync.md)
+- 前回移行: [docs/plan/](plan/) 配下の関連メモ
+- Docker Compose 設定: `docker-compose.yml`
+- 接続設定: `.env` の `NEO4J_URI` / `NEO4J_PASSWORD`

--- a/docs/plan/2026-05-26_discussion-neo4j-multi-pc-sync.md
+++ b/docs/plan/2026-05-26_discussion-neo4j-multi-pc-sync.md
@@ -1,0 +1,71 @@
+# 議論メモ: Neo4j を複数 PC で利用するための同期方式
+
+**日付**: 2026-05-26
+**議論ID**: disc-2026-05-26-neo4j-multi-pc-sync
+**参加**: ユーザー + AI (Claude Opus 4.7)
+**関連プロジェクト**: quants-neo4j-kg
+**前回議論**: [disc-2026-04-27-neo4j-storage-migration](2026-04-27-neo4j-storage-migration.md)
+
+## 背景・コンテキスト
+
+MacBook Air (このPC) で Docker 上に `neo4j-enterprise` (5.26) を稼働させており、`bolt://localhost:7687` で Claude Code から利用中。データは `~/neo4j-data/enterprise/` 配下に 2GB 規模で、5 DB (`quants` / `note` / `research` / `creator` / `neo4j` + `system`) が稼働している。
+
+別 PC (自宅 Mac) でも同じ Neo4j を利用したいという要求が発生。前回の議論 (2026-04-27) では外付け SSD からローカルディスクへの bind mount 移行を行ったが、複数 PC 間の利用は未対応のままだった。
+
+## 議論のサマリー
+
+### 比較検討した方式
+
+| 方式 | 評価 | 採否 |
+|------|------|------|
+| A. Tailscale 経由で現 Mac を共有 | Mac 常時稼働必須でユーザー要件に合わない | ✗ |
+| B. NAS (DH2300-48C1) に Neo4j 移行 | NAS が Docker 非対応 | ✗ |
+| C. Neo4j Aura / VPS にホスト | コスト高、独立運用要件と矛盾 | ✗ |
+| D. 各 PC ローカル Neo4j + Causal Cluster | Enterprise でも構築複雑、ズレ許容なら過剰 | ✗ |
+| **E. dump/load + NAS 中継ファイル受け渡し** | 独立運用・ズレ許容と整合、追加コストゼロ | **✓** |
+
+### ユーザー要件の確認結果
+
+- **接続経路**: 同一 LAN 内のみ (自宅 Wi-Fi)
+- **Mac 稼働**: 別 Mac は独立運用、一時的ズレ許容、手動同期で OK
+- **NAS Docker**: 非対応、NAS は使いたくない (ただしファイル中継には使用)
+- **同期手段**: NAS 経由
+- **対象 DB**: quants, research, note, creator
+- **方針**: まず手動手順、スクリプト化は後
+
+## 決定事項
+
+| ID | 内容 | コンテキスト |
+|----|------|------------|
+| dec-2026-05-26-501 | 同期方式は `neo4j-admin database dump / load` を採用し、NAS (`/Volumes/personal_folder`) を中継ストレージとしてファイル受け渡し | Causal Cluster は複雑、データディレクトリ rsync は破損リスク、APOC export は大規模で遅い |
+| dec-2026-05-26-502 | 同期方向は MacBook Air → 自宅 Mac の片方向 | 双方向は競合管理が複雑、一時的ズレ許容と整合 |
+| dec-2026-05-26-503 | 同期対象 DB は `quants`, `research`, `note`, `creator` の 4 つ (`system` / `neo4j` は対象外) | ユーザー明示選択、system DB は DBMS 固有で同期不要 |
+| dec-2026-05-26-504 | 両 Mac の Neo4j は独立運用、ネットワーク不通時も各自動作 | 常時オンライン要件回避、外付け SSD トラブル経験から独立運用の優位性確認 |
+| dec-2026-05-26-505 | 初回はスクリプト化せず、手動手順 (`docs/neo4j-sync-via-nas.md`) で動作検証 | DB 存在チェック・バージョン差吸収など未検証要素があるため段階実施 |
+
+## アクションアイテム
+
+| ID | 内容 | 優先度 | ステータス |
+|----|------|--------|----------|
+| act-2026-05-26-501 | quants DB 1 つで Phase 1→2 を手動実行、件数一致で動作検証 | 高 | pending |
+| act-2026-05-26-502 | 自宅 Mac の Neo4j バージョンが 5.26-enterprise であることを確認 | 高 | pending |
+| act-2026-05-26-503 | 自宅 Mac で DB 未登録の場合の `CREATE DATABASE` 手順を準備・追記 | 中 | pending |
+| act-2026-05-26-504 | 検証成功後、`scripts/neo4j_sync.sh` としてスクリプト化 | 中 | pending |
+| act-2026-05-26-505 | `docker-compose.yml` の bind mount パスを `/Volumes/NeoData` → `~/neo4j-data/` に修正 | 中 | pending |
+
+## 成果物
+
+- **手順書**: [docs/neo4j-sync-via-nas.md](../neo4j-sync-via-nas.md) (Phase 1 dump / Phase 2 load の手動コマンド)
+
+## 次回の議論トピック
+
+- 手動検証完了後のスクリプト化方針 (引数設計・エラーハンドリング・冪等性)
+- `system` DB のロール・ユーザー定義の同期可否 (現状対象外だが将来課題)
+- 逆方向 (自宅 Mac → MacBook Air) 同期の必要性が出た場合の競合解決方針
+
+## 参考情報
+
+- 関連メモリ: `project_neo4j_local_migration_2026_04_27.md` (前回の SSD → ローカル移行)
+- 関連メモリ: `feedback_neo4j_iox_restart.md` (2026-04-27 ローカル移行で解消済)
+- 前回議論: `disc-2026-04-27-neo4j-storage-migration`
+- データ規模: `~/neo4j-data/enterprise/data` = 約 2GB、`research` DB が最大 (27,960 ノード / 516,590 リレーション)

--- a/scripts/neo4j_sync.sh
+++ b/scripts/neo4j_sync.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Neo4j 複数 PC 同期スクリプト (dump/load + NAS 中継)
+#
+# Usage:
+#   ./scripts/neo4j_sync.sh dump            # Phase 1: dump 4 DBs to NAS
+#   ./scripts/neo4j_sync.sh load            # Phase 2: load 4 DBs from NAS
+#   ./scripts/neo4j_sync.sh verify          # ノード/リレーション件数を表示
+#
+# Environment variables:
+#   NEO4J_CONTAINER  (default: neo4j-enterprise)
+#   NEO4J_USER       (default: neo4j)
+#   NEO4J_PASSWORD   (default: gomasuke)
+#   NEO4J_DBS        (default: "quants research note creator") space-separated
+#   NAS_DUMP_DIR     (default: /Volumes/personal_folder/neo4j-dumps)
+#
+# Reference: docs/neo4j-sync-via-nas.md
+
+set -euo pipefail
+
+CONTAINER="${NEO4J_CONTAINER:-neo4j-enterprise}"
+USER_NAME="${NEO4J_USER:-neo4j}"
+PASSWORD="${NEO4J_PASSWORD:-gomasuke}"
+DBS="${NEO4J_DBS:-quants research note creator}"
+NAS_DIR="${NAS_DUMP_DIR:-/Volumes/personal_folder/neo4j-dumps}"
+CONTAINER_DUMP_DIR="/tmp/dumps"
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+cypher_system() {
+  docker exec "$CONTAINER" cypher-shell -u "$USER_NAME" -p "$PASSWORD" -d system "$1"
+}
+
+cypher_db() {
+  local db="$1"
+  local query="$2"
+  docker exec "$CONTAINER" cypher-shell -u "$USER_NAME" -p "$PASSWORD" -d "$db" "$query"
+}
+
+check_prereqs() {
+  log "Checking prerequisites..."
+  docker ps --filter "name=^${CONTAINER}$" --format '{{.Names}}' | grep -q "^${CONTAINER}$" \
+    || die "Container '$CONTAINER' is not running. Start it with: docker compose up -d neo4j"
+
+  [ -d "$NAS_DIR" ] || mkdir -p "$NAS_DIR" \
+    || die "Failed to create NAS dump dir: $NAS_DIR (is NAS mounted?)"
+
+  log "Container: $CONTAINER (running)"
+  log "NAS dir:   $NAS_DIR"
+  log "DBs:       $DBS"
+}
+
+# ----------------------------------------------------------------------------
+# Phase 1: dump → NAS
+# ----------------------------------------------------------------------------
+cmd_dump() {
+  check_prereqs
+
+  log "Creating container dump dir..."
+  docker exec "$CONTAINER" mkdir -p "$CONTAINER_DUMP_DIR"
+
+  for db in $DBS; do
+    log "=== [$db] Dumping ==="
+    cypher_system "STOP DATABASE $db WAIT" | tail -2
+    docker exec "$CONTAINER" neo4j-admin database dump "$db" \
+      --to-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3
+    cypher_system "START DATABASE $db WAIT" | tail -2
+  done
+
+  log "Copying dumps to NAS: $NAS_DIR"
+  for db in $DBS; do
+    docker cp "${CONTAINER}:${CONTAINER_DUMP_DIR}/${db}.dump" "${NAS_DIR}/"
+  done
+
+  log "Cleaning up container dump dir..."
+  docker exec "$CONTAINER" rm -rf "$CONTAINER_DUMP_DIR"
+
+  log "Done. Files on NAS:"
+  ls -lh "$NAS_DIR"
+}
+
+# ----------------------------------------------------------------------------
+# Phase 2: NAS → load
+# ----------------------------------------------------------------------------
+cmd_load() {
+  check_prereqs
+
+  log "Verifying NAS dump files..."
+  for db in $DBS; do
+    [ -f "${NAS_DIR}/${db}.dump" ] || die "Missing dump file: ${NAS_DIR}/${db}.dump"
+  done
+
+  log "Copying dumps into container..."
+  docker exec "$CONTAINER" mkdir -p "$CONTAINER_DUMP_DIR"
+  for db in $DBS; do
+    docker cp "${NAS_DIR}/${db}.dump" "${CONTAINER}:${CONTAINER_DUMP_DIR}/"
+  done
+
+  for db in $DBS; do
+    log "=== [$db] Loading ==="
+
+    # Check if DB exists
+    local exists
+    exists=$(cypher_system "SHOW DATABASE $db YIELD name RETURN count(name) AS c" \
+      | tail -1 | tr -d ' ' || echo "0")
+
+    if [ "$exists" = "1" ]; then
+      log "  DB exists -> overwrite load"
+      cypher_system "STOP DATABASE $db WAIT" | tail -2
+      docker exec "$CONTAINER" neo4j-admin database load "$db" \
+        --from-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3
+      cypher_system "START DATABASE $db WAIT" | tail -2
+    else
+      log "  DB does not exist -> load + CREATE DATABASE"
+      docker exec "$CONTAINER" neo4j-admin database load "$db" \
+        --from-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3
+      cypher_system "CREATE DATABASE $db IF NOT EXISTS WAIT" | tail -2
+    fi
+  done
+
+  log "Cleaning up container dump dir..."
+  docker exec "$CONTAINER" rm -rf "$CONTAINER_DUMP_DIR"
+
+  log "Done. Database status:"
+  local dbs_list
+  dbs_list=$(echo "$DBS" | tr ' ' ',' | sed "s/,/','/g")
+  cypher_system "SHOW DATABASES YIELD name, currentStatus WHERE name IN ['${dbs_list}'] RETURN name, currentStatus"
+}
+
+# ----------------------------------------------------------------------------
+# verify: 件数表示
+# ----------------------------------------------------------------------------
+cmd_verify() {
+  check_prereqs
+
+  for db in $DBS; do
+    echo ""
+    echo "=== $db ==="
+    cypher_db "$db" "MATCH (n) RETURN count(n) AS nodes"
+    cypher_db "$db" "MATCH ()-[r]->() RETURN count(r) AS relationships"
+  done
+}
+
+# ----------------------------------------------------------------------------
+# main
+# ----------------------------------------------------------------------------
+case "${1:-}" in
+  dump)   cmd_dump ;;
+  load)   cmd_load ;;
+  verify) cmd_verify ;;
+  *)
+    cat <<EOF
+Usage: $0 {dump|load|verify}
+
+  dump    Phase 1: Dump 4 DBs from this Mac's Neo4j to NAS
+  load    Phase 2: Load 4 DBs from NAS into this Mac's Neo4j
+  verify  Display node/relationship counts for each DB
+
+Environment variables:
+  NEO4J_CONTAINER  Container name (default: neo4j-enterprise)
+  NEO4J_USER       Neo4j user     (default: neo4j)
+  NEO4J_PASSWORD   Neo4j password (default: gomasuke)
+  NEO4J_DBS        Space-separated DB list
+                   (default: "quants research note creator")
+  NAS_DUMP_DIR     NAS dump directory
+                   (default: /Volumes/personal_folder/neo4j-dumps)
+
+Reference: docs/neo4j-sync-via-nas.md
+EOF
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## 概要

MacBook Air と自宅 Mac で同一の Neo4j データを共有するための dump/load + NAS 中継方式を確立。

2026-05-27 に MacBook Air → 自宅 Mac で 4 DB (quants/research/note/creator) の全件一致 (48,039 ノード / 557,497 リレーション) を確認済み。

## 変更点

- **docker-compose.yml**: bind mount を `/Volumes/NeoData/` → `${HOME}/neo4j-data/` に変更。`${HOME}` 展開でユーザー名差を吸収 (`act-2026-05-26-505`)
- **docs/neo4j-sync-via-nas.md**: 手動同期手順を新規追加。実測値、Step 2-B (新規 DB 作成)、`docker cp` の落とし穴等の知見を反映
- **docs/plan/2026-05-26_discussion-neo4j-multi-pc-sync.md**: 議論メモ
- **scripts/neo4j_sync.sh**: `dump` / `load` / `verify` 統合スクリプト (`act-2026-05-26-504`)

## 検証

| DB | dump サイズ | ノード | リレーション |
|---|---|---|---|
| quants | 1.7M | 3,789 | 8,345 |
| research | 59M | 28,100 | 516,807 |
| note | 478K | 838 | 983 |
| creator | 131M | 15,312 | 31,362 |

MacBook Air ↔ 自宅 Mac で件数完全一致。

## 既知事項

- マージ後、MacBook Air 側の稼働中コンテナは `docker compose down neo4j && docker compose up -d neo4j` での再作成が必要。`~/neo4j-data/` にデータがあるためデータ消失はなし
- 同期方向は MacBook Air → 自宅 Mac の片方向。逆方向は将来課題

## テストプラン

- [x] `docker compose config` で bind mount が `/Users/<user>/neo4j-data/` に展開されることを確認
- [x] `scripts/neo4j_sync.sh verify` が件数を正しく出力することを確認
- [x] 自宅 Mac で同手順を実施し 4 DB 件数一致を確認
- [ ] (PR マージ後) MacBook Air 側のコンテナ再作成 → DB が起動することを確認

## 関連

- 議論: `disc-2026-05-26-neo4j-multi-pc-sync`
- Decisions: `dec-2026-05-26-501` 〜 `505`
- 完了 ActionItem: `act-2026-05-26-501`〜`503` (検証完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)