### PR TITLE
feat(neo4j-sync): Claude Code hooks 連動の双方向同期を実装

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -161,6 +161,16 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/neo4j_sync.sh pull --auto 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
@@ -168,6 +178,25 @@
           {
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/skills/sync-claude-config/sync.py\" --auto 2>/dev/null || true"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__neo4j-cypher__write_neo4j_cypher",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "touch $HOME/.neo4j-sync-dirty 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/neo4j_sync.sh push --if-dirty 2>&1 | tail -3 || true"
           }
         ]
       }

--- a/docs/neo4j-sync-via-nas.md
+++ b/docs/neo4j-sync-via-nas.md
@@ -245,25 +245,77 @@ echo "Neo4j is ready"
 | **DB 存在** | 自宅 Mac に DB が未登録の場合は Step 2-B で対応 |
 | **データサイズ** | 現状約 191MB（dump 圧縮後）。NAS の SMB 帯域に依存 |
 | **停止時間** | dump 時は DB ごとに数秒〜数十秒停止 (load 時は overwrite なので接続不可) |
-| **片方向のみ** | MacBook Air → 自宅 Mac の片方向。逆方向に書き込むと差分が消える |
+| **双方向同期** | 2026-05-27 から双方向対応 (「最後に書いた側が source」)。同時書き込みは想定しない |
 | **`.DS_Store` 等** | macOS が SMB に作るメタファイル。dump 整合性には影響なし |
 | **ユーザー名差** | MacBook Air (`yukihata`) と自宅 Mac (`yuki`) でユーザー名が異なるが、`${HOME}` 展開で吸収 |
 
-## 自動化
+## 自動化 (Claude Code hooks 連動)
 
-スクリプト化版: [`scripts/neo4j_sync.sh`](../scripts/neo4j_sync.sh)
+2026-05-27 から、`scripts/neo4j_sync.sh` を Claude Code の hooks で自動実行する双方向同期に拡張。
+
+### Hooks 構成 (`.claude/settings.json`)
+
+| Hook | matcher | 動作 |
+|------|---------|------|
+| SessionStart | (なし) | `neo4j_sync.sh pull --auto` を実行。NAS の `last_source != hostname` なら 4 DB を load |
+| PostToolUse | `mcp__neo4j-cypher__write_neo4j_cypher` | `touch $HOME/.neo4j-sync-dirty` (フラグだけ立てる軽量処理) |
+| Stop | (なし) | `neo4j_sync.sh push --if-dirty` を同期実行 (dirty フラグがあれば push) |
+
+### NAS 上の `sync-state.json`
+
+`/Volumes/personal_folder/neo4j-dumps/sync-state.json`:
+
+```json
+{
+  "last_source": "yukihatas-macbook-air",
+  "last_dump_at": "2026-05-27T12:34:56Z",
+  "dbs": ["quants", "research", "note", "creator"]
+}
+```
+
+`pull --auto` は `last_source != hostname` のときだけ load を実行する。これにより「自分が書き込んだ dump を自分に load し直す」ループを防ぐ。
+
+### サブコマンド一覧
 
 ```bash
-# Phase 1 (MacBook Air で実行)
-./scripts/neo4j_sync.sh dump
-
-# Phase 2 (自宅 Mac で実行)
-./scripts/neo4j_sync.sh load
+./scripts/neo4j_sync.sh push              # dump + NAS push + sync-state.json 更新
+./scripts/neo4j_sync.sh push --if-dirty   # dirty フラグがあれば push、なければ skip (Stop hook 用)
+./scripts/neo4j_sync.sh pull              # 強制 pull (NAS → load)
+./scripts/neo4j_sync.sh pull --auto       # last_source != hostname なら pull (SessionStart hook 用)
+./scripts/neo4j_sync.sh status            # 現在の dirty / sync-state / lock を表示
+./scripts/neo4j_sync.sh dump              # 強制 dump (sync-state は更新しない、互換用)
+./scripts/neo4j_sync.sh load              # 強制 load (互換用)
+./scripts/neo4j_sync.sh verify            # 件数表示
 ```
+
+### 排他制御
+
+NAS 上に `.neo4j-sync.lock` ディレクトリを `mkdir` ベースで作成。同時 push/pull を防止する。
+30 秒待っても取得できなければ `die`。stale ロックは `rmdir /Volumes/personal_folder/neo4j-dumps/.neo4j-sync.lock` で手動解除。
+
+### macOS 通知
+
+`osascript` で通知センターに以下を表示：
+
+- 成功時: 「Pushed/Pulled 4 DBs from <source>」
+- エラー時: 「neo4j-sync ❌ <エラーメッセージ>」
+
+### Claude Code 経由以外の書き込み
+
+| 経路 | 対応 |
+|------|------|
+| `mcp__neo4j-cypher__write_neo4j_cypher` (Claude Code 経由) | PostToolUse hook で自動 dirty 化 |
+| `scripts/migrate_author_ids.py --execute` | スクリプト内で書き込み成功時に dirty フラグを touch (`migrated > 0`) |
+| Neo4j Browser UI / 直接 `cypher-shell` | 手動 `./scripts/neo4j_sync.sh push` を実行 |
+| その他カスタムスクリプト | `Path.home() / ".neo4j-sync-dirty"` を touch する処理を追加 |
+
+### ログ
+
+`~/Library/Logs/neo4j-sync.log` に全アクションを追記。
 
 ## 関連
 
-- 議論メモ: [docs/plan/2026-05-26_discussion-neo4j-multi-pc-sync.md](plan/2026-05-26_discussion-neo4j-multi-pc-sync.md)
-- 前回移行: [docs/plan/](plan/) 配下の関連メモ
+- 双方向化議論: [docs/plan/2026-05-27_discussion-neo4j-bidirectional-sync.md](plan/2026-05-27_discussion-neo4j-bidirectional-sync.md)
+- 初回確立議論: [docs/plan/2026-05-26_discussion-neo4j-multi-pc-sync.md](plan/2026-05-26_discussion-neo4j-multi-pc-sync.md)
 - Docker Compose 設定: `docker-compose.yml`
 - 接続設定: `.env` の `NEO4J_URI` / `NEO4J_PASSWORD`

--- a/docs/plan/2026-05-27_discussion-neo4j-bidirectional-sync.md
+++ b/docs/plan/2026-05-27_discussion-neo4j-bidirectional-sync.md
@@ -1,0 +1,120 @@
+# 議論メモ: Neo4j 同期の自動化と双方向化（Claude Code hooks 連動）
+
+**日付**: 2026-05-27
+**議論ID**: disc-2026-05-27-neo4j-bidirectional-sync
+**参加**: ユーザー + AI (Claude Opus 4.7)
+**関連プロジェクト**: quants-neo4j-kg
+**前回議論**: [2026-05-26 複数 PC 同期確立](2026-05-26_discussion-neo4j-multi-pc-sync.md)
+
+## 背景・コンテキスト
+
+2026-05-26 に確立した片方向同期 (MacBook Air → 自宅 Mac) を発展させ、両 Mac から書き込み可能な双方向同期にしたい。
+ただし `dec-2026-05-26-502` で「片方向のみ」と決めていたため、設計を見直す必要がある。
+
+ユーザーから出た要件:
+- Neo4j を更新したときにのみ同期したい（定期同期は不要）
+- 双方向にしたい（実態としては時期がずれるためシリアル運用）
+- 自動 pull は不要（明示的にトリガーが走るタイミングがほしい）
+- Claude Code の hooks 機能を活用したい
+- macOS 通知センターに通知
+
+## 議論のサマリー
+
+### 比較検討した自動化方式
+
+| 方式 | 評価 | 採否 |
+|------|------|------|
+| Claude CronCreate (ローカル) | Claude REPL 起動中のみ fire、7 日失効 | ✗ |
+| Claude RemoteTrigger (claude.ai 側) | クラウド側、ローカル Docker / NAS にアクセス不可 | ✗ |
+| macOS launchd (StartCalendarInterval) | 定期実行になるが「更新時のみ」の要求と乖離 | ✗ |
+| **Claude Code hooks (SessionStart / PostToolUse / Stop)** | セッション境界連動、要件に合致 | **✓** |
+
+### 双方向同期の競合管理
+
+| 戦略 | 採用 |
+|------|------|
+| 同時書き込み禁止（時期で分ける） | **採用**: ユーザー実態と一致 |
+| DB 分割 | 不要 |
+| Causal Cluster (Enterprise) | 不要 |
+| Last-Write-Wins | リスクが高く不採用 |
+
+NAS 上 `sync-state.json` に `last_source` を記録し、「最後に書いた側が source」ルールで運用する。
+
+### 動作フロー
+
+```
+[Claude Code 起動]                [セッション中]                      [Claude Code 終了]
+SessionStart hook                 PostToolUse hook                    Stop hook
+       │                          (write_neo4j_cypher のみ)                  │
+       ▼ pull --auto              ▼ touch ~/.neo4j-sync-dirty               ▼ push --if-dirty
+NAS sync-state.json 確認         (フラグだけ立てる軽量処理)          dirty=true なら
+last_source != hostname なら                                          dump → NAS push
+load 実行                                                             sync-state.json 更新
+macOS 通知                                                            macOS 通知
+```
+
+## 決定事項
+
+| ID | 内容 | コンテキスト |
+|----|------|------------|
+| dec-2026-05-27-001 | 同期方式を Claude Code hooks 連動の双方向 (「最後に書いた側が source」) に拡張。`dec-2026-05-26-502` (片方向) を supersede | ユーザー実態 (シリアル運用) と整合 |
+| dec-2026-05-27-002 | SessionStart hook で `pull --auto` を実行 | NAS の `last_source != hostname` なら load。失敗は `|| true` で吸収 |
+| dec-2026-05-27-003 | PostToolUse hook (`mcp__neo4j-cypher__write_neo4j_cypher`) で `touch ~/.neo4j-sync-dirty` | フラグだけ立てる軽量処理、実 dump は Stop |
+| dec-2026-05-27-004 | Stop hook で `push --if-dirty` を同期実行 (完了を待つ) | push 失敗を見落とさないため非同期にしない |
+| dec-2026-05-27-005 | save-to-graph スキル等の Neo4j 書き込み箇所にも dirty フラグ更新を組み込み | スクリプト経由の更新を取りこぼさない |
+| dec-2026-05-27-006 | NAS 上 `sync-state.json` に `last_source` / `last_dump_at` を記録、`.neo4j-sync.lock` で排他 | jq は macOS 標準で利用可 |
+| dec-2026-05-27-007 | macOS 通知 (osascript) で pull/push/エラーを通知 | ユーザー選択。Slack 等は不要 |
+
+## アクションアイテム
+
+| ID | 内容 | 優先度 |
+|----|------|--------|
+| act-2026-05-27-001 | `scripts/neo4j_sync.sh` に `push` / `pull` / `--auto` / `--if-dirty` / `status` サブコマンド・`sync-state.json` 対応・排他制御・macOS 通知を実装 | 高 |
+| act-2026-05-27-002 | `.claude/settings.json` に SessionStart/PostToolUse(write_neo4j_cypher)/Stop の 3 hook を追加 | 高 |
+| act-2026-05-27-003 | save-to-graph スキル等への `touch $HOME/.neo4j-sync-dirty` 組み込み | 中 |
+| act-2026-05-27-004 | `docs/neo4j-sync-via-nas.md` を双方向同期対応に更新 | 中 |
+| act-2026-05-27-005 | 両 Mac で push/pull/SessionStart/Stop の動作確認 | 高 |
+
+## NAS 上のメタデータ
+
+`/Volumes/personal_folder/neo4j-dumps/sync-state.json`:
+
+```json
+{
+  "last_source": "yukihatas-macbook-air",
+  "last_dump_at": "2026-05-27T12:34:56+09:00",
+  "dbs": ["quants", "research", "note", "creator"]
+}
+```
+
+`/Volumes/personal_folder/neo4j-dumps/.neo4j-sync.lock`:
+- `mkdir` ベースの排他ロック（同時 push/pull 防止）
+- 同期処理開始時に作成、終了時に削除（`trap`）
+
+## 動作シミュレーション
+
+### ケース 1: MacBook Air → 自宅 Mac
+
+1. **MacBook Air** Claude Code 起動 → `pull --auto`: 自分が `last_source`、何もせず即終了
+2. **MacBook Air** 書き込み作業 → `~/.neo4j-sync-dirty` が立つ
+3. **MacBook Air** Claude Code 終了 → `push --if-dirty`: dump → NAS、`last_source=yukihatas-macbook-air`、通知
+4. **自宅 Mac** 後日 Claude Code 起動 → `pull --auto`: `last_source != hostname` で load、通知
+
+### ケース 2: 自宅 Mac で書き込み → MacBook Air へ
+
+5. **自宅 Mac** 書き込み → Stop で push、`last_source=YukinoMac-mini`
+6. **MacBook Air** 次回起動 → `pull --auto` で load、通知
+
+## 次回の議論トピック
+
+- save-to-graph 以外で Neo4j 書き込みを行う箇所の網羅性確認
+- 同期エラー時の自動リトライ戦略 (今は手動再実行のみ)
+- 将来同時書き込みが発生した場合のエスカレーション策
+
+## 関連
+
+- 前回議論: [2026-05-26 複数 PC 同期確立](2026-05-26_discussion-neo4j-multi-pc-sync.md)
+- 手順書: [docs/neo4j-sync-via-nas.md](../neo4j-sync-via-nas.md)
+- スクリプト: [scripts/neo4j_sync.sh](../../scripts/neo4j_sync.sh)
+- メモリ: `project_neo4j_multi_pc_sync_2026_05_27.md`
+- Supersede: `dec-2026-05-26-502` (片方向) → `dec-2026-05-27-001` (双方向)

--- a/scripts/migrate_author_ids.py
+++ b/scripts/migrate_author_ids.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 from database.id_generator import generate_author_id
@@ -314,6 +315,14 @@ def main(argv: list[str] | None = None) -> int:
             migrated=migrated,
             total=len(plan),
         )
+
+        if migrated > 0:
+            # AIDEV-NOTE: Notify neo4j_sync.sh of Neo4j changes so the next Stop hook pushes to NAS.
+            # See docs/neo4j-sync-via-nas.md (bidirectional sync).
+            dirty_flag = Path.home() / ".neo4j-sync-dirty"
+            dirty_flag.touch()
+            logger.info("neo4j-sync dirty flag set", path=str(dirty_flag))
+
         return 0
 
     finally:

--- a/scripts/neo4j_sync.sh
+++ b/scripts/neo4j_sync.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Neo4j 複数 PC 同期スクリプト (dump/load + NAS 中継)
+# Neo4j 複数 PC 同期スクリプト (dump/load + NAS 中継 + Claude Code hooks 連動)
 #
 # Usage:
-#   ./scripts/neo4j_sync.sh dump            # Phase 1: dump 4 DBs to NAS
-#   ./scripts/neo4j_sync.sh load            # Phase 2: load 4 DBs from NAS
+#   ./scripts/neo4j_sync.sh dump            # 強制 dump → NAS
+#   ./scripts/neo4j_sync.sh load            # 強制 NAS → load
 #   ./scripts/neo4j_sync.sh verify          # ノード/リレーション件数を表示
+#   ./scripts/neo4j_sync.sh push            # dump → NAS + sync-state.json 更新
+#   ./scripts/neo4j_sync.sh push --if-dirty # dirty フラグがあれば push
+#   ./scripts/neo4j_sync.sh pull            # 強制 pull (NAS → load)
+#   ./scripts/neo4j_sync.sh pull --auto     # NAS の last_source != hostname なら pull
+#   ./scripts/neo4j_sync.sh status          # 現在の dirty/sync 状態を表示
 #
 # Environment variables:
 #   NEO4J_CONTAINER  (default: neo4j-enterprise)
@@ -12,6 +17,8 @@
 #   NEO4J_PASSWORD   (default: gomasuke)
 #   NEO4J_DBS        (default: "quants research note creator") space-separated
 #   NAS_DUMP_DIR     (default: /Volumes/personal_folder/neo4j-dumps)
+#   NEO4J_SYNC_DIRTY (default: $HOME/.neo4j-sync-dirty)
+#   NEO4J_SYNC_LOG   (default: $HOME/Library/Logs/neo4j-sync.log)
 #
 # Reference: docs/neo4j-sync-via-nas.md
 
@@ -23,17 +30,39 @@ PASSWORD="${NEO4J_PASSWORD:-gomasuke}"
 DBS="${NEO4J_DBS:-quants research note creator}"
 NAS_DIR="${NAS_DUMP_DIR:-/Volumes/personal_folder/neo4j-dumps}"
 CONTAINER_DUMP_DIR="/tmp/dumps"
+DIRTY_FLAG="${NEO4J_SYNC_DIRTY:-$HOME/.neo4j-sync-dirty}"
+LOG_FILE="${NEO4J_SYNC_LOG:-$HOME/Library/Logs/neo4j-sync.log}"
+SYNC_STATE_FILE="$NAS_DIR/sync-state.json"
+LOCK_DIR="$NAS_DIR/.neo4j-sync.lock"
+LOCK_TIMEOUT="${NEO4J_SYNC_LOCK_TIMEOUT:-30}"
+HOSTNAME_SHORT="$(hostname -s)"
+
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 
 # ----------------------------------------------------------------------------
 # Helpers
 # ----------------------------------------------------------------------------
 log() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+  local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+  echo "$msg"
+  echo "$msg" >> "$LOG_FILE" 2>/dev/null || true
 }
 
 die() {
-  echo "ERROR: $*" >&2
+  log "ERROR: $*"
+  notify_error "$*"
   exit 1
+}
+
+notify() {
+  local title="$1"
+  local message="$2"
+  local subtitle="${3:-}"
+  osascript -e "display notification \"$message\" with title \"$title\" subtitle \"$subtitle\"" 2>/dev/null || true
+}
+
+notify_error() {
+  notify "neo4j-sync ❌" "$1" "$HOSTNAME_SHORT"
 }
 
 cypher_system() {
@@ -47,53 +76,88 @@ cypher_db() {
 }
 
 check_prereqs() {
-  log "Checking prerequisites..."
   docker ps --filter "name=^${CONTAINER}$" --format '{{.Names}}' | grep -q "^${CONTAINER}$" \
-    || die "Container '$CONTAINER' is not running. Start it with: docker compose up -d neo4j"
+    || die "Container '$CONTAINER' is not running"
 
-  [ -d "$NAS_DIR" ] || mkdir -p "$NAS_DIR" \
-    || die "Failed to create NAS dump dir: $NAS_DIR (is NAS mounted?)"
-
-  log "Container: $CONTAINER (running)"
-  log "NAS dir:   $NAS_DIR"
-  log "DBs:       $DBS"
+  [ -d "$NAS_DIR" ] || mkdir -p "$NAS_DIR" 2>/dev/null \
+    || die "NAS dump dir unreachable: $NAS_DIR (is NAS mounted?)"
 }
 
 # ----------------------------------------------------------------------------
-# Phase 1: dump → NAS
+# Locking (mkdir-based on NAS)
 # ----------------------------------------------------------------------------
-cmd_dump() {
-  check_prereqs
+acquire_lock() {
+  local elapsed=0
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    if [ $elapsed -ge $LOCK_TIMEOUT ]; then
+      die "Could not acquire lock (waited ${LOCK_TIMEOUT}s). Stale lock? Remove with: rmdir '$LOCK_DIR'"
+    fi
+    log "Waiting for sync lock... (${elapsed}s/${LOCK_TIMEOUT}s)"
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+}
 
+# ----------------------------------------------------------------------------
+# sync-state.json operations (jq-based)
+# ----------------------------------------------------------------------------
+read_sync_state() {
+  if [ -f "$SYNC_STATE_FILE" ]; then
+    cat "$SYNC_STATE_FILE"
+  else
+    echo '{}'
+  fi
+}
+
+get_last_source() {
+  read_sync_state | jq -r '.last_source // ""'
+}
+
+get_last_dump_at() {
+  read_sync_state | jq -r '.last_dump_at // ""'
+}
+
+write_sync_state() {
+  local now
+  now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  local dbs_json
+  dbs_json=$(echo "$DBS" | tr ' ' '\n' | jq -R . | jq -s .)
+  jq -n \
+    --arg src "$HOSTNAME_SHORT" \
+    --arg ts "$now" \
+    --argjson dbs "$dbs_json" \
+    '{last_source: $src, last_dump_at: $ts, dbs: $dbs}' > "$SYNC_STATE_FILE"
+}
+
+# ----------------------------------------------------------------------------
+# dump → NAS (used by `dump` and `push`)
+# ----------------------------------------------------------------------------
+do_dump_to_nas() {
   log "Creating container dump dir..."
   docker exec "$CONTAINER" mkdir -p "$CONTAINER_DUMP_DIR"
 
   for db in $DBS; do
     log "=== [$db] Dumping ==="
-    cypher_system "STOP DATABASE $db WAIT" | tail -2
+    cypher_system "STOP DATABASE $db WAIT" 2>&1 | tail -2 | tee -a "$LOG_FILE"
     docker exec "$CONTAINER" neo4j-admin database dump "$db" \
-      --to-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3
-    cypher_system "START DATABASE $db WAIT" | tail -2
+      --to-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3 | tee -a "$LOG_FILE"
+    cypher_system "START DATABASE $db WAIT" 2>&1 | tail -2 | tee -a "$LOG_FILE"
   done
 
   log "Copying dumps to NAS: $NAS_DIR"
   for db in $DBS; do
-    docker cp "${CONTAINER}:${CONTAINER_DUMP_DIR}/${db}.dump" "${NAS_DIR}/"
+    docker cp "${CONTAINER}:${CONTAINER_DUMP_DIR}/${db}.dump" "${NAS_DIR}/" 2>&1 | tee -a "$LOG_FILE"
   done
 
   log "Cleaning up container dump dir..."
   docker exec "$CONTAINER" rm -rf "$CONTAINER_DUMP_DIR"
-
-  log "Done. Files on NAS:"
-  ls -lh "$NAS_DIR"
 }
 
 # ----------------------------------------------------------------------------
-# Phase 2: NAS → load
+# NAS → load (used by `load` and `pull`)
 # ----------------------------------------------------------------------------
-cmd_load() {
-  check_prereqs
-
+do_load_from_nas() {
   log "Verifying NAS dump files..."
   for db in $DBS; do
     [ -f "${NAS_DIR}/${db}.dump" ] || die "Missing dump file: ${NAS_DIR}/${db}.dump"
@@ -102,46 +166,57 @@ cmd_load() {
   log "Copying dumps into container..."
   docker exec "$CONTAINER" mkdir -p "$CONTAINER_DUMP_DIR"
   for db in $DBS; do
-    docker cp "${NAS_DIR}/${db}.dump" "${CONTAINER}:${CONTAINER_DUMP_DIR}/"
+    docker cp "${NAS_DIR}/${db}.dump" "${CONTAINER}:${CONTAINER_DUMP_DIR}/" 2>&1 | tee -a "$LOG_FILE"
   done
 
   for db in $DBS; do
     log "=== [$db] Loading ==="
 
-    # Check if DB exists
     local exists
-    exists=$(cypher_system "SHOW DATABASE $db YIELD name RETURN count(name) AS c" \
+    exists=$(cypher_system "SHOW DATABASE $db YIELD name RETURN count(name) AS c" 2>/dev/null \
       | tail -1 | tr -d ' ' || echo "0")
 
     if [ "$exists" = "1" ]; then
       log "  DB exists -> overwrite load"
-      cypher_system "STOP DATABASE $db WAIT" | tail -2
+      cypher_system "STOP DATABASE $db WAIT" 2>&1 | tail -2 | tee -a "$LOG_FILE"
       docker exec "$CONTAINER" neo4j-admin database load "$db" \
-        --from-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3
-      cypher_system "START DATABASE $db WAIT" | tail -2
+        --from-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3 | tee -a "$LOG_FILE"
+      cypher_system "START DATABASE $db WAIT" 2>&1 | tail -2 | tee -a "$LOG_FILE"
     else
       log "  DB does not exist -> load + CREATE DATABASE"
       docker exec "$CONTAINER" neo4j-admin database load "$db" \
-        --from-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3
-      cypher_system "CREATE DATABASE $db IF NOT EXISTS WAIT" | tail -2
+        --from-path="$CONTAINER_DUMP_DIR" --overwrite-destination=true 2>&1 | tail -3 | tee -a "$LOG_FILE"
+      cypher_system "CREATE DATABASE $db IF NOT EXISTS WAIT" 2>&1 | tail -2 | tee -a "$LOG_FILE"
     fi
   done
 
   log "Cleaning up container dump dir..."
   docker exec "$CONTAINER" rm -rf "$CONTAINER_DUMP_DIR"
-
-  log "Done. Database status:"
-  local dbs_list
-  dbs_list=$(echo "$DBS" | tr ' ' ',' | sed "s/,/','/g")
-  cypher_system "SHOW DATABASES YIELD name, currentStatus WHERE name IN ['${dbs_list}'] RETURN name, currentStatus"
 }
 
 # ----------------------------------------------------------------------------
-# verify: 件数表示
+# cmd_dump / cmd_load: 既存互換 (sync-state.json 更新なし)
+# ----------------------------------------------------------------------------
+cmd_dump() {
+  check_prereqs
+  log "dump (legacy, no state update): host=$HOSTNAME_SHORT"
+  do_dump_to_nas
+  log "Done. Files on NAS:"
+  ls -lh "$NAS_DIR" | tee -a "$LOG_FILE"
+}
+
+cmd_load() {
+  check_prereqs
+  log "load (legacy, no state check): host=$HOSTNAME_SHORT"
+  do_load_from_nas
+  log "Done."
+}
+
+# ----------------------------------------------------------------------------
+# verify
 # ----------------------------------------------------------------------------
 cmd_verify() {
   check_prereqs
-
   for db in $DBS; do
     echo ""
     echo "=== $db ==="
@@ -151,19 +226,125 @@ cmd_verify() {
 }
 
 # ----------------------------------------------------------------------------
+# push: dump + NAS push + sync-state.json 更新
+# ----------------------------------------------------------------------------
+cmd_push() {
+  local if_dirty="${1:-}"
+
+  if [ "$if_dirty" = "--if-dirty" ]; then
+    if [ ! -f "$DIRTY_FLAG" ]; then
+      log "push --if-dirty: no dirty flag at $DIRTY_FLAG, skipping"
+      exit 0
+    fi
+    log "push --if-dirty: dirty flag found, proceeding"
+  fi
+
+  check_prereqs
+  acquire_lock
+
+  log "push: host=$HOSTNAME_SHORT"
+  do_dump_to_nas
+  write_sync_state
+  rm -f "$DIRTY_FLAG"
+
+  log "Done. last_source updated to: $HOSTNAME_SHORT"
+  notify "neo4j-sync ⬆️" "Pushed 4 DBs to NAS" "$HOSTNAME_SHORT"
+}
+
+# ----------------------------------------------------------------------------
+# pull: NAS の last_source を確認して load (auto なら条件付き)
+# ----------------------------------------------------------------------------
+cmd_pull() {
+  local auto="${1:-}"
+
+  check_prereqs
+
+  if [ ! -f "$SYNC_STATE_FILE" ]; then
+    if [ "$auto" = "--auto" ]; then
+      log "pull --auto: no sync-state.json yet, skipping"
+      exit 0
+    fi
+    log "pull: no sync-state.json (initial state), proceeding anyway"
+  fi
+
+  local last_source
+  last_source="$(get_last_source)"
+
+  if [ "$auto" = "--auto" ]; then
+    if [ -z "$last_source" ] || [ "$last_source" = "$HOSTNAME_SHORT" ]; then
+      log "pull --auto: last_source='$last_source' (self or empty), skipping"
+      exit 0
+    fi
+    log "pull --auto: last_source='$last_source' != self='$HOSTNAME_SHORT', will load"
+  fi
+
+  acquire_lock
+
+  log "pull: host=$HOSTNAME_SHORT, source=$last_source"
+  do_load_from_nas
+
+  log "Done. Loaded from source: $last_source"
+  notify "neo4j-sync ⬇️" "Pulled 4 DBs from $last_source" "$HOSTNAME_SHORT"
+}
+
+# ----------------------------------------------------------------------------
+# status: 現在の状態を表示
+# ----------------------------------------------------------------------------
+cmd_status() {
+  echo "=== neo4j-sync status ==="
+  echo "Host:        $HOSTNAME_SHORT"
+  echo "Container:   $CONTAINER"
+  echo "DBs:         $DBS"
+  echo "NAS dir:     $NAS_DIR"
+  echo "Dirty flag:  $DIRTY_FLAG"
+
+  if [ -f "$DIRTY_FLAG" ]; then
+    echo "  → dirty (modified since last push): YES"
+    echo "  → modified at: $(stat -f '%Sm' "$DIRTY_FLAG" 2>/dev/null || echo unknown)"
+  else
+    echo "  → dirty: no"
+  fi
+
+  echo ""
+  echo "=== NAS sync-state.json ==="
+  if [ -f "$SYNC_STATE_FILE" ]; then
+    cat "$SYNC_STATE_FILE" | jq .
+  else
+    echo "  (no sync-state.json yet)"
+  fi
+
+  echo ""
+  echo "=== Lock ==="
+  if [ -d "$LOCK_DIR" ]; then
+    echo "  LOCKED (created: $(stat -f '%Sm' "$LOCK_DIR" 2>/dev/null || echo unknown))"
+  else
+    echo "  unlocked"
+  fi
+}
+
+# ----------------------------------------------------------------------------
 # main
 # ----------------------------------------------------------------------------
 case "${1:-}" in
   dump)   cmd_dump ;;
   load)   cmd_load ;;
   verify) cmd_verify ;;
+  push)   shift; cmd_push "${1:-}" ;;
+  pull)   shift; cmd_pull "${1:-}" ;;
+  status) cmd_status ;;
   *)
     cat <<EOF
-Usage: $0 {dump|load|verify}
+Usage: $0 <command> [options]
 
-  dump    Phase 1: Dump 4 DBs from this Mac's Neo4j to NAS
-  load    Phase 2: Load 4 DBs from NAS into this Mac's Neo4j
-  verify  Display node/relationship counts for each DB
+Commands:
+  dump              強制 dump → NAS (sync-state.json は更新しない、互換用)
+  load              強制 NAS → load (互換用)
+  verify            ノード/リレーション件数を表示
+  push              dump + NAS push + sync-state.json 更新
+  push --if-dirty   ~/.neo4j-sync-dirty があれば push、なければ skip
+  pull              強制 pull (NAS → load) + sync-state.json 確認
+  pull --auto       last_source != hostname なら pull、それ以外は skip
+  status            現在の dirty / sync-state / lock を表示
 
 Environment variables:
   NEO4J_CONTAINER  Container name (default: neo4j-enterprise)
@@ -173,6 +354,8 @@ Environment variables:
                    (default: "quants research note creator")
   NAS_DUMP_DIR     NAS dump directory
                    (default: /Volumes/personal_folder/neo4j-dumps)
+  NEO4J_SYNC_DIRTY Dirty flag file (default: \$HOME/.neo4j-sync-dirty)
+  NEO4J_SYNC_LOG   Log file (default: \$HOME/Library/Logs/neo4j-sync.log)
 
 Reference: docs/neo4j-sync-via-nas.md
 EOF


### PR DESCRIPTION
## 概要

Neo4j データを更新したタイミングで Mac 間自動同期する仕組みを実装。

2026-05-26 の片方向同期 (`dec-2026-05-26-502`) を supersede し、「最後に書いた側が source」ルールで競合回避する双方向同期に拡張。

## 仕組み

```
[Claude Code 起動]                    [セッション中]                     [Claude Code 終了]
SessionStart hook                     PostToolUse hook                   Stop hook
       │                              (write_neo4j_cypher のみ)              │
       │ pull --auto                                                         │ push --if-dirty
       ▼                              ▼                                      ▼
NAS sync-state.json 確認            touch ~/.neo4j-sync-dirty         dirty=true なら
last_source != hostname →          (フラグだけ立てる軽量処理)         dump → NAS push +
load 実行                                                              sync-state.json 更新
```

## 変更内容

| ファイル | 変更 |
|---|---|
| `scripts/neo4j_sync.sh` | `push` / `pull` / `status` サブコマンド追加。`--auto` / `--if-dirty`、`sync-state.json` 対応、mkdir ベース排他ロック、macOS 通知 (osascript)、ログファイル |
| `.claude/settings.json` | `SessionStart` / `PostToolUse(write_neo4j_cypher)` / `Stop` の 3 hook を追加 |
| `scripts/migrate_author_ids.py` | `--execute` で `migrated > 0` のとき `~/.neo4j-sync-dirty` を touch |
| `docs/neo4j-sync-via-nas.md` | 双方向同期セクション追加 |
| `docs/plan/2026-05-27_discussion-neo4j-bidirectional-sync.md` | 議論メモ |

## NAS 上の `sync-state.json`

```json
{
  "last_source": "yukihatas-macbook-air",
  "last_dump_at": "2026-05-27T01:35:57Z",
  "dbs": ["quants", "research", "note", "creator"]
}
```

## 動作確認 (MacBook Air)

| 検証項目 | 結果 |
|---|---|
| `status` 表示 | ✅ |
| dirty フラグ → `push --if-dirty` 実行 → dump 成功 | ✅ (4 DB / 191MB) |
| sync-state.json 生成・更新 | ✅ |
| dirty フラグ削除 | ✅ |
| `pull --auto` で self skip | ✅ "self or empty, skipping" |
| `push --if-dirty` で no-dirty skip | ✅ "no dirty flag, skipping" |
| settings.json JSON 整合性 | ✅ jq で検証 |

実 hook 経由の動作（SessionStart / PostToolUse / Stop）はマージ後に両 Mac で確認。

## テストプラン

- [x] スクリプトのサブコマンドが期待通り動く
- [x] sync-state.json が正しく生成される
- [x] dirty フラグの touch/check/clear が機能する
- [x] settings.json が JSON として有効
- [ ] (マージ後) Claude Code セッション開始時に pull --auto が走る
- [ ] (マージ後) write_neo4j_cypher の後で dirty フラグが立つ
- [ ] (マージ後) Claude Code 終了時に push --if-dirty が走る
- [ ] (マージ後) 自宅 Mac で同様に動作

## 関連

- 議論: `disc-2026-05-27-neo4j-bidirectional-sync`
- Decisions: `dec-2026-05-27-001` 〜 `007` (supersedes `dec-2026-05-26-502`)
- ActionItems: `act-2026-05-27-001` 〜 `005`
- 前回 PR: #3968 (本体) / #3969 (起動待ちループ fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)